### PR TITLE
fix: version-gate generated RawProps::at() for react-native 0.87

### DIFF
--- a/packages/nitrogen/src/views/CppHybridViewComponent.ts
+++ b/packages/nitrogen/src/views/CppHybridViewComponent.ts
@@ -209,7 +209,7 @@ namespace ${namespace} {
       `
 ${name}([&]() -> CachedProp<${type}> {
   try {
-    const react::RawValue* rawValue = rawProps.at("${prop.name}", nullptr, nullptr);
+    const react::RawValue* rawValue = NITRO_RAWPROPS_AT(rawProps, "${prop.name}");
     if (rawValue == nullptr) return sourceProps.${name};
     const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
     return CachedProp<${type}>::fromRawValue(*runtime, ${valueConversion}, sourceProps.${name});
@@ -238,6 +238,16 @@ ${createFileMetadataString(`${component}.cpp`)}
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/components/view/ViewProps.h>
+#include <cxxreact/ReactNativeVersion.h>
+
+// react-native 0.87 removed the \`at(name, prefix, suffix)\` overload of
+// \`react::RawProps\` in favor of a single-argument \`at(name)\`. Keep supporting
+// older versions (<= 0.86) that still require the 3-argument form.
+#if REACT_NATIVE_VERSION_MAJOR > 0 || REACT_NATIVE_VERSION_MINOR > 86
+#define NITRO_RAWPROPS_AT(rawProps, name) (rawProps).at(name)
+#else
+#define NITRO_RAWPROPS_AT(rawProps, name) (rawProps).at(name, nullptr, nullptr)
+#endif
 
 namespace ${namespace} {
 
@@ -281,6 +291,8 @@ namespace ${namespace} {
 #endif
 
 } // namespace ${namespace}
+
+#undef NITRO_RAWPROPS_AT
 `.trim()
 
   const files: SourceFile[] = [

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridRecyclableTestViewComponent.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridRecyclableTestViewComponent.cpp
@@ -17,6 +17,16 @@
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/components/view/ViewProps.h>
+#include <cxxreact/ReactNativeVersion.h>
+
+// react-native 0.87 removed the `at(name, prefix, suffix)` overload of
+// `react::RawProps` in favor of a single-argument `at(name)`. Keep supporting
+// older versions (<= 0.86) that still require the 3-argument form.
+#if REACT_NATIVE_VERSION_MAJOR > 0 || REACT_NATIVE_VERSION_MINOR > 86
+#define NITRO_RAWPROPS_AT(rawProps, name) (rawProps).at(name)
+#else
+#define NITRO_RAWPROPS_AT(rawProps, name) (rawProps).at(name, nullptr, nullptr)
+#endif
 
 namespace margelo::nitro::test::views {
 
@@ -28,7 +38,7 @@ namespace margelo::nitro::test::views {
     react::ViewProps(context, sourceProps, rawProps, filterObjectKeys),
     isBlue([&]() -> CachedProp<bool> {
       try {
-        const react::RawValue* rawValue = rawProps.at("isBlue", nullptr, nullptr);
+        const react::RawValue* rawValue = NITRO_RAWPROPS_AT(rawProps, "isBlue");
         if (rawValue == nullptr) return sourceProps.isBlue;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
         return CachedProp<bool>::fromRawValue(*runtime, value, sourceProps.isBlue);
@@ -38,7 +48,7 @@ namespace margelo::nitro::test::views {
     }()),
     hybridRef([&]() -> CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridRecyclableTestViewSpec>& /* ref */)>>> {
       try {
-        const react::RawValue* rawValue = rawProps.at("hybridRef", nullptr, nullptr);
+        const react::RawValue* rawValue = NITRO_RAWPROPS_AT(rawProps, "hybridRef");
         if (rawValue == nullptr) return sourceProps.hybridRef;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
         return CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridRecyclableTestViewSpec>& /* ref */)>>>::fromRawValue(*runtime, value.asObject(*runtime).getProperty(*runtime, PropNameIDCache::get(*runtime, "f")), sourceProps.hybridRef);
@@ -81,3 +91,5 @@ namespace margelo::nitro::test::views {
 #endif
 
 } // namespace margelo::nitro::test::views
+
+#undef NITRO_RAWPROPS_AT

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
@@ -17,6 +17,16 @@
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/components/view/ViewProps.h>
+#include <cxxreact/ReactNativeVersion.h>
+
+// react-native 0.87 removed the `at(name, prefix, suffix)` overload of
+// `react::RawProps` in favor of a single-argument `at(name)`. Keep supporting
+// older versions (<= 0.86) that still require the 3-argument form.
+#if REACT_NATIVE_VERSION_MAJOR > 0 || REACT_NATIVE_VERSION_MINOR > 86
+#define NITRO_RAWPROPS_AT(rawProps, name) (rawProps).at(name)
+#else
+#define NITRO_RAWPROPS_AT(rawProps, name) (rawProps).at(name, nullptr, nullptr)
+#endif
 
 namespace margelo::nitro::test::views {
 
@@ -28,7 +38,7 @@ namespace margelo::nitro::test::views {
     react::ViewProps(context, sourceProps, rawProps, filterObjectKeys),
     isBlue([&]() -> CachedProp<bool> {
       try {
-        const react::RawValue* rawValue = rawProps.at("isBlue", nullptr, nullptr);
+        const react::RawValue* rawValue = NITRO_RAWPROPS_AT(rawProps, "isBlue");
         if (rawValue == nullptr) return sourceProps.isBlue;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
         return CachedProp<bool>::fromRawValue(*runtime, value, sourceProps.isBlue);
@@ -38,7 +48,7 @@ namespace margelo::nitro::test::views {
     }()),
     hasBeenCalled([&]() -> CachedProp<bool> {
       try {
-        const react::RawValue* rawValue = rawProps.at("hasBeenCalled", nullptr, nullptr);
+        const react::RawValue* rawValue = NITRO_RAWPROPS_AT(rawProps, "hasBeenCalled");
         if (rawValue == nullptr) return sourceProps.hasBeenCalled;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
         return CachedProp<bool>::fromRawValue(*runtime, value, sourceProps.hasBeenCalled);
@@ -48,7 +58,7 @@ namespace margelo::nitro::test::views {
     }()),
     colorScheme([&]() -> CachedProp<ColorScheme> {
       try {
-        const react::RawValue* rawValue = rawProps.at("colorScheme", nullptr, nullptr);
+        const react::RawValue* rawValue = NITRO_RAWPROPS_AT(rawProps, "colorScheme");
         if (rawValue == nullptr) return sourceProps.colorScheme;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
         return CachedProp<ColorScheme>::fromRawValue(*runtime, value, sourceProps.colorScheme);
@@ -58,7 +68,7 @@ namespace margelo::nitro::test::views {
     }()),
     someCallback([&]() -> CachedProp<std::function<void()>> {
       try {
-        const react::RawValue* rawValue = rawProps.at("someCallback", nullptr, nullptr);
+        const react::RawValue* rawValue = NITRO_RAWPROPS_AT(rawProps, "someCallback");
         if (rawValue == nullptr) return sourceProps.someCallback;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
         return CachedProp<std::function<void()>>::fromRawValue(*runtime, value.asObject(*runtime).getProperty(*runtime, PropNameIDCache::get(*runtime, "f")), sourceProps.someCallback);
@@ -68,7 +78,7 @@ namespace margelo::nitro::test::views {
     }()),
     hybridRef([&]() -> CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridTestViewSpec>& /* ref */)>>> {
       try {
-        const react::RawValue* rawValue = rawProps.at("hybridRef", nullptr, nullptr);
+        const react::RawValue* rawValue = NITRO_RAWPROPS_AT(rawProps, "hybridRef");
         if (rawValue == nullptr) return sourceProps.hybridRef;
         const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
         return CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridTestViewSpec>& /* ref */)>>>::fromRawValue(*runtime, value.asObject(*runtime).getProperty(*runtime, PropNameIDCache::get(*runtime, "f")), sourceProps.hybridRef);
@@ -114,3 +124,5 @@ namespace margelo::nitro::test::views {
 #endif
 
 } // namespace margelo::nitro::test::views
+
+#undef NITRO_RAWPROPS_AT


### PR DESCRIPTION
react-native 0.87 removed the (name, prefix, suffix) overload of
react::RawProps::at() in favor of a single-argument at(name):

- https://github.com/react/react-native/pull/55763

This breaks nitro codegen output on newer react-native while older versions
(<= 0.86) still require the 3-argument form.

Update the CppHybridViewComponent codegen template to emit a
NITRO_RAWPROPS_AT macro guarded by REACT_NATIVE_VERSION_* (from
<cxxreact/ReactNativeVersion.h>):

  * RN > 0.86 (incl. nightly 1000.x): rawProps.at(name)
  * RN <= 0.86:                       rawProps.at(name, nullptr, nullptr)

Regenerate the committed HybridTestView / HybridRecyclableTestView
component files so the generated output stays in sync with the template.