### PR TITLE
fix(android): compute HardwareBuffer size in bytes, not pixels

### DIFF
--- a/packages/react-native-nitro-modules/android/src/main/cpp/utils/JHardwareBufferUtils.cpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/utils/JHardwareBufferUtils.cpp
@@ -15,8 +15,35 @@ size_t JHardwareBufferUtils::getHardwareBufferSize([[maybe_unused]] AHardwareBuf
 #if __ANDROID_API__ >= 26
   AHardwareBuffer_Desc description;
   AHardwareBuffer_describe(hardwareBuffer, &description);
-  size_t sourceSize = description.height * description.stride;
-  return sourceSize;
+  // AHardwareBuffer_Desc.stride is in PIXELS, not bytes - height * stride
+  // under-reports e.g. RGBA_8888 buffers 4x. Multiply by the format's
+  // bytes-per-pixel. Unknown/planar formats (YUV etc.) keep the legacy
+  // height * stride value: their stride semantics are format-specific
+  // and nothing here reads them as tightly-packed bytes.
+  size_t bytesPerPixel;
+  switch (description.format) {
+    case AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM:
+    case AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM:
+    case AHARDWAREBUFFER_FORMAT_R10G10B10A2_UNORM:
+      bytesPerPixel = 4;
+      break;
+    case AHARDWAREBUFFER_FORMAT_R8G8B8_UNORM:
+      bytesPerPixel = 3;
+      break;
+    case AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM:
+      bytesPerPixel = 2;
+      break;
+    case AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT:
+      bytesPerPixel = 8;
+      break;
+    case AHARDWAREBUFFER_FORMAT_BLOB:
+      // BLOB buffers: width IS the size in bytes (height == 1, stride N/A).
+      return description.width;
+    default:
+      bytesPerPixel = 1;
+      break;
+  }
+  return static_cast<size_t>(description.height) * description.stride * bytesPerPixel;
 #else
   throw std::runtime_error("ArrayBuffer(HardwareBuffer) requires NDK API 26 or above! (minSdk >= 26)");
 #endif
@@ -67,7 +94,7 @@ void JHardwareBufferUtils::copyHardwareBuffer([[maybe_unused]] AHardwareBuffer* 
 
   // 2. Get info about the destination buffer
 #ifdef NITRO_DEBUG
-  size_t destinationSize = getHardwareBufferSize(sourceHardwareBuffer);
+  size_t destinationSize = getHardwareBufferSize(destinationHardwareBuffer);
   if (sourceSize != destinationSize) {
     throw std::runtime_error("Source HardwareBuffer (" + std::to_string(sourceSize) + " bytes) and destination HardwareBuffer (" +
                              std::to_string(destinationSize) + " bytes) are not the same size!");


### PR DESCRIPTION
## What

`JHardwareBufferUtils::getHardwareBufferSize` returns `height * stride`, but [`AHardwareBuffer_Desc.stride`](https://developer.android.com/ndk/reference/struct/a-hardware-buffer-desc) is measured in **pixels**, not bytes. For an RGBA_8888 buffer the size is under-reported 4x.

Every `ArrayBuffer` wrapping a HardwareBuffer then exposes a 4x-too-small `size`, and any consumer that allocates/copies based on the real pixel dimensions overflows the under-sized buffer.

## Real-world impact

We shipped this in production (React Native app using `ArrayBuffer.wrap(HardwareBuffer)` to hand camera frames to OpenCV): `getPixelBuffer` returned a buffer 1/4 the expected size, and the downstream `memcpy` of `width * height * 4` bytes ran off the end of the allocation → hard `SIGSEGV` in `libc.so` on users' devices (seen on Samsung Xclipse / Android 16 via Crashlytics). Multiplying by bytes-per-pixel fixed it.

## Changes

- `getHardwareBufferSize`: multiply `height * stride` by the format's bytes-per-pixel for the packed RGB(A)/565/F16 formats.
- `AHARDWAREBUFFER_FORMAT_BLOB`: per NDK docs, `width` **is** the size in bytes (`height == 1`, stride N/A) — return it directly.
- Unknown/planar formats (YUV etc.) keep the legacy `height * stride` value: their stride semantics are format-specific, and I didn't want to silently change behavior for formats where tightly-packed byte math doesn't apply.
- Drive-by fix in `copyHardwareBuffer`: the `NITRO_DEBUG` size-equality check read `getHardwareBufferSize(sourceHardwareBuffer)` for **both** sides, making the check a tautology — it now reads the destination buffer.

## Testing

Verified on device (Android 16, Samsung Xclipse GPU) that RGBA_8888 HardwareBuffer-backed ArrayBuffers now report `width * height * 4` and the downstream consumer no longer segfaults. We've been running this as a patch-package fix in production since.
