### PR TITLE
fix: make static per-Runtime caches thread-safe (fatal "jsi::Function has already been deleted" crashes)

### DIFF
--- a/packages/react-native-nitro-modules/cpp/jsi/JSICache.cpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSICache.cpp
@@ -12,6 +12,15 @@
 
 namespace margelo::nitro {
 
+// Guards `_globalCache`. Different Runtimes call `getOrCreateCache` from their own
+// Threads concurrently (RN JS thread + Worklet Runtimes), and un-synchronized
+// `unordered_map` access is UB - a racy `find` miss creates a DUPLICATE cache for a
+// live Runtime, and `defineGlobal` silently replaces `__nitroJsiCache` in release,
+// so the orphaned cache gets GC'd and force-destroys every `jsi::Function` created
+// through it ("the underlying `jsi::Function` has already been deleted!").
+// Never held across any JSI call (`getOrCreateCache` is re-entrant via `defineGlobal`).
+static std::mutex g_globalCacheMutex;
+
 template <typename T>
 inline void destroyReferences(const std::vector<WeakReference<T>>& references) {
   for (auto& func : references) {
@@ -36,15 +45,25 @@ JSICache::~JSICache() {
 }
 
 JSICacheReference JSICache::getOrCreateCache(jsi::Runtime& runtime) {
-  auto found = _globalCache.find(&runtime);
-  if (found != _globalCache.end()) [[likely]] {
-    // Fast path: get weak_ptr to JSICache from our global list.
-    std::weak_ptr<JSICache> weak = found->second;
-    std::shared_ptr<JSICache> strong = weak.lock();
-    if (strong) {
-      // It's still alive! Return it
-      return JSICacheReference(strong);
+  bool hadStaleEntry = false;
+  {
+    std::unique_lock lock(g_globalCacheMutex);
+    auto found = _globalCache.find(&runtime);
+    if (found != _globalCache.end()) [[likely]] {
+      // Fast path: get weak_ptr to JSICache from our global list.
+      std::weak_ptr<JSICache> weak = found->second;
+      std::shared_ptr<JSICache> strong = weak.lock();
+      if (strong) {
+        // It's still alive! Return it
+        // (JSICacheReference locks the instance mutex - taken after dropping the static lock is fine,
+        //  the shared_ptr keeps the cache alive either way. Lock order stays static -> instance.)
+        lock.unlock();
+        return JSICacheReference(strong);
+      }
+      hadStaleEntry = true;
     }
+  }
+  if (hadStaleEntry) {
     Logger::log(LogLevel::Warning, TAG, "JSICache was created, but it is no longer strong!");
   }
 
@@ -56,12 +75,16 @@ JSICacheReference JSICache::getOrCreateCache(jsi::Runtime& runtime) {
   jsi::Object cache(runtime);
   cache.setNativeState(runtime, nativeState);
   // Add it to our map of caches first, because the next `::defineGlobal(...)` call will already be using it (recursively)
-  _globalCache[&runtime] = nativeState;
+  {
+    std::unique_lock lock(g_globalCacheMutex);
+    _globalCache[&runtime] = nativeState;
+  }
   try {
     // Call Object.defineProperty(global, ...) now with our cache (it internally already uses cache)
     CommonGlobals::defineGlobal(runtime, KnownGlobalPropertyName::JSI_CACHE, std::move(cache));
   } catch (...) {
     // If `defineGlobal(...)` failed, we should remove it from `_globalCache` so we don't have invalid caches.
+    std::unique_lock lock(g_globalCacheMutex);
     _globalCache.erase(&runtime);
     throw;
   }

--- a/packages/react-native-nitro-modules/cpp/prototype/HybridObjectPrototype.cpp
+++ b/packages/react-native-nitro-modules/cpp/prototype/HybridObjectPrototype.cpp
@@ -15,6 +15,15 @@ namespace margelo::nitro {
 
 std::unordered_map<jsi::Runtime*, HybridObjectPrototype::PrototypeCache> HybridObjectPrototype::_prototypeCache;
 
+// Guards the OUTER `_prototypeCache` map only - `operator[]` inserts, and concurrent
+// insertion/rehash from different Runtimes' Threads (HybridObjects are materialized on
+// parallel Runtimes - see the `ensureInitialized` mutex below) is UB. The inner
+// per-Runtime `PrototypeCache` is only ever accessed from that Runtime's own Thread,
+// and `unordered_map` value references stay valid across rehash, so the reference can
+// be used lock-free after acquisition (also keeps the recursive `createPrototype`
+// call below deadlock-free).
+static std::mutex g_prototypeCacheMutex;
+
 jsi::Value HybridObjectPrototype::createPrototype(jsi::Runtime& runtime, const std::shared_ptr<Prototype>& prototype) {
   // 0. Check if we're at the highest level of our prototype chain
   if (prototype == nullptr) {
@@ -24,7 +33,12 @@ jsi::Value HybridObjectPrototype::createPrototype(jsi::Runtime& runtime, const s
 
   // 1. Try looking for the given prototype in cache.
   //    If we find it in cache, we can create instances faster and skip creating the prototype from scratch!
-  auto& prototypeCache = _prototypeCache[&runtime];
+  PrototypeCache* prototypeCachePtr;
+  {
+    std::unique_lock lock(g_prototypeCacheMutex);
+    prototypeCachePtr = &_prototypeCache[&runtime];
+  }
+  auto& prototypeCache = *prototypeCachePtr;
   auto cachedPrototype = prototypeCache.find(prototype->getNativeInstanceId());
   if (cachedPrototype != prototypeCache.end()) {
     const BorrowingReference<jsi::Object>& cachedObject = cachedPrototype->second;

--- a/packages/react-native-nitro-modules/cpp/threading/Dispatcher.cpp
+++ b/packages/react-native-nitro-modules/cpp/threading/Dispatcher.cpp
@@ -11,6 +11,7 @@
 #include "JSIHelpers.hpp"
 #include "NitroDefines.hpp"
 #include "NitroLogger.hpp"
+#include <mutex>
 
 namespace margelo::nitro {
 
@@ -22,11 +23,19 @@ using namespace facebook;
  */
 std::unordered_map<jsi::Runtime * NON_NULL, std::weak_ptr<Dispatcher>> Dispatcher::_globalCache;
 
+// Guards `_globalCache` - it is mutated from every Runtime's Thread (RN JS thread,
+// Worklet Runtime initializers on their own threads), and un-synchronized
+// `unordered_map` access is UB. Never held across any JSI call.
+static std::mutex g_globalCacheMutex;
+
 void Dispatcher::installRuntimeGlobalDispatcher(jsi::Runtime& runtime, std::shared_ptr<Dispatcher> dispatcher) {
   Logger::log(LogLevel::Info, TAG, "Installing global Dispatcher Holder into Runtime \"%s\"...", getRuntimeId(runtime).c_str());
 
   // Store a weak reference in global cache
-  _globalCache[&runtime] = dispatcher;
+  {
+    std::unique_lock lock(g_globalCacheMutex);
+    _globalCache[&runtime] = dispatcher;
+  }
 
   // Inject the dispatcher into Runtime global (runtime will hold a strong reference)
   jsi::Value dispatcherHolder = JSIConverter<std::shared_ptr<Dispatcher>>::toJSI(runtime, dispatcher);
@@ -34,14 +43,17 @@ void Dispatcher::installRuntimeGlobalDispatcher(jsi::Runtime& runtime, std::shar
 }
 
 std::shared_ptr<Dispatcher> Dispatcher::getRuntimeGlobalDispatcher(jsi::Runtime& runtime) {
-  auto found = _globalCache.find(&runtime);
-  if (found != _globalCache.end()) [[likely]] {
-    // the runtime is known - we have something in cache
-    std::weak_ptr<Dispatcher> weakDispatcher = found->second;
-    std::shared_ptr<Dispatcher> strongDispatcher = weakDispatcher.lock();
-    if (strongDispatcher) {
-      // the weak reference we cached is still valid - return it!
-      return strongDispatcher;
+  {
+    std::unique_lock lock(g_globalCacheMutex);
+    auto found = _globalCache.find(&runtime);
+    if (found != _globalCache.end()) [[likely]] {
+      // the runtime is known - we have something in cache
+      std::weak_ptr<Dispatcher> weakDispatcher = found->second;
+      std::shared_ptr<Dispatcher> strongDispatcher = weakDispatcher.lock();
+      if (strongDispatcher) {
+        // the weak reference we cached is still valid - return it!
+        return strongDispatcher;
+      }
     }
   }
 
@@ -58,7 +70,10 @@ std::shared_ptr<Dispatcher> Dispatcher::getRuntimeGlobalDispatcher(jsi::Runtime&
   // 2. Cast it to the jsi::Object
   std::shared_ptr<Dispatcher> dispatcher = JSIConverter<std::shared_ptr<Dispatcher>>::fromJSI(runtime, dispatcherHolderValue);
   // 3. Throw it in our cache and return
-  _globalCache[&runtime] = dispatcher;
+  {
+    std::unique_lock lock(g_globalCacheMutex);
+    _globalCache[&runtime] = dispatcher;
+  }
   return dispatcher;
 }
 

--- a/packages/react-native-nitro-modules/cpp/utils/CommonGlobals.cpp
+++ b/packages/react-native-nitro-modules/cpp/utils/CommonGlobals.cpp
@@ -10,6 +10,7 @@
 #include "JSIHelpers.hpp"
 #include "NitroDefines.hpp"
 #include "PropNameIDCache.hpp"
+#include <mutex>
 
 #if __has_include(<cxxreact/ReactNativeVersion.h>)
 #include <cxxreact/ReactNativeVersion.h>
@@ -23,6 +24,13 @@ namespace margelo::nitro {
 using namespace facebook;
 
 std::unordered_map<jsi::Runtime*, CommonGlobals::FunctionCache> CommonGlobals::_cache;
+
+// Guards the OUTER `_cache` map only - `operator[]` inserts, and concurrent
+// insertion/rehash from different Runtimes' Threads is UB. The inner per-Runtime
+// `FunctionCache` is only ever accessed from that Runtime's own Thread, and
+// `unordered_map` value references stay valid across rehash, so the reference can
+// be used lock-free after acquisition.
+static std::mutex g_functionCacheMutex;
 
 // pragma MARK: Object
 
@@ -188,7 +196,12 @@ const jsi::PropNameID& CommonGlobals::getKnownGlobalPropertyName(jsi::Runtime& r
 const jsi::Function& CommonGlobals::getGlobalFunction(jsi::Runtime& runtime, const char* key,
                                                       std::function<jsi::Function(jsi::Runtime&)> getFunction) {
   // Let's try to find the function in cache
-  FunctionCache& functionCache = _cache[&runtime];
+  FunctionCache* functionCachePtr;
+  {
+    std::unique_lock lock(g_functionCacheMutex);
+    functionCachePtr = &_cache[&runtime];
+  }
+  FunctionCache& functionCache = *functionCachePtr;
   std::string stringKey = key;
   auto iterator = functionCache.find(stringKey);
   if (iterator != functionCache.end()) {

--- a/packages/react-native-nitro-modules/cpp/utils/JSCallback.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/JSCallback.hpp
@@ -56,6 +56,15 @@ public:
     }
   }
 
+  /**
+   * Whether the underlying `jsi::Function` is still alive and can be called.
+   * It is force-deleted when its owning Runtime's `JSICache` is destroyed (Runtime teardown).
+   */
+  [[nodiscard]]
+  inline bool isAlive() const {
+    return _function != nullptr;
+  }
+
 public:
   inline R operator()(Args... args) const {
     return call(args...);
@@ -110,6 +119,16 @@ public:
       return;
     }
     dispatcher->runAsync([callback = _callback, ... args = std::forward<Args>(args)]() mutable {
+      if (!callback.isAlive()) [[unlikely]] {
+        // The underlying `jsi::Function` was force-deleted (Runtime/JSICache teardown)
+        // between scheduling and execution. This is a fire-and-forget call whose result
+        // is ignored anyway - throwing here would escalate to an uncaught fatal in the
+        // target Runtime's scheduler, so log and skip instead.
+        std::string typeName = TypeInfo::getFriendlyTypename<AsyncJSCallback<R(Args...)>>(true);
+        Logger::log(LogLevel::Warning, "AsyncJSCallback", "Skipping call to %s - the underlying `jsi::Function` has already been deleted.",
+                    typeName.c_str());
+        return;
+      }
       // Call actual JS callback, synchronously now.
       return callback.call(std::forward<Args>(args)...);
     });

--- a/packages/react-native-nitro-modules/cpp/utils/PropNameIDCache.cpp
+++ b/packages/react-native-nitro-modules/cpp/utils/PropNameIDCache.cpp
@@ -7,6 +7,7 @@
 
 #include "PropNameIDCache.hpp"
 #include "JSICache.hpp"
+#include <mutex>
 
 namespace margelo::nitro {
 
@@ -14,8 +15,20 @@ using namespace facebook;
 
 std::unordered_map<jsi::Runtime*, PropNameIDCache::CacheMap> PropNameIDCache::_cache;
 
+// Guards the OUTER `_cache` map only - `operator[]` inserts, and concurrent
+// insertion/rehash from different Runtimes' Threads is UB. The inner per-Runtime
+// `CacheMap` is only ever accessed from that Runtime's own Thread, and
+// `unordered_map` value references stay valid across rehash, so the reference can
+// be used lock-free after acquisition.
+static std::mutex g_cacheMutex;
+
 const jsi::PropNameID& PropNameIDCache::get(jsi::Runtime& runtime, const std::string& value) {
-  CacheMap& cache = _cache[&runtime];
+  CacheMap* cachePtr;
+  {
+    std::unique_lock lock(g_cacheMutex);
+    cachePtr = &_cache[&runtime];
+  }
+  CacheMap& cache = *cachePtr;
   const auto& cachedName = cache.find(value);
   if (cachedName != cache.end()) {
     // cache warm!


### PR DESCRIPTION
## Problem

Nitro keeps five static `unordered_map`s keyed by `jsi::Runtime*` with no locking: `JSICache::_globalCache`, `Dispatcher::_globalCache`, `CommonGlobals::_cache`, `PropNameIDCache::_cache`, `HybridObjectPrototype::_prototypeCache`. Apps running multiple Runtimes (the RN runtime + react-native-worklets runtimes, e.g. VisionCamera frame processors) read and mutate these concurrently from different threads — and concurrent `unordered_map` mutation is UB. (`HybridObjectPrototype::ensureInitialized` already has a mutex "in case we try to create HybridObjects in parallel Runtimes", but the maps themselves are unguarded.)

We are seeing this crash in production (Android arm64, RN 0.86 bridgeless, release builds): fatal `Non-js exception: Cannot call SyncJSCallback<void()> - the underlying jsi::Function has already been deleted!` (also the `void(const std::string&)` variant), always shortly after additional worklet runtimes spin up, plus occasional `[libNitroModules.so]` SIGSEGVs consistent with the same race.

## Mechanism (worst case)

1. Thread A (worklet runtime init) inserts into `JSICache::_globalCache`, triggering a rehash, while thread B (main runtime) runs `getOrCreateCache` — `find()` spuriously misses the live entry.
2. Thread B creates a **duplicate** `JSICache` for the main runtime. In release, `defineGlobal` is a plain `setProperty`, so `__nitroJsiCache` is silently replaced (debug throws, so the race never reproduces in dev builds).
3. The orphaned cache is GC'd and `~JSICache()` force-destroys every `jsi::Function` created through it — while the runtime is alive and healthy.
4. The next stored callback fired from native throws into the RuntimeScheduler → app-killing fatal. (A queued `callAndForget` invocation always holds a strong `BorrowingReference` copy, so cache destruction is the only way `_function` can be null under it.)

## Fix

**Commit 1** — a mutex per static map, scoped strictly to the map operations and never held across a JSI call (`getOrCreateCache` is re-entrant via `defineGlobal` → `getGlobalFunction` → `getOrCreateCache`). For the nested caches only the outer `map[&runtime]` slot acquisition is locked: the inner per-Runtime map is only ever touched from that Runtime's own thread, and `unordered_map` value references are stable across rehash. Hot paths pay an uncontended lock around a lookup — behavior otherwise unchanged.

**Commit 2** (separable if you'd rather discuss it) — `callAndForget` checks a new `SyncJSCallback::isAlive()` inside the dispatched lambda and logs-and-skips a force-deleted function instead of throwing an uncaught fatal. It is fire-and-forget — results/completions are ignored by contract — and this also covers the legitimate case of a queued invocation draining after Runtime teardown. The Promise-returning `call()` path is unchanged (its throw surfaces as a catchable rejection).

Not touched, audited as safe: `Prototype::get`'s cache (all mutations serialized by `ensureInitialized`'s mutex) and `NitroTypeInfo::replaceRegex`'s regex cache (debug-only code path).

Possibly related: #1104.
