### PR TITLE
fix: prevent `WeakReference::lock()` from resurrecting a value mid final-release

### DIFF
--- a/packages/react-native-nitro-modules/cpp/utils/BorrowingReference.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/BorrowingReference.hpp
@@ -71,10 +71,10 @@ public:
   }
 
 private:
-  // WeakReference<T> -> BorrowingReference<T> Lock-constructor
-  explicit BorrowingReference(const WeakReference<T>& ref) : _value(ref._value), _state(ref._state) {
-    _state->strongRefCount++;
-  }
+  // WeakReference<T> -> BorrowingReference<T> Lock-constructor.
+  // The caller (`WeakReference<T>::lock()`) has already claimed the strong ref count via
+  // `tryIncrementStrongRefCount()`, so this must NOT increment it again.
+  explicit BorrowingReference(const WeakReference<T>& ref) : _value(ref._value), _state(ref._state) {}
 
 private:
   // BorrowingReference<C> -> BorrowingReference<T> Cast-constructor

--- a/packages/react-native-nitro-modules/cpp/utils/ReferenceState.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/ReferenceState.hpp
@@ -34,6 +34,23 @@ struct ReferenceState {
     return oldRefCount <= 1;
   }
 
+  /**
+   * Increments the strong ref count by one - unless it is already zero, and returns whether it did.
+   *
+   * A zero strong count means the final strong release is already under way (`~BorrowingReference` decrements
+   * the count BEFORE calling `forceDestroyValue()`), so handing out a strong reference in that window would
+   * resurrect a dying value. This is `weak_ptr::lock()`'s increment-if-not-zero.
+   */
+  inline bool tryIncrementStrongRefCount() {
+    size_t count = strongRefCount.load();
+    while (count != 0) {
+      if (strongRefCount.compare_exchange_weak(count, count + 1)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   explicit ReferenceState() : strongRefCount(1), weakRefCount(0), isDeleted(false) {}
 };
 

--- a/packages/react-native-nitro-modules/cpp/utils/WeakReference+Borrowing.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/WeakReference+Borrowing.hpp
@@ -26,6 +26,11 @@ BorrowingReference<T> WeakReference<T>::lock() const {
     // return nullptr
     return BorrowingReference<T>();
   }
+  if (!_state->tryIncrementStrongRefCount()) {
+    // the last strong reference is mid-release - the value is about to be destroyed, it just hasn't
+    // flagged `isDeleted` yet.
+    return BorrowingReference<T>();
+  }
 
   return BorrowingReference(*this);
 }


### PR DESCRIPTION
Part 1 of 3 - #1464 split into atomic PRs as requested. This one is fully standalone and can merge on its own; the other two build on it (order: this one, then #1468, then #1469).

## The race

`lock()` checks `isDeleted` and then unconditionally increments the strong count. But `~BorrowingReference` decrements the count **before** calling `forceDestroyValue()`, and holds no mutex while doing so. A `lock()` landing in that window hands out a strong reference to a value whose final release is already in flight - and the resurrected reference's destructor then runs a second `forceDestroyValue()` concurrently with the releaser's.

Nitro allows HybridObject/callback releases on any thread, so the window is reachable.

## The fix

`lock()` now claims the strong count with an increment-if-not-zero compare-exchange loop, exactly like `weak_ptr::lock()`. A zero strong count means the final release is already under way, so returning null there is simply correct. The private `WeakReference -> BorrowingReference` lock-constructor no longer increments, since `lock()` has already claimed the count.

## Testing

Compile-checked (NDK clang, C++20) and reasoned through; this specific change has not been soaked on-device on its own, so please review closely. Formatted to match `config/.clang-format` output in the surrounding code.
