### PR TITLE
fix: free `ReferenceState` via a `shared_ptr`-style control block

### DIFF
--- a/packages/react-native-nitro-modules/cpp/utils/BorrowingReference.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/BorrowingReference.hpp
@@ -71,10 +71,10 @@ public:
   }
 
 private:
-  // WeakReference<T> -> BorrowingReference<T> Lock-constructor
-  explicit BorrowingReference(const WeakReference<T>& ref) : _value(ref._value), _state(ref._state) {
-    _state->strongRefCount++;
-  }
+  // WeakReference<T> -> BorrowingReference<T> Lock-constructor.
+  // The caller (`WeakReference<T>::lock()`) has already claimed the strong ref count via
+  // `tryIncrementStrongRefCount()`, so this must NOT increment it again.
+  explicit BorrowingReference(const WeakReference<T>& ref) : _value(ref._value), _state(ref._state) {}
 
 private:
   // BorrowingReference<C> -> BorrowingReference<T> Cast-constructor

--- a/packages/react-native-nitro-modules/cpp/utils/BorrowingReference.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/BorrowingReference.hpp
@@ -56,8 +56,8 @@ public:
       bool shouldDestroy = _state->decrementStrongRefCount();
       if (shouldDestroy) {
         forceDestroyValue();
+        releaseImplicitWeakRef();
       }
-      maybeDestroyState();
     }
 
     _value = ref._value;
@@ -97,8 +97,8 @@ public:
     bool shouldDestroy = _state->decrementStrongRefCount();
     if (shouldDestroy) {
       forceDestroyValue();
+      releaseImplicitWeakRef();
     }
-    maybeDestroyState();
   }
 
 public:
@@ -192,12 +192,14 @@ public:
   }
 
 private:
-  void maybeDestroyState() {
-    if (_state->strongRefCount == 0 && _state->weakRefCount == 0) {
-      // free the full memory if there are no more references at all
+  // Releases the strong cohort's implicit weak reference (see `ReferenceState`). Called exactly once per state,
+  // by whichever strong reference performed the final strong release - the value is already destroyed at this
+  // point. Frees the state if no `WeakReference` is left holding it either.
+  void releaseImplicitWeakRef() {
+    if (_state->weakRefCount.fetch_sub(1) == 1) {
       delete _state;
-      _state = nullptr;
     }
+    _state = nullptr;
   }
 
   void forceDestroyValue() {

--- a/packages/react-native-nitro-modules/cpp/utils/ReferenceState.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/ReferenceState.hpp
@@ -51,7 +51,11 @@ struct ReferenceState {
     return false;
   }
 
-  explicit ReferenceState() : strongRefCount(1), weakRefCount(0), isDeleted(false) {}
+  // `weakRefCount` starts at 1: the strong cohort collectively owns one implicit weak reference, released by
+  // whichever strong reference performs the final strong release (after it destroyed the value). The state is
+  // freed by whoever brings `weakRefCount` to zero, decided by `fetch_sub`'s return value alone - the same
+  // shape as `shared_ptr`'s control block.
+  explicit ReferenceState() : strongRefCount(1), weakRefCount(1), isDeleted(false) {}
 };
 
 } // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/cpp/utils/ReferenceState.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/ReferenceState.hpp
@@ -34,6 +34,23 @@ struct ReferenceState {
     return oldRefCount <= 1;
   }
 
+  /**
+   * Increments the strong ref count by one - unless it is already zero, and returns whether it did.
+   *
+   * A zero strong count means the final strong release is already under way (`~BorrowingReference` decrements
+   * the count BEFORE calling `forceDestroyValue()`), so handing out a strong reference in that window would
+   * resurrect a dying value. This is `weak_ptr::lock()`'s increment-if-not-zero.
+   */
+  inline bool tryIncrementStrongRefCount() {
+    size_t count = strongRefCount.load();
+    while (count != 0) {
+      if (strongRefCount.compare_exchange_weak(count, count + 1)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   explicit ReferenceState() : strongRefCount(1), weakRefCount(0), isDeleted(false) {}
 };
 

--- a/packages/react-native-nitro-modules/cpp/utils/WeakReference+Borrowing.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/WeakReference+Borrowing.hpp
@@ -26,6 +26,11 @@ BorrowingReference<T> WeakReference<T>::lock() const {
     // return nullptr
     return BorrowingReference<T>();
   }
+  if (!_state->tryIncrementStrongRefCount()) {
+    // the last strong reference is mid-release - the value is about to be destroyed, it just hasn't
+    // flagged `isDeleted` yet.
+    return BorrowingReference<T>();
+  }
 
   return BorrowingReference(*this);
 }

--- a/packages/react-native-nitro-modules/cpp/utils/WeakReference.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/WeakReference.hpp
@@ -49,8 +49,7 @@ public:
       return *this;
 
     if (_state != nullptr) {
-      _state->weakRefCount--;
-      maybeDestroy();
+      releaseWeakRef();
     }
 
     _value = ref._value;
@@ -67,8 +66,7 @@ public:
 
     if (_state != nullptr) {
       // destroy previous pointer
-      _state->weakRefCount--;
-      maybeDestroy();
+      releaseWeakRef();
     }
 
     _value = ref._value;
@@ -83,8 +81,7 @@ public:
 
   ~WeakReference() {
     if (_state != nullptr) {
-      _state->weakRefCount--;
-      maybeDestroy();
+      releaseWeakRef();
     }
   }
 
@@ -98,17 +95,15 @@ public:
   friend class BorrowingReference<T>;
 
 private:
-  void maybeDestroy() {
-    if (_state->strongRefCount == 0 && _state->weakRefCount == 0) {
-      // free the full memory if there are no more references at all
-      if (!_state->isDeleted) [[unlikely]] {
-        std::string typeName = TypeInfo::getFriendlyTypename<T>(true);
-        throw std::runtime_error("WeakReference<" + typeName + "> encountered a stale `_value` - BorrowingReference<" + typeName +
-                                 "> should've already deleted this!");
-      }
+  // Releases this weak reference's count on the state, freeing the state if it was the last reference overall.
+  // The strong cohort owns one implicit weak reference (see `ReferenceState`), so the count can only reach zero
+  // after the final strong release already destroyed the value, and `fetch_sub`'s return value alone decides
+  // who frees the state.
+  void releaseWeakRef() {
+    if (_state->weakRefCount.fetch_sub(1) == 1) {
       delete _state;
-      _state = nullptr;
     }
+    _state = nullptr;
   }
 
 private:


### PR DESCRIPTION
Part 2 of 3 - #1464 split into atomic PRs as requested. **Stacked on #1467, which must merge first** - this branch contains #1467's commit, so only the last commit is new here. I'll rebase once #1467 lands. (It needs #1467 not just textually: without the non-resurrecting `lock()`, a resurrected strong reference would perform a second final strong release and double-release the implicit weak reference introduced here.)

## The race

Both `BorrowingReference::maybeDestroyState()` and `WeakReference::maybeDestroy()` freed the state when `strongRefCount == 0 && weakRefCount == 0`. Those are two independent atomics read as a unit, so a last-strong releaser and a last-weak releaser running concurrently can **both** observe `(0, 0)` - a double `delete _state` - or one can read a counter out of a state the other has already freed.

## The fix

`ReferenceState` now uses `shared_ptr`'s control-block scheme: `weakRefCount` starts at 1, representing one implicit weak reference collectively owned by the strong cohort, released by whichever strong reference performs the final strong release (after it destroyed the value). The state is freed by whoever brings `weakRefCount` to zero, decided by `fetch_sub`'s return value alone - so exactly one thread ever sees the `1 -> 0` transition, and `weakRefCount` cannot reach zero before the final strong release has completed.

The "stale `_value`" throw in `WeakReference::maybeDestroy()` goes away with it: under the control block, the weak count reaching zero implies the value was already destroyed by the final strong release.

## Testing

Has been running on-device (Android, release build) against a high-rate HybridObject conversion path as part of the combined #1464 change, with all Nitro-consuming modules rebuilt - no crashes or dispose warnings. Not exercised in isolation from #1467/part 3. Formatted to match `config/.clang-format` output in the surrounding code.
