### PR TITLE
fix: Re-apply all props when Fabric re-creates a HybridView's native View

### DIFF
--- a/example/__tests__/views.harness.tsx
+++ b/example/__tests__/views.harness.tsx
@@ -1,0 +1,51 @@
+import { Activity } from 'react'
+import { Platform } from 'react-native'
+import { describe, expect, it, render, waitUntil } from 'react-native-harness'
+import { callback } from 'react-native-nitro-modules'
+import { TestView, type TestViewRef } from 'react-native-nitro-test'
+
+const refs: TestViewRef[] = []
+const hybridRef = callback((ref: TestViewRef) => {
+  refs.push(ref)
+})
+
+// Stable element - React does not re-render it, so its ShadowNode never changes.
+const testView = (
+  <TestView
+    isBlue={true}
+    hasBeenCalled={false}
+    colorScheme="light"
+    someCallback={callback(() => {})}
+    hybridRef={hybridRef}
+    style={{ width: 20, height: 20 }}
+  />
+)
+const renderTestView = (visible: boolean) => (
+  <Activity mode={visible ? 'visible' : 'hidden'}>{testView}</Activity>
+)
+
+// On iOS, hiding a subtree drops its native Views and showing it again creates new ones - for
+// ShadowNodes that did not change. This is what react-native-screens does when a screen is
+// detached and re-attached. On Android the native View survives being hidden, so there is
+// nothing to re-create there. See https://github.com/mrousavy/nitro/issues/1380
+const itOnIos = Platform.OS === 'ios' ? it : it.skip
+
+describe('HybridView', () => {
+  itOnIos('applies all props to a native View that Fabric re-created', async () => {
+    refs.length = 0
+
+    const { rerender, unmount } = await render(renderTestView(true))
+    await waitUntil(() => refs.length === 1)
+    expect(refs[0]!.isBlue).toBe(true)
+
+    await rerender(renderTestView(false))
+    await rerender(renderTestView(true))
+
+    // A new native View was created, so `hybridRef` fires again with the new HybridView...
+    await waitUntil(() => refs.length === 2)
+    // ...and that new HybridView received `isBlue` again, instead of keeping its native default.
+    expect(refs[1]!.isBlue).toBe(true)
+
+    unmount()
+  })
+})

--- a/packages/nitrogen/src/views/kotlin/KotlinHybridViewManager.ts
+++ b/packages/nitrogen/src/views/kotlin/KotlinHybridViewManager.ts
@@ -49,6 +49,7 @@ import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
 import com.margelo.nitro.R.id.associated_hybrid_view_tag
+import com.margelo.nitro.R.id.needs_full_props_update_tag
 import com.margelo.nitro.views.RecyclableView
 import ${javaNamespace}.*
 
@@ -71,6 +72,7 @@ public class ${manager}: SimpleViewManager<View>() {
     val hybridView = ${viewImplementation}(reactContext)
     val view = hybridView.view
     view.setTag(associated_hybrid_view_tag, hybridView)
+    view.setTag(needs_full_props_update_tag, true)
     return view
   }
 
@@ -78,12 +80,19 @@ public class ${manager}: SimpleViewManager<View>() {
     val hybridView = getHybridView(view)
       ?: throw Error("Couldn't find view $view in local views table!")
 
-    // 1. Update each prop individually
+    // 1. \`isDirty\` only tells us whether a prop changed in the ShadowTree - not whether it has
+    //    ever been applied to this View. Fabric can create a new View for a ShadowNode that did
+    //    not change (e.g. when a subtree is hidden and shown again), in which case no prop would
+    //    be dirty at all. A newly created (or recycled) View therefore applies all props once.
+    val forceUpdate = view.getTag(needs_full_props_update_tag) as? Boolean ?: true
+    view.setTag(needs_full_props_update_tag, false)
+
+    // 2. Update each prop individually
     hybridView.beforeUpdate()
-    ${stateUpdaterName}.updateViewProps(hybridView, stateWrapper)
+    ${stateUpdaterName}.updateViewProps(hybridView, stateWrapper, forceUpdate)
     hybridView.afterUpdate()
 
-    // 2. Continue in base View props
+    // 3. Continue in base View props
     return super.updateState(view, props, stateWrapper)
   }
 
@@ -102,6 +111,9 @@ public class ${manager}: SimpleViewManager<View>() {
     if (hybridView is RecyclableView) {
       // Recycle in it's implementation
       hybridView.prepareForRecycle()
+
+      // This View will be re-used for a different ShadowNode later on, so it needs all props again.
+      hybridView.view.setTag(needs_full_props_update_tag, true)
 
       // Maybe update the view if it changed
       return hybridView.view
@@ -132,7 +144,7 @@ internal class ${stateUpdaterName} {
      */
     @Suppress("KotlinJniMissingFunction")
     @JvmStatic
-    external fun updateViewProps(view: ${HybridTSpec}, state: StateWrapper)
+    external fun updateViewProps(view: ${HybridTSpec}, state: StateWrapper, forceUpdate: Boolean)
   }
 }
   `.trim()
@@ -171,7 +183,8 @@ public:
 public:
   static void updateViewProps(jni::alias_ref<jni::JClass> /* class */,
                               jni::alias_ref<${JHybridTSpec}::JavaPart> view,
-                              jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface);
+                              jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface,
+                              jboolean forceUpdate);
 
 public:
   static void registerNatives() {
@@ -193,7 +206,7 @@ public:
     const name = escapeCppName(p.name)
     const setter = p.getSetterName('other')
     return `
-if (props->${name}.isDirty) {
+if ((forceUpdate && props->${name}.hasValue()) || props->${name}.isDirty) {
   hybridView->${setter}(props->${name}.value);
   props->${name}.isDirty = false;
 }
@@ -214,7 +227,8 @@ using ConcreteStateData = react::ConcreteState<${stateClassName}>;
 
 void J${stateUpdaterName}::updateViewProps(jni::alias_ref<jni::JClass> /* class */,
                                            jni::alias_ref<${JHybridTSpec}::JavaPart> javaView,
-                                           jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface) {
+                                           jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface,
+                                           jboolean forceUpdate) {
   std::shared_ptr<${JHybridTSpec}> hybridView = javaView->get${JHybridTSpec}();
 
   // Get concrete StateWrapperImpl from passed StateWrapper interface object
@@ -237,7 +251,7 @@ void J${stateUpdaterName}::updateViewProps(jni::alias_ref<jni::JClass> /* class 
   ${indent(propsUpdaterCalls.join('\n'), '  ')}
 
   // Update hybridRef if it changed
-  if (props->hybridRef.isDirty) {
+  if ((forceUpdate && props->hybridRef.hasValue()) || props->hybridRef.isDirty) {
     // hybridRef changed - call it with new this
     const auto& maybeFunc = props->hybridRef.value;
     if (maybeFunc.has_value()) {

--- a/packages/nitrogen/src/views/swift/SwiftHybridViewManager.ts
+++ b/packages/nitrogen/src/views/swift/SwiftHybridViewManager.ts
@@ -45,7 +45,7 @@ export function createSwiftHybridViewManager(
     )
     return `
 // ${p.jsSignature}
-if (newViewProps.${name}.isDirty) {
+if ((forceUpdate && newViewProps.${name}.hasValue()) || newViewProps.${name}.isDirty) {
   swiftPart.${setter}(${indent(parse, '  ')});
   newViewProps.${name}.isDirty = false;
 }
@@ -87,6 +87,7 @@ using namespace ${namespace}::views;
 
 @implementation ${component} {
   std::shared_ptr<${HybridTSpecSwift}> _hybridView;
+  BOOL _didUpdateProps;
 }
 
 + (void) load {
@@ -126,15 +127,22 @@ using namespace ${namespace}::views;
   auto& newViewProps = const_cast<${propsClassName}&>(newViewPropsConst);
   ${swiftNamespace}::${HybridTSpecCxx}& swiftPart = _hybridView->getSwiftPart();
 
-  // 2. Update each prop individually
+  // 2. \`isDirty\` only tells us whether a prop changed in the ShadowTree - not whether it has
+  //    ever been applied to *this* View. Fabric can create a new View for a ShadowNode that
+  //    did not change (e.g. when a subtree is hidden and shown again), in which case no prop
+  //    would be dirty at all. A newly created (or recycled) View therefore applies all props once.
+  const bool forceUpdate = !_didUpdateProps;
+  _didUpdateProps = YES;
+
+  // 3. Update each prop individually
   swiftPart.beforeUpdate();
 
   ${indent(propAssignments.join('\n'), '  ')}
 
   swiftPart.afterUpdate();
 
-  // 3. Update hybridRef if it changed
-  if (newViewProps.hybridRef.isDirty) {
+  // 4. Update hybridRef if it changed
+  if ((forceUpdate && newViewProps.hybridRef.hasValue()) || newViewProps.hybridRef.isDirty) {
     // hybridRef changed - call it with new this
     const auto& maybeFunc = newViewProps.hybridRef.value;
     if (maybeFunc.has_value()) {
@@ -143,7 +151,7 @@ using namespace ${namespace}::views;
     newViewProps.hybridRef.isDirty = false;
   }
 
-  // 4. Continue in base class
+  // 5. Continue in base class
   [super updateProps:props oldProps:oldProps];
 }
 
@@ -153,6 +161,8 @@ using namespace ${namespace}::views;
 
 - (void)prepareForRecycle {
   [super prepareForRecycle];
+  // This View will be re-used for a different ShadowNode later on, so it needs all props again.
+  _didUpdateProps = NO;
   ${swiftNamespace}::${HybridTSpecCxx}& swiftPart = _hybridView->getSwiftPart();
   swiftPart.maybePrepareForRecycle();
 }

--- a/packages/react-native-nitro-modules/android/src/main/res/values/ids.xml
+++ b/packages/react-native-nitro-modules/android/src/main/res/values/ids.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item type="id" name="associated_hybrid_view_tag"/>
+    <item type="id" name="needs_full_props_update_tag"/>
 </resources>

--- a/packages/react-native-nitro-modules/cpp/views/CachedProp.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/CachedProp.hpp
@@ -33,6 +33,15 @@ private:
   BorrowingReference<jsi::Value> jsiValue;
 
 public:
+  /**
+   * Whether this prop ever received a value from JS.
+   * A prop that was never set by JS still holds a default-constructed `value`,
+   * which must not be applied to the View.
+   */
+  bool hasValue() const noexcept {
+    return jsiValue != nullptr;
+  }
+
   bool equals(jsi::Runtime& runtime, const jsi::Value& other) const {
     if (jsiValue == nullptr) {
       return false;

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridRecyclableTestViewStateUpdater.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridRecyclableTestViewStateUpdater.cpp
@@ -17,7 +17,8 @@ using ConcreteStateData = react::ConcreteState<HybridRecyclableTestViewState>;
 
 void JHybridRecyclableTestViewStateUpdater::updateViewProps(jni::alias_ref<jni::JClass> /* class */,
                                            jni::alias_ref<JHybridRecyclableTestViewSpec::JavaPart> javaView,
-                                           jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface) {
+                                           jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface,
+                                           jboolean forceUpdate) {
   std::shared_ptr<JHybridRecyclableTestViewSpec> hybridView = javaView->getJHybridRecyclableTestViewSpec();
 
   // Get concrete StateWrapperImpl from passed StateWrapper interface object
@@ -37,13 +38,13 @@ void JHybridRecyclableTestViewStateUpdater::updateViewProps(jni::alias_ref<jni::
   }
 
   // Update all props if they are dirty
-  if (props->isBlue.isDirty) {
+  if ((forceUpdate && props->isBlue.hasValue()) || props->isBlue.isDirty) {
     hybridView->setIsBlue(props->isBlue.value);
     props->isBlue.isDirty = false;
   }
 
   // Update hybridRef if it changed
-  if (props->hybridRef.isDirty) {
+  if ((forceUpdate && props->hybridRef.hasValue()) || props->hybridRef.isDirty) {
     // hybridRef changed - call it with new this
     const auto& maybeFunc = props->hybridRef.value;
     if (maybeFunc.has_value()) {

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridRecyclableTestViewStateUpdater.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridRecyclableTestViewStateUpdater.hpp
@@ -31,7 +31,8 @@ public:
 public:
   static void updateViewProps(jni::alias_ref<jni::JClass> /* class */,
                               jni::alias_ref<JHybridRecyclableTestViewSpec::JavaPart> view,
-                              jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface);
+                              jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface,
+                              jboolean forceUpdate);
 
 public:
   static void registerNatives() {

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.cpp
@@ -17,7 +17,8 @@ using ConcreteStateData = react::ConcreteState<HybridTestViewState>;
 
 void JHybridTestViewStateUpdater::updateViewProps(jni::alias_ref<jni::JClass> /* class */,
                                            jni::alias_ref<JHybridTestViewSpec::JavaPart> javaView,
-                                           jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface) {
+                                           jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface,
+                                           jboolean forceUpdate) {
   std::shared_ptr<JHybridTestViewSpec> hybridView = javaView->getJHybridTestViewSpec();
 
   // Get concrete StateWrapperImpl from passed StateWrapper interface object
@@ -37,25 +38,25 @@ void JHybridTestViewStateUpdater::updateViewProps(jni::alias_ref<jni::JClass> /*
   }
 
   // Update all props if they are dirty
-  if (props->isBlue.isDirty) {
+  if ((forceUpdate && props->isBlue.hasValue()) || props->isBlue.isDirty) {
     hybridView->setIsBlue(props->isBlue.value);
     props->isBlue.isDirty = false;
   }
-  if (props->hasBeenCalled.isDirty) {
+  if ((forceUpdate && props->hasBeenCalled.hasValue()) || props->hasBeenCalled.isDirty) {
     hybridView->setHasBeenCalled(props->hasBeenCalled.value);
     props->hasBeenCalled.isDirty = false;
   }
-  if (props->colorScheme.isDirty) {
+  if ((forceUpdate && props->colorScheme.hasValue()) || props->colorScheme.isDirty) {
     hybridView->setColorScheme(props->colorScheme.value);
     props->colorScheme.isDirty = false;
   }
-  if (props->someCallback.isDirty) {
+  if ((forceUpdate && props->someCallback.hasValue()) || props->someCallback.isDirty) {
     hybridView->setSomeCallback(props->someCallback.value);
     props->someCallback.isDirty = false;
   }
 
   // Update hybridRef if it changed
-  if (props->hybridRef.isDirty) {
+  if ((forceUpdate && props->hybridRef.hasValue()) || props->hybridRef.isDirty) {
     // hybridRef changed - call it with new this
     const auto& maybeFunc = props->hybridRef.value;
     if (maybeFunc.has_value()) {

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.hpp
@@ -31,7 +31,8 @@ public:
 public:
   static void updateViewProps(jni::alias_ref<jni::JClass> /* class */,
                               jni::alias_ref<JHybridTestViewSpec::JavaPart> view,
-                              jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface);
+                              jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface,
+                              jboolean forceUpdate);
 
 public:
   static void registerNatives() {

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridRecyclableTestViewManager.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridRecyclableTestViewManager.kt
@@ -13,6 +13,7 @@ import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
 import com.margelo.nitro.R.id.associated_hybrid_view_tag
+import com.margelo.nitro.R.id.needs_full_props_update_tag
 import com.margelo.nitro.views.RecyclableView
 import com.margelo.nitro.test.*
 
@@ -35,6 +36,7 @@ public class HybridRecyclableTestViewManager: SimpleViewManager<View>() {
     val hybridView = HybridRecyclableTestView(reactContext)
     val view = hybridView.view
     view.setTag(associated_hybrid_view_tag, hybridView)
+    view.setTag(needs_full_props_update_tag, true)
     return view
   }
 
@@ -42,12 +44,19 @@ public class HybridRecyclableTestViewManager: SimpleViewManager<View>() {
     val hybridView = getHybridView(view)
       ?: throw Error("Couldn't find view $view in local views table!")
 
-    // 1. Update each prop individually
+    // 1. `isDirty` only tells us whether a prop changed in the ShadowTree - not whether it has
+    //    ever been applied to this View. Fabric can create a new View for a ShadowNode that did
+    //    not change (e.g. when a subtree is hidden and shown again), in which case no prop would
+    //    be dirty at all. A newly created (or recycled) View therefore applies all props once.
+    val forceUpdate = view.getTag(needs_full_props_update_tag) as? Boolean ?: true
+    view.setTag(needs_full_props_update_tag, false)
+
+    // 2. Update each prop individually
     hybridView.beforeUpdate()
-    HybridRecyclableTestViewStateUpdater.updateViewProps(hybridView, stateWrapper)
+    HybridRecyclableTestViewStateUpdater.updateViewProps(hybridView, stateWrapper, forceUpdate)
     hybridView.afterUpdate()
 
-    // 2. Continue in base View props
+    // 3. Continue in base View props
     return super.updateState(view, props, stateWrapper)
   }
 
@@ -66,6 +75,9 @@ public class HybridRecyclableTestViewManager: SimpleViewManager<View>() {
     if (hybridView is RecyclableView) {
       // Recycle in it's implementation
       hybridView.prepareForRecycle()
+
+      // This View will be re-used for a different ShadowNode later on, so it needs all props again.
+      hybridView.view.setTag(needs_full_props_update_tag, true)
 
       // Maybe update the view if it changed
       return hybridView.view

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridRecyclableTestViewStateUpdater.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridRecyclableTestViewStateUpdater.kt
@@ -18,6 +18,6 @@ internal class HybridRecyclableTestViewStateUpdater {
      */
     @Suppress("KotlinJniMissingFunction")
     @JvmStatic
-    external fun updateViewProps(view: HybridRecyclableTestViewSpec, state: StateWrapper)
+    external fun updateViewProps(view: HybridRecyclableTestViewSpec, state: StateWrapper, forceUpdate: Boolean)
   }
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridTestViewManager.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridTestViewManager.kt
@@ -13,6 +13,7 @@ import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
 import com.margelo.nitro.R.id.associated_hybrid_view_tag
+import com.margelo.nitro.R.id.needs_full_props_update_tag
 import com.margelo.nitro.views.RecyclableView
 import com.margelo.nitro.test.*
 
@@ -35,6 +36,7 @@ public class HybridTestViewManager: SimpleViewManager<View>() {
     val hybridView = HybridTestView(reactContext)
     val view = hybridView.view
     view.setTag(associated_hybrid_view_tag, hybridView)
+    view.setTag(needs_full_props_update_tag, true)
     return view
   }
 
@@ -42,12 +44,19 @@ public class HybridTestViewManager: SimpleViewManager<View>() {
     val hybridView = getHybridView(view)
       ?: throw Error("Couldn't find view $view in local views table!")
 
-    // 1. Update each prop individually
+    // 1. `isDirty` only tells us whether a prop changed in the ShadowTree - not whether it has
+    //    ever been applied to this View. Fabric can create a new View for a ShadowNode that did
+    //    not change (e.g. when a subtree is hidden and shown again), in which case no prop would
+    //    be dirty at all. A newly created (or recycled) View therefore applies all props once.
+    val forceUpdate = view.getTag(needs_full_props_update_tag) as? Boolean ?: true
+    view.setTag(needs_full_props_update_tag, false)
+
+    // 2. Update each prop individually
     hybridView.beforeUpdate()
-    HybridTestViewStateUpdater.updateViewProps(hybridView, stateWrapper)
+    HybridTestViewStateUpdater.updateViewProps(hybridView, stateWrapper, forceUpdate)
     hybridView.afterUpdate()
 
-    // 2. Continue in base View props
+    // 3. Continue in base View props
     return super.updateState(view, props, stateWrapper)
   }
 
@@ -66,6 +75,9 @@ public class HybridTestViewManager: SimpleViewManager<View>() {
     if (hybridView is RecyclableView) {
       // Recycle in it's implementation
       hybridView.prepareForRecycle()
+
+      // This View will be re-used for a different ShadowNode later on, so it needs all props again.
+      hybridView.view.setTag(needs_full_props_update_tag, true)
 
       // Maybe update the view if it changed
       return hybridView.view

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridTestViewStateUpdater.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridTestViewStateUpdater.kt
@@ -18,6 +18,6 @@ internal class HybridTestViewStateUpdater {
      */
     @Suppress("KotlinJniMissingFunction")
     @JvmStatic
-    external fun updateViewProps(view: HybridTestViewSpec, state: StateWrapper)
+    external fun updateViewProps(view: HybridTestViewSpec, state: StateWrapper, forceUpdate: Boolean)
   }
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridRecyclableTestViewComponent.mm
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridRecyclableTestViewComponent.mm
@@ -37,6 +37,7 @@ using namespace margelo::nitro::test::views;
 
 @implementation HybridRecyclableTestViewComponent {
   std::shared_ptr<HybridRecyclableTestViewSpecSwift> _hybridView;
+  BOOL _didUpdateProps;
 }
 
 + (void) load {
@@ -76,19 +77,26 @@ using namespace margelo::nitro::test::views;
   auto& newViewProps = const_cast<HybridRecyclableTestViewProps&>(newViewPropsConst);
   NitroTest::HybridRecyclableTestViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
 
-  // 2. Update each prop individually
+  // 2. `isDirty` only tells us whether a prop changed in the ShadowTree - not whether it has
+  //    ever been applied to *this* View. Fabric can create a new View for a ShadowNode that
+  //    did not change (e.g. when a subtree is hidden and shown again), in which case no prop
+  //    would be dirty at all. A newly created (or recycled) View therefore applies all props once.
+  const bool forceUpdate = !_didUpdateProps;
+  _didUpdateProps = YES;
+
+  // 3. Update each prop individually
   swiftPart.beforeUpdate();
 
   // isBlue: boolean
-  if (newViewProps.isBlue.isDirty) {
+  if ((forceUpdate && newViewProps.isBlue.hasValue()) || newViewProps.isBlue.isDirty) {
     swiftPart.setIsBlue(newViewProps.isBlue.value);
     newViewProps.isBlue.isDirty = false;
   }
 
   swiftPart.afterUpdate();
 
-  // 3. Update hybridRef if it changed
-  if (newViewProps.hybridRef.isDirty) {
+  // 4. Update hybridRef if it changed
+  if ((forceUpdate && newViewProps.hybridRef.hasValue()) || newViewProps.hybridRef.isDirty) {
     // hybridRef changed - call it with new this
     const auto& maybeFunc = newViewProps.hybridRef.value;
     if (maybeFunc.has_value()) {
@@ -97,7 +105,7 @@ using namespace margelo::nitro::test::views;
     newViewProps.hybridRef.isDirty = false;
   }
 
-  // 4. Continue in base class
+  // 5. Continue in base class
   [super updateProps:props oldProps:oldProps];
 }
 
@@ -107,6 +115,8 @@ using namespace margelo::nitro::test::views;
 
 - (void)prepareForRecycle {
   [super prepareForRecycle];
+  // This View will be re-used for a different ShadowNode later on, so it needs all props again.
+  _didUpdateProps = NO;
   NitroTest::HybridRecyclableTestViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
   swiftPart.maybePrepareForRecycle();
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
@@ -37,6 +37,7 @@ using namespace margelo::nitro::test::views;
 
 @implementation HybridTestViewComponent {
   std::shared_ptr<HybridTestViewSpecSwift> _hybridView;
+  BOOL _didUpdateProps;
 }
 
 + (void) load {
@@ -76,34 +77,41 @@ using namespace margelo::nitro::test::views;
   auto& newViewProps = const_cast<HybridTestViewProps&>(newViewPropsConst);
   NitroTest::HybridTestViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
 
-  // 2. Update each prop individually
+  // 2. `isDirty` only tells us whether a prop changed in the ShadowTree - not whether it has
+  //    ever been applied to *this* View. Fabric can create a new View for a ShadowNode that
+  //    did not change (e.g. when a subtree is hidden and shown again), in which case no prop
+  //    would be dirty at all. A newly created (or recycled) View therefore applies all props once.
+  const bool forceUpdate = !_didUpdateProps;
+  _didUpdateProps = YES;
+
+  // 3. Update each prop individually
   swiftPart.beforeUpdate();
 
   // isBlue: boolean
-  if (newViewProps.isBlue.isDirty) {
+  if ((forceUpdate && newViewProps.isBlue.hasValue()) || newViewProps.isBlue.isDirty) {
     swiftPart.setIsBlue(newViewProps.isBlue.value);
     newViewProps.isBlue.isDirty = false;
   }
   // hasBeenCalled: boolean
-  if (newViewProps.hasBeenCalled.isDirty) {
+  if ((forceUpdate && newViewProps.hasBeenCalled.hasValue()) || newViewProps.hasBeenCalled.isDirty) {
     swiftPart.setHasBeenCalled(newViewProps.hasBeenCalled.value);
     newViewProps.hasBeenCalled.isDirty = false;
   }
   // colorScheme: enum
-  if (newViewProps.colorScheme.isDirty) {
+  if ((forceUpdate && newViewProps.colorScheme.hasValue()) || newViewProps.colorScheme.isDirty) {
     swiftPart.setColorScheme(static_cast<int>(newViewProps.colorScheme.value));
     newViewProps.colorScheme.isDirty = false;
   }
   // someCallback: function
-  if (newViewProps.someCallback.isDirty) {
+  if ((forceUpdate && newViewProps.someCallback.hasValue()) || newViewProps.someCallback.isDirty) {
     swiftPart.setSomeCallback(newViewProps.someCallback.value);
     newViewProps.someCallback.isDirty = false;
   }
 
   swiftPart.afterUpdate();
 
-  // 3. Update hybridRef if it changed
-  if (newViewProps.hybridRef.isDirty) {
+  // 4. Update hybridRef if it changed
+  if ((forceUpdate && newViewProps.hybridRef.hasValue()) || newViewProps.hybridRef.isDirty) {
     // hybridRef changed - call it with new this
     const auto& maybeFunc = newViewProps.hybridRef.value;
     if (maybeFunc.has_value()) {
@@ -112,7 +120,7 @@ using namespace margelo::nitro::test::views;
     newViewProps.hybridRef.isDirty = false;
   }
 
-  // 4. Continue in base class
+  // 5. Continue in base class
   [super updateProps:props oldProps:oldProps];
 }
 
@@ -122,6 +130,8 @@ using namespace margelo::nitro::test::views;
 
 - (void)prepareForRecycle {
   [super prepareForRecycle];
+  // This View will be re-used for a different ShadowNode later on, so it needs all props again.
+  _didUpdateProps = NO;
   NitroTest::HybridTestViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
   swiftPart.maybePrepareForRecycle();
 }


### PR DESCRIPTION
Fixes #1380

## The bug

`CachedProp::isDirty` answers "did this prop change in the ShadowTree?", but the generated `updateProps` uses it to answer "does this prop need to be applied to this native View?". Those are different questions the moment Fabric creates a **new native View for a ShadowNode that did not change** — every prop is clean, no setter runs, and the fresh view keeps its Swift/Kotlin defaults.

React Native core views are immune because `updateProps(newProps, oldProps)` diffs by value, and `oldProps` is `defaultProps` for a freshly mounted view, so everything is re-applied on mount.

The `isDirty = false` write (added in 67d45a4 / #1195 to avoid repeated JNI/Swift roundtrips) is what turns the flag into one-shot state on props that are shared across mounts.

## Reproducing it without `react-native-screens`

The issue reproduces through `react-native-screens`, but the underlying trigger is plain React: a hidden `<Activity>` (or `<Suspense>` — that is what `react-freeze`, and therefore `react-native-screens`, uses) drops the native views of its subtree, and showing it again creates new ones for the *same, unchanged* ShadowNodes.

Verified on the iOS simulator on `main` by logging `HybridTestView`'s `init` and `isBlue.didSet`:

```
16:44:12.910  HybridTestView CREATED ObjectIdentifier(0x…a2700)   <- mount
16:44:12.910  setIsBlue(true) on ObjectIdentifier(0x…a2700)
              (hide - nothing)
16:44:15.966  HybridTestView CREATED ObjectIdentifier(0x…d2c0)    <- show: new View
              (no setIsBlue - the new View is left at its Swift default)
```

`hybridRef` is affected by the same flag, so JS is also left holding the destroyed HybridView.

## The fix

A newly created — or recycled — View applies every prop it has, once. That is exactly what an RN core view does on mount; after the first update the behaviour is unchanged and only dirty props are applied.

- iOS (`SwiftHybridViewManager.ts`): a `_didUpdateProps` ivar, reset in `prepareForRecycle` so a pooled view re-used for a different ShadowNode does not keep the previous node's values.
- Android (`KotlinHybridViewManager.ts`): `updateViewProps` is a free JNI function, so the flag lives on the view itself as a tag (`needs_full_props_update_tag`, next to the existing `associated_hybrid_view_tag`), set in `createViewInstance` / `prepareToRecycleView` and passed into the JNI call.

### One correction to the fix proposed in the issue

Forcing *all* props unconditionally is not safe. A prop JS never passed still has a default-constructed `CachedProp` — an empty `std::function`, a `nullptr` `shared_ptr<HybridObject>`, and so on — and it is `isDirty == false` forever, so today its setter is never called. Pushing that into Swift/Kotlin on first update would be a new crash source.

So this PR adds `CachedProp::hasValue()` (`jsiValue != nullptr`, i.e. "JS assigned this prop at some point") and the generated condition is:

```cpp
if ((forceUpdate && newViewProps.isBlue.hasValue()) || newViewProps.isBlue.isDirty) { … }
```

This also makes the behaviour exactly equivalent to RN core: a prop JS never set equals `defaultProps`, so core would not apply it either.

## Performance

This partially walks back #1195, so to be explicit about the cost:

- The extra work is **one full prop application per mounted native View**, and nothing else. `RCTMountingManager` calls `updateProps` exactly once per `Insert` after a `Create` (`RCTMountingManager.mm`, `ShadowViewMutation::Insert` → `updateProps:oldProps:nullptr`), and the flag is set on that first call. On Android the same holds for the first `updateState` after `createViewInstance`.
- It is **not** per update. Steady-state prop updates take the same path as before: `forceUpdate` is `false`, `isDirty` decides, and `isDirty = false` still short-circuits unchanged props on later clones. The JNI/Swift roundtrips #1195 removed stay removed.
- It is **not** per re-parent either — a `Remove` + `Insert` (reorder) reuses the same view instance, whose flag is already set.
- For recycled views it is once per recycle, which is the point: a pooled view re-used for another ShadowNode would otherwise show the previous node's props.
- Props JS never set are still never applied (`hasValue()`), so the forced pass is bounded by the props actually present on the element.

Net: on mount, a Nitro view now does what an RN core view has always done. Nothing changes for the update path that #1195 optimized.

## Test

`example/__tests__/views.harness.tsx` — a runtime test in the Harness suite. `getTests.ts` has no React renderer, and this bug is only observable by mounting a view, so it lives in `__tests__/` alongside `nitro.harness.ts`; `example/__tests__/**` is already in both harness workflows' path filters. It reuses the existing `TestView` spec and adds no new spec, struct, or dependency.

The test renders `<TestView isBlue={true} />` inside an `<Activity>`, hides it, shows it again, and asserts that the re-created View reports `isBlue === true` — i.e. that the box is still blue, which is the user-visible symptom in the issue.

Counterfactual, iOS simulator (iPhone 17, iOS 26.3), same test file both times:

```
# with the codegen change reverted
FAIL __tests__/views.harness.tsx
  ● HybridView › applies all props to a native View that Fabric re-created
    Timed out in waitUntil!
    > 41 |     await waitUntil(() => refs.length === 2)
Tests: 1 failed, 1 total

# with the fix
Tests: 1 passed, 1 total
```

Full suites:

- **iOS**: `523 passed, 523 total` (2 suites).
- **Android** (API 36 arm64 emulator): `9 failed, 1 skipped, 513 passed`. The 9 failures are all `createHardwareBuffer` / `ArrayBuffer` cases and are **identical on `main` without this change** (verified by rebuilding and re-running the baseline APK) — emulator limitations, unrelated to this PR. The 1 skip is the new test, see below.

### What I could not verify

The new test is **iOS-only**. On Android with RN 0.85.3 I could not get Fabric to re-create a HybridView's native View: with the same `<Activity>` toggle, `createViewInstance` is called exactly once (confirmed by logging `HybridTestView`'s `init` and reading logcat) — the view survives being hidden. The issue reporter also only validated on iOS.

The Android half of the fix is therefore the symmetric change to identical code, verified to build and to leave the existing Android suite unchanged, but **not** verified to fix an observable Android symptom. It is a no-op on Android today: `forceUpdate` is only ever `true` on the first `updateState`, where every prop JS set is already dirty. If you would rather keep the Android side out until there is a reproducing case, I am happy to drop it.

## Notes

- `bun specs` was re-run; the generated diff is limited to the view manager files and is mechanical. This PR adds no spec, so the generated tree changes *only* because of the codegen change.
- `bun typecheck` and `bun lint-all` (JS/TS, clang-format, swift-format, ktlint) pass with no reformatting.
- Trial-merged against #1478 (my other open PR, which also regenerates nitrogen output): merges cleanly with no conflicts, and `bun specs` on the merged tree produces no further diff — the two touch disjoint generated files (`views/*` vs `HybridTestObject*`).
