### PR TITLE
fix(ios): force-apply all view props on a component view's first updateProps (blank view after react-freeze recreation)

### DIFF
--- a/packages/nitrogen/src/views/swift/SwiftHybridViewManager.ts
+++ b/packages/nitrogen/src/views/swift/SwiftHybridViewManager.ts
@@ -45,7 +45,7 @@ export function createSwiftHybridViewManager(
     )
     return `
 // ${p.jsSignature}
-if (newViewProps.${name}.isDirty) {
+if (force || newViewProps.${name}.isDirty) {
   swiftPart.${setter}(${indent(parse, '  ')});
   newViewProps.${name}.isDirty = false;
 }
@@ -87,6 +87,15 @@ using namespace ${namespace}::views;
 
 @implementation ${component} {
   std::shared_ptr<${HybridTSpecSwift}> _hybridView;
+  // Fabric can mount this component view with a Props object whose isDirty
+  // flags were already consumed by a different view instance:
+  // - a view recreated from an unchanged ShadowNode (e.g. react-freeze /
+  //   Suspense re-inserting a previously hidden screen), or
+  // - a recycled view being remounted for another ShadowNode.
+  // In both cases updateProps would apply nothing and the fresh HybridView
+  // would stay unconfigured (and hybridRef would never fire).
+  // Force-apply every prop on this instance's first updateProps.
+  BOOL _didApplyInitialProps;
 }
 
 + (void) load {
@@ -126,6 +135,11 @@ using namespace ${namespace}::views;
   auto& newViewProps = const_cast<${propsClassName}&>(newViewPropsConst);
   ${swiftNamespace}::${HybridTSpecCxx}& swiftPart = _hybridView->getSwiftPart();
 
+  // Force-apply all props the first time this view instance updates
+  // (see _didApplyInitialProps above).
+  BOOL force = !_didApplyInitialProps;
+  _didApplyInitialProps = YES;
+
   // 2. Update each prop individually
   swiftPart.beforeUpdate();
 
@@ -134,7 +148,7 @@ using namespace ${namespace}::views;
   swiftPart.afterUpdate();
 
   // 3. Update hybridRef if it changed
-  if (newViewProps.hybridRef.isDirty) {
+  if (force || newViewProps.hybridRef.isDirty) {
     // hybridRef changed - call it with new this
     const auto& maybeFunc = newViewProps.hybridRef.value;
     if (maybeFunc.has_value()) {
@@ -153,6 +167,9 @@ using namespace ${namespace}::views;
 
 - (void)prepareForRecycle {
   [super prepareForRecycle];
+  // The next mount serves a different ShadowNode whose props' isDirty flags
+  // may already be consumed - force-apply them again.
+  _didApplyInitialProps = NO;
   ${swiftNamespace}::${HybridTSpecCxx}& swiftPart = _hybridView->getSwiftPart();
   swiftPart.maybePrepareForRecycle();
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridRecyclableTestViewComponent.mm
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridRecyclableTestViewComponent.mm
@@ -37,6 +37,15 @@ using namespace margelo::nitro::test::views;
 
 @implementation HybridRecyclableTestViewComponent {
   std::shared_ptr<HybridRecyclableTestViewSpecSwift> _hybridView;
+  // Fabric can mount this component view with a Props object whose isDirty
+  // flags were already consumed by a different view instance:
+  // - a view recreated from an unchanged ShadowNode (e.g. react-freeze /
+  //   Suspense re-inserting a previously hidden screen), or
+  // - a recycled view being remounted for another ShadowNode.
+  // In both cases updateProps would apply nothing and the fresh HybridView
+  // would stay unconfigured (and hybridRef would never fire).
+  // Force-apply every prop on this instance's first updateProps.
+  BOOL _didApplyInitialProps;
 }
 
 + (void) load {
@@ -76,11 +85,16 @@ using namespace margelo::nitro::test::views;
   auto& newViewProps = const_cast<HybridRecyclableTestViewProps&>(newViewPropsConst);
   NitroTest::HybridRecyclableTestViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
 
+  // Force-apply all props the first time this view instance updates
+  // (see _didApplyInitialProps above).
+  BOOL force = !_didApplyInitialProps;
+  _didApplyInitialProps = YES;
+
   // 2. Update each prop individually
   swiftPart.beforeUpdate();
 
   // isBlue: boolean
-  if (newViewProps.isBlue.isDirty) {
+  if (force || newViewProps.isBlue.isDirty) {
     swiftPart.setIsBlue(newViewProps.isBlue.value);
     newViewProps.isBlue.isDirty = false;
   }
@@ -88,7 +102,7 @@ using namespace margelo::nitro::test::views;
   swiftPart.afterUpdate();
 
   // 3. Update hybridRef if it changed
-  if (newViewProps.hybridRef.isDirty) {
+  if (force || newViewProps.hybridRef.isDirty) {
     // hybridRef changed - call it with new this
     const auto& maybeFunc = newViewProps.hybridRef.value;
     if (maybeFunc.has_value()) {
@@ -107,6 +121,9 @@ using namespace margelo::nitro::test::views;
 
 - (void)prepareForRecycle {
   [super prepareForRecycle];
+  // The next mount serves a different ShadowNode whose props' isDirty flags
+  // may already be consumed - force-apply them again.
+  _didApplyInitialProps = NO;
   NitroTest::HybridRecyclableTestViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
   swiftPart.maybePrepareForRecycle();
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
@@ -37,6 +37,15 @@ using namespace margelo::nitro::test::views;
 
 @implementation HybridTestViewComponent {
   std::shared_ptr<HybridTestViewSpecSwift> _hybridView;
+  // Fabric can mount this component view with a Props object whose isDirty
+  // flags were already consumed by a different view instance:
+  // - a view recreated from an unchanged ShadowNode (e.g. react-freeze /
+  //   Suspense re-inserting a previously hidden screen), or
+  // - a recycled view being remounted for another ShadowNode.
+  // In both cases updateProps would apply nothing and the fresh HybridView
+  // would stay unconfigured (and hybridRef would never fire).
+  // Force-apply every prop on this instance's first updateProps.
+  BOOL _didApplyInitialProps;
 }
 
 + (void) load {
@@ -76,26 +85,31 @@ using namespace margelo::nitro::test::views;
   auto& newViewProps = const_cast<HybridTestViewProps&>(newViewPropsConst);
   NitroTest::HybridTestViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
 
+  // Force-apply all props the first time this view instance updates
+  // (see _didApplyInitialProps above).
+  BOOL force = !_didApplyInitialProps;
+  _didApplyInitialProps = YES;
+
   // 2. Update each prop individually
   swiftPart.beforeUpdate();
 
   // isBlue: boolean
-  if (newViewProps.isBlue.isDirty) {
+  if (force || newViewProps.isBlue.isDirty) {
     swiftPart.setIsBlue(newViewProps.isBlue.value);
     newViewProps.isBlue.isDirty = false;
   }
   // hasBeenCalled: boolean
-  if (newViewProps.hasBeenCalled.isDirty) {
+  if (force || newViewProps.hasBeenCalled.isDirty) {
     swiftPart.setHasBeenCalled(newViewProps.hasBeenCalled.value);
     newViewProps.hasBeenCalled.isDirty = false;
   }
   // colorScheme: enum
-  if (newViewProps.colorScheme.isDirty) {
+  if (force || newViewProps.colorScheme.isDirty) {
     swiftPart.setColorScheme(static_cast<int>(newViewProps.colorScheme.value));
     newViewProps.colorScheme.isDirty = false;
   }
   // someCallback: function
-  if (newViewProps.someCallback.isDirty) {
+  if (force || newViewProps.someCallback.isDirty) {
     swiftPart.setSomeCallback(newViewProps.someCallback.value);
     newViewProps.someCallback.isDirty = false;
   }
@@ -103,7 +117,7 @@ using namespace margelo::nitro::test::views;
   swiftPart.afterUpdate();
 
   // 3. Update hybridRef if it changed
-  if (newViewProps.hybridRef.isDirty) {
+  if (force || newViewProps.hybridRef.isDirty) {
     // hybridRef changed - call it with new this
     const auto& maybeFunc = newViewProps.hybridRef.value;
     if (maybeFunc.has_value()) {
@@ -122,6 +136,9 @@ using namespace margelo::nitro::test::views;
 
 - (void)prepareForRecycle {
   [super prepareForRecycle];
+  // The next mount serves a different ShadowNode whose props' isDirty flags
+  // may already be consumed - force-apply them again.
+  _didApplyInitialProps = NO;
   NitroTest::HybridTestViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
   swiftPart.maybePrepareForRecycle();
 }


### PR DESCRIPTION
## Symptom

On iOS (new architecture), a Nitro view renders **permanently blank** after navigating away from its screen and coming back, when the app uses `react-native-screens` with `enableFreeze(true)` (react-freeze / Suspense). The native view is laid out correctly (size, background) but no props are ever applied to the fresh hybrid, and `hybridRef` never fires — so JS keeps a ref to the dead old hybrid and imperative calls silently no-op.

Originally reproduced and analyzed with `RiveView` from `rive-app/rive-nitro-react-native` — full write-up in rive-app/rive-nitro-react-native#365 (opened against the generated file committed there; this PR is the durable fix in the template, as suggested in that PR's description).

## Root cause

When a screen is frozen, Fabric **deletes** its native views; on return it **recreates** them from the same, unchanged ShadowNodes — calling `updateProps:oldProps:` on the brand-new component view with the **same cached `Props` object** as before.

The generated `updateProps` guards every prop with `isDirty` and, after applying it, mutates the shared props object (`newViewProps.<prop>.isDirty = false;` via `const_cast`). Those flags were already consumed by the *previous* view instance, so on recreation `updateProps` applies **nothing**:

- the fresh HybridView keeps all its default values (unconfigured);
- `hybridRef` never re-fires, so JS still holds the ref to the old, dead hybrid.

Nothing ever marks the props dirty again unless a prop changes identity on the JS side, so the view stays broken forever.

The same "consumed flags on a shared Props object" mechanism also affects **recycled** views being remounted for a different ShadowNode — the stale-props family of #1050.

## Fix

In `SwiftHybridViewManager.ts` (the template for `Hybrid*Component.mm`):

- track `BOOL _didApplyInitialProps` on the component view;
- force-apply every prop (and `hybridRef`) on the **first** `updateProps` of each view instance, keeping the `isDirty` fast path for all subsequent updates;
- reset the flag in `prepareForRecycle`, so a recycled view force-applies the next node's props on remount.

First-ever mounts are unaffected (all flags are dirty there anyway). Regenerated the committed `react-native-nitro-test` fixtures.

We've been running the equivalent patch (minus the recycle part) in production (several Rive scenes behind frozen tab/stack screens) and it fixes the blank-view repro deterministically.

Android's JNI state updater has the same consumed-`isDirty` pattern in theory, but we could not reproduce the bug there and fixing it needs a JNI signature change (`updateViewProps(view, state, forceApply)`), so this PR is iOS-only — happy to follow up on Android if you think it's worth it.

## Repro

1. RN app with new architecture + `react-native-screens`, `enableFreeze(true)`
2. Screen A renders a Nitro view with props; push any screen B on top (freeze unmounts A's native views)
3. Go back to A → the recreated view has no props applied; `hybridRef` never fired; only a prop identity change revives it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
