### PR TITLE
test: add Harness coverage for Nitro Views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,5 +87,8 @@ lib/
 # TypeScript
 tsconfig.tsbuildinfo
 
+# React Native Harness
+example/.harness/
+
 # Claude Code local settings
 .claude/settings.local.json

--- a/bun.lock
+++ b/bun.lock
@@ -81,14 +81,17 @@
         "@react-native-community/cli-platform-ios": "20.1.3",
         "@react-native-harness/platform-android": "1.4.1",
         "@react-native-harness/platform-apple": "1.4.1",
+        "@react-native-harness/ui": "1.4.1",
         "@react-native/babel-preset": "0.85.3",
         "@react-native/eslint-config": "0.85.3",
         "@react-native/metro-config": "0.85.3",
         "@react-native/typescript-config": "0.85.3",
         "@types/deep-equal": "^1.0.4",
+        "@types/upng-js": "2.1.5",
         "babel-plugin-module-resolver": "^5.0.3",
         "nitrogen": "*",
         "react-native-harness": "1.4.1",
+        "upng-js": "2.1.0",
       },
     },
     "packages/nitrogen": {
@@ -1082,6 +1085,8 @@
 
     "@react-native-harness/tools": ["@react-native-harness/tools@1.4.1", "", { "dependencies": { "@clack/prompts": "1.0.0-alpha.9", "nano-spawn": "^1.0.2", "picocolors": "^1.1.1", "tslib": "^2.3.0" }, "peerDependencies": { "react-native": "*" } }, "sha512-t72z8ZxognDpSpNPVs6Q4vsKaHqi7KzIIDsD9vaMbduoJD3ViERObI0pr2LonteZhuW9QG85NDH7xuu+EI+yPg=="],
 
+    "@react-native-harness/ui": ["@react-native-harness/ui@1.4.1", "", { "dependencies": { "@react-native-harness/runtime": "1.4.1", "tslib": "^2.3.0" }, "peerDependencies": { "react-native": "*" } }, "sha512-27PdOHvmqc33qO2XwI1V6M3thRa2Ji/v5W4etLtpNmIo2SULhSRMbpR1E2LEu7AZ6VDr1V4zQj1B+wc9gEYkbg=="],
+
     "@react-native-segmented-control/segmented-control": ["@react-native-segmented-control/segmented-control@2.5.7", "", { "peerDependencies": { "react": ">=16.0", "react-native": ">=0.62" } }, "sha512-l84YeVX8xAU3lvOJSvV4nK/NbGhIm2gBfveYolwaoCbRp+/SLXtc6mYrQmM9ScXNwU14mnzjQTpTHWl5YPnkzQ=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.85.3", "", {}, "sha512-u9ZiYP23vA2IFtdFQFmetzSmk6SM0xgKIoiOsr1hXNHjHaLhOm+/Ph1ud57wX6+Dbwdzx8coJgnzSKL3W21PCg=="],
@@ -1507,6 +1512,8 @@
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/upng-js": ["@types/upng-js@2.1.5", "", {}, "sha512-CzXg1lcCcWzrmYmke9BLbBPzb2DpdC1bXuXf0BtK3Bygvsozslei8S1bheDI1QUfZzZpMeQI5fywfnMj4CxocQ=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -3302,7 +3309,7 @@
 
     "package-manager-detector": ["package-manager-detector@1.4.0", "", {}, "sha512-rRZ+pR1Usc+ND9M2NkmCvE/LYJS+8ORVV9X0KuNSY/gFsp7RBHJM/ADh9LYq4Vvfq6QkKrW6/weuh8SMEtN5gw=="],
 
-    "pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
     "param-case": ["param-case@3.0.4", "", { "dependencies": { "dot-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A=="],
 
@@ -4097,6 +4104,8 @@
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "update-notifier": ["update-notifier@6.0.2", "", { "dependencies": { "boxen": "^7.0.0", "chalk": "^5.0.1", "configstore": "^6.0.0", "has-yarn": "^3.0.0", "import-lazy": "^4.0.0", "is-ci": "^3.0.1", "is-installed-globally": "^0.4.0", "is-npm": "^6.0.0", "is-yarn-global": "^0.4.0", "latest-version": "^7.0.0", "pupa": "^3.1.0", "semver": "^7.3.7", "semver-diff": "^4.0.0", "xdg-basedir": "^5.1.0" } }, "sha512-EDxhTEVPZZRLWYcJ4ZXjGFN0oP7qYvbXWzEgRm/Yql4dHX5wDbvh89YHP6PK1lzZJYrMtXUuZZz8XGK+U6U1og=="],
+
+    "upng-js": ["upng-js@2.1.0", "", { "dependencies": { "pako": "^1.0.5" } }, "sha512-d3xzZzpMP64YkjP5pr8gNyvBt7dLk/uGI67EctzDuVp4lCZyVMo0aJO6l/VDlgbInJYDY6cnClLoBp29eKWI6g=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
@@ -5351,6 +5360,8 @@
     "typescript-eslint/@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.60.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.60.0", "@typescript-eslint/type-utils": "8.60.0", "@typescript-eslint/utils": "8.60.0", "@typescript-eslint/visitor-keys": "8.60.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.60.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw=="],
 
     "typescript-eslint/@typescript-eslint/parser": ["@typescript-eslint/parser@8.60.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.60.0", "@typescript-eslint/types": "8.60.0", "@typescript-eslint/typescript-estree": "8.60.0", "@typescript-eslint/visitor-keys": "8.60.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg=="],
+
+    "unicode-trie/pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
 
     "update-notifier/boxen": ["boxen@7.1.1", "", { "dependencies": { "ansi-align": "^3.0.1", "camelcase": "^7.0.1", "chalk": "^5.2.0", "cli-boxes": "^3.0.0", "string-width": "^5.1.2", "type-fest": "^2.13.0", "widest-line": "^4.0.1", "wrap-ansi": "^8.1.0" } }, "sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog=="],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,6 +58,7 @@ export default [
   {
     ignores: [
       '**/node_modules/**',
+      '**/.harness/**',
       '**/lib/**',
       '**/.eslintrc.*',
       '**/.prettierrc.*',

--- a/example/__tests__/nitro.views.harness.tsx
+++ b/example/__tests__/nitro.views.harness.tsx
@@ -1,0 +1,702 @@
+import * as React from 'react'
+import { PixelRatio, Platform, type LayoutRectangle, View } from 'react-native'
+import {
+  describe,
+  expect,
+  fn,
+  it,
+  render,
+  waitUntil,
+} from 'react-native-harness'
+import { screen } from '@react-native-harness/ui'
+import { callback } from 'react-native-nitro-modules'
+import {
+  HybridTestObjectCpp,
+  HybridTestObjectSwiftKotlin,
+  RecyclableTestView,
+  type RecyclableTestViewRef,
+  TestView,
+  type TestViewRef,
+} from 'react-native-nitro-test'
+import * as UPNG from 'upng-js'
+
+interface Deferred<T> {
+  promise: Promise<T>
+  resolve: (value: T) => void
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+  return { promise, resolve }
+}
+
+interface ImageSize {
+  width: number
+  height: number
+}
+
+interface PixelCoverage {
+  blue: number
+  red: number
+  opaque: number
+}
+
+interface ViewCapture {
+  size: ImageSize
+  pixelCoverage: PixelCoverage
+}
+
+function getPngSize(data: Uint8Array): ImageSize {
+  const pngSignature = [137, 80, 78, 71, 13, 10, 26, 10]
+  const actualSignature = Array.from(data.subarray(0, pngSignature.length))
+  if (actualSignature.some((byte, index) => byte !== pngSignature[index])) {
+    throw new Error('Harness UI did not return a valid PNG screenshot.')
+  }
+
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength)
+  return {
+    width: view.getUint32(16),
+    height: view.getUint32(20),
+  }
+}
+
+const COLOR_DOMINANCE_MARGIN = 50
+
+function getPixelCoverage(data: Uint8Array): PixelCoverage {
+  const copiedData = Uint8Array.from(data)
+  const decodedImage = UPNG.decode(copiedData.buffer)
+  const rgbaBuffer = UPNG.toRGBA8(decodedImage)[0]
+  if (rgbaBuffer == null) {
+    throw new Error('Failed to decode the Harness UI PNG screenshot.')
+  }
+
+  const rgba = new Uint8Array(rgbaBuffer)
+  const pixelCount = rgba.length / 4
+  if (pixelCount === 0) {
+    throw new Error('Harness UI returned an empty PNG screenshot.')
+  }
+
+  let bluePixels = 0
+  let redPixels = 0
+  let opaquePixels = 0
+  for (let index = 0; index < rgba.length; index += 4) {
+    const red = rgba[index] ?? 0
+    const green = rgba[index + 1] ?? 0
+    const blue = rgba[index + 2] ?? 0
+    const alpha = rgba[index + 3] ?? 0
+
+    if (alpha > 250) {
+      opaquePixels += 1
+    }
+    if (
+      alpha > 250 &&
+      blue - red > COLOR_DOMINANCE_MARGIN &&
+      blue - green > COLOR_DOMINANCE_MARGIN
+    ) {
+      bluePixels += 1
+    }
+    if (
+      alpha > 250 &&
+      red - green > COLOR_DOMINANCE_MARGIN &&
+      red - blue > COLOR_DOMINANCE_MARGIN
+    ) {
+      redPixels += 1
+    }
+  }
+
+  return {
+    blue: bluePixels / pixelCount,
+    red: redPixels / pixelCount,
+    opaque: opaquePixels / pixelCount,
+  }
+}
+
+async function captureView(testID: string): Promise<ViewCapture> {
+  const element = await screen.findByTestId(testID)
+  const screenshot = await screen.screenshot(element)
+  if (screenshot == null) {
+    throw new Error(`Failed to capture the mounted View "${testID}".`)
+  }
+
+  return {
+    size: getPngSize(screenshot.data),
+    pixelCoverage: getPixelCoverage(screenshot.data),
+  }
+}
+
+function expectRenderedSize(
+  actualSize: ImageSize,
+  expectedSize: ImageSize
+): void {
+  expect(actualSize).toEqual({
+    width: PixelRatio.getPixelSizeForLayoutSize(expectedSize.width),
+    height: PixelRatio.getPixelSizeForLayoutSize(expectedSize.height),
+  })
+}
+
+const MIN_EXPECTED_PIXEL_COVERAGE = 0.95
+
+function expectBlue(actualCoverage: PixelCoverage): void {
+  expect(actualCoverage.blue).toBeGreaterThanOrEqual(
+    MIN_EXPECTED_PIXEL_COVERAGE
+  )
+  expect(actualCoverage.opaque).toBeGreaterThanOrEqual(
+    MIN_EXPECTED_PIXEL_COVERAGE
+  )
+}
+
+function expectRed(actualCoverage: PixelCoverage): void {
+  expect(actualCoverage.red).toBeGreaterThanOrEqual(MIN_EXPECTED_PIXEL_COVERAGE)
+  expect(actualCoverage.opaque).toBeGreaterThanOrEqual(
+    MIN_EXPECTED_PIXEL_COVERAGE
+  )
+}
+
+const INITIAL_SIZE = { width: 80, height: 60 }
+const RESIZED_SIZE = { width: 160, height: 120 }
+const RENDER_TIMEOUT = 4_000
+const SUPPORTS_NATIVE_VIEW_RECYCLING =
+  Platform.OS === 'ios' || Number(Platform.Version) >= 28
+
+describe('TestView', () => {
+  it('renders with native props, layout, pixels, methods, and callbacks', async () => {
+    const viewRef = deferred<TestViewRef>()
+    const layout = deferred<LayoutRectangle>()
+    const callbackFinished = deferred<void>()
+    let mountedView: TestViewRef | undefined
+    let callbackSawUpdatedState = false
+    const onSomeCallback = fn(() => {
+      callbackSawUpdatedState = mountedView?.hasBeenCalled === true
+      callbackFinished.resolve(undefined)
+    })
+
+    await render(
+      <TestView
+        testID="test-view-initial"
+        style={INITIAL_SIZE}
+        hybridRef={callback((view) => viewRef.resolve(view))}
+        isBlue={true}
+        hasBeenCalled={false}
+        colorScheme="dark"
+        someCallback={callback(onSomeCallback)}
+        onLayout={({ nativeEvent }) => layout.resolve(nativeEvent.layout)}
+      />,
+      { timeout: RENDER_TIMEOUT }
+    )
+
+    mountedView = await viewRef.promise
+    const reportedLayout = await layout.promise
+    expect(reportedLayout.width).toBeCloseTo(INITIAL_SIZE.width, 0)
+    expect(reportedLayout.height).toBeCloseTo(INITIAL_SIZE.height, 0)
+    expect(mountedView.isBlue).toBe(true)
+    expect(mountedView.hasBeenCalled).toBe(false)
+    expect(mountedView.colorScheme).toBe('dark')
+    expect(mountedView.getOnDropViewCount()).toBe(0)
+    expect(HybridTestObjectCpp.getIsViewBlue(mountedView)).toBe(true)
+    expect(HybridTestObjectSwiftKotlin.getIsViewBlue(mountedView)).toBe(true)
+
+    const capture = await captureView('test-view-initial')
+    expectRenderedSize(capture.size, INITIAL_SIZE)
+    expectBlue(capture.pixelCoverage)
+
+    mountedView.someMethod()
+    await callbackFinished.promise
+    expect(mountedView.hasBeenCalled).toBe(true)
+    expect(callbackSawUpdatedState).toBe(true)
+    expect(onSomeCallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('updates every prop, changes pixels, and resizes the same native view', async () => {
+    const initialRef = deferred<TestViewRef>()
+    const initialCallback = fn()
+    const renderResult = await render(
+      <TestView
+        testID="test-view-updates"
+        style={INITIAL_SIZE}
+        hybridRef={callback((view) => initialRef.resolve(view))}
+        isBlue={true}
+        hasBeenCalled={false}
+        colorScheme="dark"
+        someCallback={callback(initialCallback)}
+      />,
+      { timeout: RENDER_TIMEOUT }
+    )
+
+    const firstView = await initialRef.promise
+    const blueCapture = await captureView('test-view-updates')
+    expectRenderedSize(blueCapture.size, INITIAL_SIZE)
+    expectBlue(blueCapture.pixelCoverage)
+
+    const updatedRef = deferred<TestViewRef>()
+    const updatedCallbackFinished = deferred<void>()
+    const updatedCallback = fn(() => updatedCallbackFinished.resolve(undefined))
+    const updatedHybridRef = callback((view: TestViewRef) =>
+      updatedRef.resolve(view)
+    )
+    const updatedSomeCallback = callback(updatedCallback)
+
+    await renderResult.rerender(
+      <TestView
+        testID="test-view-updates"
+        style={INITIAL_SIZE}
+        hybridRef={updatedHybridRef}
+        isBlue={false}
+        hasBeenCalled={true}
+        colorScheme="light"
+        someCallback={updatedSomeCallback}
+      />
+    )
+
+    const updatedView = await updatedRef.promise
+    expect(updatedView.equals(firstView)).toBe(true)
+    expect(updatedView.isBlue).toBe(false)
+    expect(updatedView.hasBeenCalled).toBe(true)
+    expect(updatedView.colorScheme).toBe('light')
+    expect(updatedView.getOnDropViewCount()).toBe(0)
+    expect(HybridTestObjectCpp.getIsViewBlue(updatedView)).toBe(false)
+    expect(HybridTestObjectSwiftKotlin.getIsViewBlue(updatedView)).toBe(false)
+
+    updatedView.someMethod()
+    await updatedCallbackFinished.promise
+    expect(initialCallback).not.toHaveBeenCalled()
+    expect(updatedCallback).toHaveBeenCalledTimes(1)
+
+    const redCapture = await captureView('test-view-updates')
+    expectRenderedSize(redCapture.size, INITIAL_SIZE)
+    expectRed(redCapture.pixelCoverage)
+
+    const resizedLayout = deferred<LayoutRectangle>()
+    await renderResult.rerender(
+      <TestView
+        testID="test-view-updates"
+        style={RESIZED_SIZE}
+        hybridRef={updatedHybridRef}
+        isBlue={false}
+        hasBeenCalled={true}
+        colorScheme="light"
+        someCallback={updatedSomeCallback}
+        onLayout={({ nativeEvent }) =>
+          resizedLayout.resolve(nativeEvent.layout)
+        }
+      />
+    )
+
+    const reportedResizedLayout = await resizedLayout.promise
+    expect(reportedResizedLayout.width).toBeCloseTo(RESIZED_SIZE.width, 0)
+    expect(reportedResizedLayout.height).toBeCloseTo(RESIZED_SIZE.height, 0)
+    expect(firstView.isBlue).toBe(false)
+    expect(firstView.hasBeenCalled).toBe(true)
+    expect(firstView.colorScheme).toBe('light')
+
+    const resizedCapture = await captureView('test-view-updates')
+    expectRenderedSize(resizedCapture.size, RESIZED_SIZE)
+    expectRed(resizedCapture.pixelCoverage)
+  })
+
+  it('unmounts and creates a fresh native view when remounted', async () => {
+    const firstRef = deferred<TestViewRef>()
+    const renderResult = await render(
+      <TestView
+        testID="test-view-lifecycle"
+        style={INITIAL_SIZE}
+        hybridRef={callback((view) => firstRef.resolve(view))}
+        isBlue={true}
+        hasBeenCalled={false}
+        colorScheme="dark"
+        someCallback={callback(fn())}
+      />,
+      { timeout: RENDER_TIMEOUT }
+    )
+    const firstView = await firstRef.promise
+    const initialOnDropViewCount = firstView.getOnDropViewCount()
+    expect(screen.queryByTestId('test-view-lifecycle')).not.toBeNull()
+
+    renderResult.unmount()
+    await waitUntil(
+      () => screen.queryByTestId('test-view-lifecycle') === null,
+      { timeout: RENDER_TIMEOUT }
+    )
+    expect(firstView.getOnDropViewCount()).toBe(initialOnDropViewCount + 1)
+
+    const secondRef = deferred<TestViewRef>()
+    await render(
+      <TestView
+        testID="test-view-lifecycle"
+        style={INITIAL_SIZE}
+        hybridRef={callback((view) => secondRef.resolve(view))}
+        isBlue={false}
+        hasBeenCalled={true}
+        colorScheme="light"
+        someCallback={callback(fn())}
+      />,
+      { timeout: RENDER_TIMEOUT }
+    )
+    const secondView = await secondRef.promise
+
+    expect(secondView.equals(firstView)).toBe(false)
+    expect(secondView.isBlue).toBe(false)
+    expect(secondView.hasBeenCalled).toBe(true)
+    expect(secondView.colorScheme).toBe('light')
+    expect(secondView.getOnDropViewCount()).toBe(0)
+    const remountedCapture = await captureView('test-view-lifecycle')
+    expectRenderedSize(remountedCapture.size, INITIAL_SIZE)
+    expectRed(remountedCapture.pixelCoverage)
+  })
+})
+
+describe('multiple RecyclableTestViews', () => {
+  it('keeps instances isolated while one is updated and recycled', async () => {
+    const firstRef = deferred<RecyclableTestViewRef>()
+    const secondRef = deferred<RecyclableTestViewRef>()
+    const firstHybridRef = callback((view: RecyclableTestViewRef) =>
+      firstRef.resolve(view)
+    )
+    const secondHybridRef = callback((view: RecyclableTestViewRef) =>
+      secondRef.resolve(view)
+    )
+
+    const renderResult = await render(
+      <View style={{ flexDirection: 'row' }}>
+        <RecyclableTestView
+          key="first"
+          testID="isolated-recyclable-view-first"
+          style={INITIAL_SIZE}
+          hybridRef={firstHybridRef}
+          isBlue={false}
+        />
+        <RecyclableTestView
+          key="second"
+          testID="isolated-recyclable-view-second"
+          style={INITIAL_SIZE}
+          hybridRef={secondHybridRef}
+          isBlue={false}
+        />
+      </View>,
+      { timeout: RENDER_TIMEOUT }
+    )
+
+    const firstView = await firstRef.promise
+    const secondView = await secondRef.promise
+    const firstOnDropViewCount = firstView.getOnDropViewCount()
+    const firstPrepareForRecycleCount = firstView.getPrepareForRecycleCount()
+    const secondOnDropViewCount = secondView.getOnDropViewCount()
+    const secondPrepareForRecycleCount = secondView.getPrepareForRecycleCount()
+    expect(firstView.equals(secondView)).toBe(false)
+    expect(firstView.isBlue).toBe(false)
+    expect(secondView.isBlue).toBe(false)
+    expect(firstView.getInvalidLifecycleOrderCount()).toBe(0)
+    expect(secondView.getInvalidLifecycleOrderCount()).toBe(0)
+
+    const initialFirstCapture = await captureView(
+      'isolated-recyclable-view-first'
+    )
+    const initialSecondCapture = await captureView(
+      'isolated-recyclable-view-second'
+    )
+    expectRenderedSize(initialFirstCapture.size, INITIAL_SIZE)
+    expectRenderedSize(initialSecondCapture.size, INITIAL_SIZE)
+    expectRed(initialFirstCapture.pixelCoverage)
+    expectRed(initialSecondCapture.pixelCoverage)
+
+    await renderResult.rerender(
+      <View style={{ flexDirection: 'row' }}>
+        <RecyclableTestView
+          key="first"
+          testID="isolated-recyclable-view-first"
+          style={INITIAL_SIZE}
+          hybridRef={firstHybridRef}
+          isBlue={true}
+        />
+        <RecyclableTestView
+          key="second"
+          testID="isolated-recyclable-view-second"
+          style={INITIAL_SIZE}
+          hybridRef={secondHybridRef}
+          isBlue={false}
+        />
+      </View>
+    )
+
+    expect(firstView.isBlue).toBe(true)
+    expect(secondView.isBlue).toBe(false)
+    expect(firstView.getOnDropViewCount()).toBe(firstOnDropViewCount)
+    expect(firstView.getPrepareForRecycleCount()).toBe(
+      firstPrepareForRecycleCount
+    )
+    expect(secondView.getOnDropViewCount()).toBe(secondOnDropViewCount)
+    expect(secondView.getPrepareForRecycleCount()).toBe(
+      secondPrepareForRecycleCount
+    )
+
+    const updatedFirstCapture = await captureView(
+      'isolated-recyclable-view-first'
+    )
+    const unchangedSecondCapture = await captureView(
+      'isolated-recyclable-view-second'
+    )
+    expectBlue(updatedFirstCapture.pixelCoverage)
+    expectRed(unchangedSecondCapture.pixelCoverage)
+
+    await renderResult.rerender(
+      <View style={{ flexDirection: 'row' }}>
+        <RecyclableTestView
+          key="second"
+          testID="isolated-recyclable-view-second"
+          style={INITIAL_SIZE}
+          hybridRef={secondHybridRef}
+          isBlue={false}
+        />
+      </View>
+    )
+
+    expect(screen.queryByTestId('isolated-recyclable-view-first')).toBeNull()
+    expect(firstView.getOnDropViewCount()).toBe(firstOnDropViewCount + 1)
+    expect(firstView.getPrepareForRecycleCount()).toBe(
+      firstPrepareForRecycleCount + (SUPPORTS_NATIVE_VIEW_RECYCLING ? 1 : 0)
+    )
+    expect(firstView.getInvalidLifecycleOrderCount()).toBe(0)
+    expect(secondView.isBlue).toBe(false)
+    expect(secondView.getOnDropViewCount()).toBe(secondOnDropViewCount)
+    expect(secondView.getPrepareForRecycleCount()).toBe(
+      secondPrepareForRecycleCount
+    )
+    expect(secondView.getInvalidLifecycleOrderCount()).toBe(0)
+    const mountedSiblingCapture = await captureView(
+      'isolated-recyclable-view-second'
+    )
+    expectRed(mountedSiblingCapture.pixelCoverage)
+
+    const remountedFirstRef = deferred<RecyclableTestViewRef>()
+    await renderResult.rerender(
+      <View style={{ flexDirection: 'row' }}>
+        <RecyclableTestView
+          key="first"
+          testID="isolated-recyclable-view-first"
+          style={INITIAL_SIZE}
+          hybridRef={callback((view) => remountedFirstRef.resolve(view))}
+          isBlue={true}
+        />
+        <RecyclableTestView
+          key="second"
+          testID="isolated-recyclable-view-second"
+          style={INITIAL_SIZE}
+          hybridRef={secondHybridRef}
+          isBlue={false}
+        />
+      </View>
+    )
+
+    const remountedFirstView = await remountedFirstRef.promise
+    expect(remountedFirstView.equals(firstView)).toBe(
+      SUPPORTS_NATIVE_VIEW_RECYCLING
+    )
+    expect(remountedFirstView.equals(secondView)).toBe(false)
+    expect(remountedFirstView.isBlue).toBe(true)
+    expect(remountedFirstView.getOnDropViewCount()).toBe(
+      SUPPORTS_NATIVE_VIEW_RECYCLING ? firstOnDropViewCount + 1 : 0
+    )
+    expect(remountedFirstView.getPrepareForRecycleCount()).toBe(
+      SUPPORTS_NATIVE_VIEW_RECYCLING ? firstPrepareForRecycleCount + 1 : 0
+    )
+    expect(remountedFirstView.getInvalidLifecycleOrderCount()).toBe(0)
+    expect(secondView.isBlue).toBe(false)
+    expect(secondView.getOnDropViewCount()).toBe(secondOnDropViewCount)
+    expect(secondView.getPrepareForRecycleCount()).toBe(
+      secondPrepareForRecycleCount
+    )
+
+    const remountedFirstCapture = await captureView(
+      'isolated-recyclable-view-first'
+    )
+    const finalSecondCapture = await captureView(
+      'isolated-recyclable-view-second'
+    )
+    expectBlue(remountedFirstCapture.pixelCoverage)
+    expectRed(finalSecondCapture.pixelCoverage)
+  })
+})
+
+describe('RecyclableTestView', () => {
+  it('renders, changes pixels, and resizes the same native view', async () => {
+    const initialRef = deferred<RecyclableTestViewRef>()
+    const initialLayout = deferred<LayoutRectangle>()
+    const renderResult = await render(
+      <RecyclableTestView
+        testID="recyclable-view-updates"
+        style={INITIAL_SIZE}
+        hybridRef={callback((view) => initialRef.resolve(view))}
+        isBlue={false}
+        onLayout={({ nativeEvent }) =>
+          initialLayout.resolve(nativeEvent.layout)
+        }
+      />,
+      { timeout: RENDER_TIMEOUT }
+    )
+
+    const firstView = await initialRef.promise
+    const reportedInitialLayout = await initialLayout.promise
+    expect(reportedInitialLayout.width).toBeCloseTo(INITIAL_SIZE.width, 0)
+    expect(reportedInitialLayout.height).toBeCloseTo(INITIAL_SIZE.height, 0)
+    expect(firstView.isBlue).toBe(false)
+    expect(firstView.getInvalidLifecycleOrderCount()).toBe(0)
+    const initialOnDropViewCount = firstView.getOnDropViewCount()
+    const initialPrepareForRecycleCount = firstView.getPrepareForRecycleCount()
+
+    const redCapture = await captureView('recyclable-view-updates')
+    expectRenderedSize(redCapture.size, INITIAL_SIZE)
+    expectRed(redCapture.pixelCoverage)
+
+    const updatedRef = deferred<RecyclableTestViewRef>()
+    const updatedHybridRef = callback((view: RecyclableTestViewRef) =>
+      updatedRef.resolve(view)
+    )
+    await renderResult.rerender(
+      <RecyclableTestView
+        testID="recyclable-view-updates"
+        style={INITIAL_SIZE}
+        hybridRef={updatedHybridRef}
+        isBlue={true}
+      />
+    )
+
+    const updatedView = await updatedRef.promise
+    expect(updatedView.equals(firstView)).toBe(true)
+    expect(updatedView.isBlue).toBe(true)
+    expect(updatedView.getPrepareForRecycleCount()).toBe(
+      initialPrepareForRecycleCount
+    )
+
+    const blueCapture = await captureView('recyclable-view-updates')
+    expectRenderedSize(blueCapture.size, INITIAL_SIZE)
+    expectBlue(blueCapture.pixelCoverage)
+
+    const resizedLayout = deferred<LayoutRectangle>()
+    await renderResult.rerender(
+      <RecyclableTestView
+        testID="recyclable-view-updates"
+        style={RESIZED_SIZE}
+        hybridRef={updatedHybridRef}
+        isBlue={true}
+        onLayout={({ nativeEvent }) =>
+          resizedLayout.resolve(nativeEvent.layout)
+        }
+      />
+    )
+
+    const reportedResizedLayout = await resizedLayout.promise
+    expect(reportedResizedLayout.width).toBeCloseTo(RESIZED_SIZE.width, 0)
+    expect(reportedResizedLayout.height).toBeCloseTo(RESIZED_SIZE.height, 0)
+    expect(firstView.isBlue).toBe(true)
+    expect(firstView.getPrepareForRecycleCount()).toBe(
+      initialPrepareForRecycleCount
+    )
+    expect(firstView.getOnDropViewCount()).toBe(initialOnDropViewCount)
+
+    const resizedCapture = await captureView('recyclable-view-updates')
+    expectRenderedSize(resizedCapture.size, RESIZED_SIZE)
+    expectBlue(resizedCapture.pixelCoverage)
+  })
+
+  it('reuses and resets the native view across recycling cycles', async () => {
+    const firstRef = deferred<RecyclableTestViewRef>()
+    const renderResult = await render(
+      <RecyclableTestView
+        testID="recyclable-view-lifecycle"
+        style={INITIAL_SIZE}
+        hybridRef={callback((view) => firstRef.resolve(view))}
+        isBlue={true}
+      />,
+      { timeout: RENDER_TIMEOUT }
+    )
+    const firstView = await firstRef.promise
+    const initialOnDropViewCount = firstView.getOnDropViewCount()
+    const initialPrepareForRecycleCount = firstView.getPrepareForRecycleCount()
+
+    const initialCapture = await captureView('recyclable-view-lifecycle')
+    expectRenderedSize(initialCapture.size, INITIAL_SIZE)
+    expectBlue(initialCapture.pixelCoverage)
+
+    await renderResult.rerender(<View />)
+    expect(screen.queryByTestId('recyclable-view-lifecycle')).toBeNull()
+    expect(firstView.getOnDropViewCount()).toBe(initialOnDropViewCount + 1)
+    expect(firstView.getPrepareForRecycleCount()).toBe(
+      initialPrepareForRecycleCount + (SUPPORTS_NATIVE_VIEW_RECYCLING ? 1 : 0)
+    )
+    expect(firstView.getInvalidLifecycleOrderCount()).toBe(0)
+
+    const secondRef = deferred<RecyclableTestViewRef>()
+    const secondLayout = deferred<LayoutRectangle>()
+    await renderResult.rerender(
+      <RecyclableTestView
+        testID="recyclable-view-lifecycle"
+        style={RESIZED_SIZE}
+        hybridRef={callback((view) => secondRef.resolve(view))}
+        isBlue={false}
+        onLayout={({ nativeEvent }) => secondLayout.resolve(nativeEvent.layout)}
+      />
+    )
+
+    const secondView = await secondRef.promise
+    const reportedSecondLayout = await secondLayout.promise
+    expect(secondView.equals(firstView)).toBe(SUPPORTS_NATIVE_VIEW_RECYCLING)
+    expect(secondView.getPrepareForRecycleCount()).toBe(
+      SUPPORTS_NATIVE_VIEW_RECYCLING ? initialPrepareForRecycleCount + 1 : 0
+    )
+    expect(secondView.getOnDropViewCount()).toBe(
+      SUPPORTS_NATIVE_VIEW_RECYCLING ? initialOnDropViewCount + 1 : 0
+    )
+    expect(secondView.getInvalidLifecycleOrderCount()).toBe(0)
+    expect(secondView.isBlue).toBe(false)
+    expect(reportedSecondLayout.width).toBeCloseTo(RESIZED_SIZE.width, 0)
+    expect(reportedSecondLayout.height).toBeCloseTo(RESIZED_SIZE.height, 0)
+
+    const secondCapture = await captureView('recyclable-view-lifecycle')
+    expectRenderedSize(secondCapture.size, RESIZED_SIZE)
+    expectRed(secondCapture.pixelCoverage)
+
+    await renderResult.rerender(<View />)
+    expect(screen.queryByTestId('recyclable-view-lifecycle')).toBeNull()
+    expect(secondView.getOnDropViewCount()).toBe(
+      SUPPORTS_NATIVE_VIEW_RECYCLING ? initialOnDropViewCount + 2 : 1
+    )
+    expect(secondView.getPrepareForRecycleCount()).toBe(
+      (SUPPORTS_NATIVE_VIEW_RECYCLING ? initialPrepareForRecycleCount + 1 : 0) +
+        (SUPPORTS_NATIVE_VIEW_RECYCLING ? 1 : 0)
+    )
+    expect(secondView.getInvalidLifecycleOrderCount()).toBe(0)
+
+    const thirdRef = deferred<RecyclableTestViewRef>()
+    const thirdLayout = deferred<LayoutRectangle>()
+    await renderResult.rerender(
+      <RecyclableTestView
+        testID="recyclable-view-lifecycle"
+        style={INITIAL_SIZE}
+        hybridRef={callback((view) => thirdRef.resolve(view))}
+        isBlue={true}
+        onLayout={({ nativeEvent }) => thirdLayout.resolve(nativeEvent.layout)}
+      />
+    )
+
+    const thirdView = await thirdRef.promise
+    const reportedThirdLayout = await thirdLayout.promise
+    expect(thirdView.equals(secondView)).toBe(SUPPORTS_NATIVE_VIEW_RECYCLING)
+    expect(thirdView.equals(firstView)).toBe(SUPPORTS_NATIVE_VIEW_RECYCLING)
+    expect(thirdView.getPrepareForRecycleCount()).toBe(
+      SUPPORTS_NATIVE_VIEW_RECYCLING ? initialPrepareForRecycleCount + 2 : 0
+    )
+    expect(thirdView.getOnDropViewCount()).toBe(
+      SUPPORTS_NATIVE_VIEW_RECYCLING ? initialOnDropViewCount + 2 : 0
+    )
+    expect(thirdView.getInvalidLifecycleOrderCount()).toBe(0)
+    expect(thirdView.isBlue).toBe(true)
+    expect(reportedThirdLayout.width).toBeCloseTo(INITIAL_SIZE.width, 0)
+    expect(reportedThirdLayout.height).toBeCloseTo(INITIAL_SIZE.height, 0)
+
+    const thirdCapture = await captureView('recyclable-view-lifecycle')
+    expectRenderedSize(thirdCapture.size, INITIAL_SIZE)
+    expectBlue(thirdCapture.pixelCoverage)
+  })
+})

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,27 @@
 PODS:
   - FBLazyVector (0.85.3)
+  - HarnessUI (1.4.1):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
   - hermes-engine (250829098.0.10):
     - hermes-engine/Pre-built (= 250829098.0.10)
   - hermes-engine/Pre-built (250829098.0.10)
@@ -1981,6 +2003,7 @@ PODS:
 
 DEPENDENCIES:
   - FBLazyVector (from `../../node_modules/react-native/Libraries/FBLazyVector`)
+  - "HarnessUI (from `../../node_modules/@react-native-harness/ui`)"
   - hermes-engine (from `../../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - NitroModules (from `../../node_modules/react-native-nitro-modules`)
   - NitroTest (from `../../node_modules/react-native-nitro-test`)
@@ -2065,6 +2088,8 @@ DEPENDENCIES:
 EXTERNAL SOURCES:
   FBLazyVector:
     :path: "../../node_modules/react-native/Libraries/FBLazyVector"
+  HarnessUI:
+    :path: "../../node_modules/@react-native-harness/ui"
   hermes-engine:
     :podspec: "../../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
     :tag: hermes-v250829098.0.10
@@ -2227,6 +2252,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
+  HarnessUI: bb94ae23e70e83983e4e914a8d7573969e33b930
   hermes-engine: 411df881c1affac35ba53c66e3317eca368c0678
   NitroModules: 452230d9b63c6c3f59dd97eeaa27ec3449271d4a
   NitroTest: 0afe14464750e8e44fc5976c4fe6440b0cd811f1

--- a/example/package.json
+++ b/example/package.json
@@ -44,10 +44,13 @@
     "@react-native/typescript-config": "0.85.3",
     "@react-native-harness/platform-android": "1.4.1",
     "@react-native-harness/platform-apple": "1.4.1",
+    "@react-native-harness/ui": "1.4.1",
     "@types/deep-equal": "^1.0.4",
+    "@types/upng-js": "2.1.5",
     "babel-plugin-module-resolver": "^5.0.3",
     "nitrogen": "*",
-    "react-native-harness": "1.4.1"
+    "react-native-harness": "1.4.1",
+    "upng-js": "2.1.0"
   },
   "engines": {
     "node": ">=20.19.4"

--- a/example/rn-harness.config.mjs
+++ b/example/rn-harness.config.mjs
@@ -33,6 +33,7 @@ const config = {
   ],
   defaultRunner: 'android',
   resetEnvironmentBetweenTestFiles: 'runtime',
+  testTimeout: process.env.CI === 'true' ? 30000 : 10000,
   platformReadyTimeout: process.env.CI === 'true' ? 420000 : 300000,
   bridgeTimeout: process.env.CI === 'true' ? 180000 : 60000,
   bundleStartTimeout: process.env.CI === 'true' ? 120000 : 60000,

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridRecyclableTestView.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridRecyclableTestView.kt
@@ -17,6 +17,9 @@ class HybridRecyclableTestView(
   // View
   override val view: View = View(context)
   private var isRecycled = false
+  private var invalidLifecycleOrderCount = 0.0
+  private var onDropViewCount = 0.0
+  private var prepareForRecycleCount = 0.0
 
   // Props
   override var isBlue: Boolean = false
@@ -29,11 +32,22 @@ class HybridRecyclableTestView(
     }
 
   override fun onDropView() {
+    onDropViewCount += 1
     Log.i(TAG, "View dropped!")
   }
 
+  override fun getOnDropViewCount(): Double = onDropViewCount
+
+  override fun getInvalidLifecycleOrderCount(): Double = invalidLifecycleOrderCount
+
+  override fun getPrepareForRecycleCount(): Double = prepareForRecycleCount
+
   // Recycling conformance
   override fun prepareForRecycle() {
+    if (onDropViewCount != prepareForRecycleCount + 1) {
+      invalidLifecycleOrderCount += 1
+    }
+    prepareForRecycleCount += 1
     view.setBackgroundColor(Color.YELLOW)
     isRecycled = true
   }

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestView.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestView.kt
@@ -13,6 +13,7 @@ class HybridTestView(
 ) : HybridTestViewSpec() {
   // View
   override val view: View = View(context)
+  private var onDropViewCount = 0.0
 
   // Props
   override var isBlue: Boolean = false
@@ -26,8 +27,14 @@ class HybridTestView(
   override var someCallback: () -> Unit = {}
 
   // Methods
+  override fun getOnDropViewCount(): Double = onDropViewCount
+
   override fun someMethod() {
     hasBeenCalled = true
     someCallback()
+  }
+
+  override fun onDropView() {
+    onDropViewCount += 1
   }
 }

--- a/packages/react-native-nitro-test/ios/HybridRecyclableTestView.swift
+++ b/packages/react-native-nitro-test/ios/HybridRecyclableTestView.swift
@@ -12,6 +12,9 @@ class HybridRecyclableTestView: HybridRecyclableTestViewSpec, RecyclableView {
   // UIView
   var view: UIView = UIView()
   private var isRecycled = false
+  private var invalidLifecycleOrderCount: Double = 0
+  private var onDropViewCount: Double = 0
+  private var prepareForRecycleCount: Double = 0
 
   // Props
   var isBlue: Bool = false {
@@ -23,11 +26,28 @@ class HybridRecyclableTestView: HybridRecyclableTestViewSpec, RecyclableView {
   }
 
   func onDropView() {
+    onDropViewCount += 1
     print("View dropped!")
+  }
+
+  func getOnDropViewCount() throws -> Double {
+    return onDropViewCount
+  }
+
+  func getInvalidLifecycleOrderCount() throws -> Double {
+    return invalidLifecycleOrderCount
+  }
+
+  func getPrepareForRecycleCount() throws -> Double {
+    return prepareForRecycleCount
   }
 
   // Recycling conformance
   func prepareForRecycle() {
+    if onDropViewCount != prepareForRecycleCount + 1 {
+      invalidLifecycleOrderCount += 1
+    }
+    prepareForRecycleCount += 1
     view.backgroundColor = .yellow
     isRecycled = true
   }

--- a/packages/react-native-nitro-test/ios/HybridTestView.swift
+++ b/packages/react-native-nitro-test/ios/HybridTestView.swift
@@ -11,6 +11,7 @@ import UIKit
 class HybridTestView: HybridTestViewSpec {
   // UIView
   var view: UIView = UIView()
+  private var onDropViewCount: Double = 0
 
   // Props
   var isBlue: Bool = false {
@@ -23,8 +24,16 @@ class HybridTestView: HybridTestViewSpec {
   var someCallback: () -> Void = {}
 
   // Methods
+  func getOnDropViewCount() throws -> Double {
+    return onDropViewCount
+  }
+
   func someMethod() throws {
     hasBeenCalled = true
     someCallback()
+  }
+
+  func onDropView() {
+    onDropViewCount += 1
   }
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridRecyclableTestViewSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridRecyclableTestViewSpec.cpp
@@ -52,6 +52,20 @@ namespace margelo::nitro::test {
   }
 
   // Methods
-  
+  double JHybridRecyclableTestViewSpec::getInvalidLifecycleOrderCount() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getInvalidLifecycleOrderCount");
+    auto __result = method(_javaPart);
+    return __result;
+  }
+  double JHybridRecyclableTestViewSpec::getOnDropViewCount() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getOnDropViewCount");
+    auto __result = method(_javaPart);
+    return __result;
+  }
+  double JHybridRecyclableTestViewSpec::getPrepareForRecycleCount() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getPrepareForRecycleCount");
+    auto __result = method(_javaPart);
+    return __result;
+  }
 
 } // namespace margelo::nitro::test

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridRecyclableTestViewSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridRecyclableTestViewSpec.hpp
@@ -55,7 +55,9 @@ namespace margelo::nitro::test {
 
   public:
     // Methods
-    
+    double getInvalidLifecycleOrderCount() override;
+    double getOnDropViewCount() override;
+    double getPrepareForRecycleCount() override;
 
   private:
     jni::global_ref<JHybridRecyclableTestViewSpec::JavaPart> _javaPart;

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.cpp
@@ -92,6 +92,11 @@ namespace margelo::nitro::test {
   }
 
   // Methods
+  double JHybridTestViewSpec::getOnDropViewCount() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getOnDropViewCount");
+    auto __result = method(_javaPart);
+    return __result;
+  }
   void JHybridTestViewSpec::someMethod() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void()>("someMethod");
     method(_javaPart);

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.hpp
@@ -61,6 +61,7 @@ namespace margelo::nitro::test {
 
   public:
     // Methods
+    double getOnDropViewCount() override;
     void someMethod() override;
 
   private:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridRecyclableTestViewSpec.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridRecyclableTestViewSpec.kt
@@ -34,7 +34,17 @@ abstract class HybridRecyclableTestViewSpec: HybridView() {
   abstract var isBlue: Boolean
 
   // Methods
+  @DoNotStrip
+  @Keep
+  abstract fun getInvalidLifecycleOrderCount(): Double
   
+  @DoNotStrip
+  @Keep
+  abstract fun getOnDropViewCount(): Double
+  
+  @DoNotStrip
+  @Keep
+  abstract fun getPrepareForRecycleCount(): Double
 
   // Default implementation of `HybridObject.toString()`
   override fun toString(): String {

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestViewSpec.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestViewSpec.kt
@@ -62,6 +62,10 @@ abstract class HybridTestViewSpec: HybridView() {
   // Methods
   @DoNotStrip
   @Keep
+  abstract fun getOnDropViewCount(): Double
+  
+  @DoNotStrip
+  @Keep
   abstract fun someMethod(): Unit
 
   // Default implementation of `HybridObject.toString()`

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
@@ -320,6 +320,15 @@ namespace margelo::nitro::test::bridge::swift {
   using std__weak_ptr_HybridRecyclableTestViewSpec_ = std::weak_ptr<HybridRecyclableTestViewSpec>;
   inline std__weak_ptr_HybridRecyclableTestViewSpec_ weakify_std__shared_ptr_HybridRecyclableTestViewSpec_(const std::shared_ptr<HybridRecyclableTestViewSpec>& strong) noexcept { return strong; }
   
+  // pragma MARK: Result<double>
+  using Result_double_ = Result<double>;
+  inline Result_double_ create_Result_double_(double value) noexcept {
+    return Result<double>::withValue(std::move(value));
+  }
+  inline Result_double_ create_Result_double_(const std::exception_ptr& error) noexcept {
+    return Result<double>::withError(error);
+  }
+  
   // pragma MARK: std::shared_ptr<HybridTestObjectSwiftKotlinSpec>
   /**
    * Specialized version of `std::shared_ptr<HybridTestObjectSwiftKotlinSpec>`.
@@ -1709,15 +1718,6 @@ namespace margelo::nitro::test::bridge::swift {
   }
   inline Result_void_ create_Result_void_(const std::exception_ptr& error) noexcept {
     return Result<void>::withError(error);
-  }
-  
-  // pragma MARK: Result<double>
-  using Result_double_ = Result<double>;
-  inline Result_double_ create_Result_double_(double value) noexcept {
-    return Result<double>::withValue(std::move(value));
-  }
-  inline Result_double_ create_Result_double_(const std::exception_ptr& error) noexcept {
-    return Result<double>::withError(error);
   }
   
   // pragma MARK: Result<nitro::NullType>

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridRecyclableTestViewSpecSwift.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridRecyclableTestViewSpecSwift.hpp
@@ -71,7 +71,30 @@ namespace margelo::nitro::test {
 
   public:
     // Methods
-    
+    inline double getInvalidLifecycleOrderCount() override {
+      auto __result = _swiftPart.getInvalidLifecycleOrderCount();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline double getOnDropViewCount() override {
+      auto __result = _swiftPart.getOnDropViewCount();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline double getPrepareForRecycleCount() override {
+      auto __result = _swiftPart.getPrepareForRecycleCount();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
 
   private:
     NitroTest::HybridRecyclableTestViewSpec_cxx _swiftPart;

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestViewSpecSwift.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestViewSpecSwift.hpp
@@ -93,6 +93,14 @@ namespace margelo::nitro::test {
 
   public:
     // Methods
+    inline double getOnDropViewCount() override {
+      auto __result = _swiftPart.getOnDropViewCount();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
     inline void someMethod() override {
       auto __result = _swiftPart.someMethod();
       if (__result.hasError()) [[unlikely]] {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridRecyclableTestViewSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridRecyclableTestViewSpec.swift
@@ -13,7 +13,9 @@ public protocol HybridRecyclableTestViewSpec_protocol: HybridObject, HybridView 
   var isBlue: Bool { get set }
 
   // Methods
-  
+  func getInvalidLifecycleOrderCount() throws -> Double
+  func getOnDropViewCount() throws -> Double
+  func getPrepareForRecycleCount() throws -> Double
 }
 
 public extension HybridRecyclableTestViewSpec_protocol {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridRecyclableTestViewSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridRecyclableTestViewSpec_cxx.swift
@@ -133,6 +133,42 @@ open class HybridRecyclableTestViewSpec_cxx {
   }
 
   // Methods
+  @inline(__always)
+  public final func getInvalidLifecycleOrderCount() -> bridge.Result_double_ {
+    do {
+      let __result = try self.__implementation.getInvalidLifecycleOrderCount()
+      let __resultCpp = __result
+      return bridge.create_Result_double_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_double_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func getOnDropViewCount() -> bridge.Result_double_ {
+    do {
+      let __result = try self.__implementation.getOnDropViewCount()
+      let __resultCpp = __result
+      return bridge.create_Result_double_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_double_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func getPrepareForRecycleCount() -> bridge.Result_double_ {
+    do {
+      let __result = try self.__implementation.getPrepareForRecycleCount()
+      let __resultCpp = __result
+      return bridge.create_Result_double_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_double_(__exceptionPtr)
+    }
+  }
+  
   public final func getView() -> UnsafeMutableRawPointer {
     return Unmanaged.passRetained(__implementation.view).toOpaque()
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec.swift
@@ -16,6 +16,7 @@ public protocol HybridTestViewSpec_protocol: HybridObject, HybridView {
   var someCallback: () -> Void { get set }
 
   // Methods
+  func getOnDropViewCount() throws -> Double
   func someMethod() throws -> Void
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec_cxx.swift
@@ -175,6 +175,18 @@ open class HybridTestViewSpec_cxx {
 
   // Methods
   @inline(__always)
+  public final func getOnDropViewCount() -> bridge.Result_double_ {
+    do {
+      let __result = try self.__implementation.getOnDropViewCount()
+      let __resultCpp = __result
+      return bridge.create_Result_double_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_double_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public final func someMethod() -> bridge.Result_void_ {
     do {
       try self.__implementation.someMethod()

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridRecyclableTestViewSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridRecyclableTestViewSpec.cpp
@@ -16,6 +16,9 @@ namespace margelo::nitro::test {
     registerHybrids(this, [](Prototype& prototype) {
       prototype.registerHybridGetter("isBlue", &HybridRecyclableTestViewSpec::getIsBlue);
       prototype.registerHybridSetter("isBlue", &HybridRecyclableTestViewSpec::setIsBlue);
+      prototype.registerHybridMethod("getInvalidLifecycleOrderCount", &HybridRecyclableTestViewSpec::getInvalidLifecycleOrderCount);
+      prototype.registerHybridMethod("getOnDropViewCount", &HybridRecyclableTestViewSpec::getOnDropViewCount);
+      prototype.registerHybridMethod("getPrepareForRecycleCount", &HybridRecyclableTestViewSpec::getPrepareForRecycleCount);
     });
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridRecyclableTestViewSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridRecyclableTestViewSpec.hpp
@@ -49,7 +49,9 @@ namespace margelo::nitro::test {
 
     public:
       // Methods
-      
+      virtual double getInvalidLifecycleOrderCount() = 0;
+      virtual double getOnDropViewCount() = 0;
+      virtual double getPrepareForRecycleCount() = 0;
 
     protected:
       // Hybrid Setup

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestViewSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestViewSpec.cpp
@@ -22,6 +22,7 @@ namespace margelo::nitro::test {
       prototype.registerHybridSetter("colorScheme", &HybridTestViewSpec::setColorScheme);
       prototype.registerHybridGetter("someCallback", &HybridTestViewSpec::getSomeCallback);
       prototype.registerHybridSetter("someCallback", &HybridTestViewSpec::setSomeCallback);
+      prototype.registerHybridMethod("getOnDropViewCount", &HybridTestViewSpec::getOnDropViewCount);
       prototype.registerHybridMethod("someMethod", &HybridTestViewSpec::someMethod);
     });
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestViewSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestViewSpec.hpp
@@ -57,6 +57,7 @@ namespace margelo::nitro::test {
 
     public:
       // Methods
+      virtual double getOnDropViewCount() = 0;
       virtual void someMethod() = 0;
 
     protected:

--- a/packages/react-native-nitro-test/src/specs/RecyclableTestView.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/RecyclableTestView.nitro.ts
@@ -7,7 +7,11 @@ import type {
 export interface RecyclableTestViewProps extends HybridViewProps {
   isBlue: boolean
 }
-export interface RecyclableTestViewMethods extends HybridViewMethods {}
+export interface RecyclableTestViewMethods extends HybridViewMethods {
+  getInvalidLifecycleOrderCount(): number
+  getOnDropViewCount(): number
+  getPrepareForRecycleCount(): number
+}
 
 export type RecyclableTestView = HybridView<
   RecyclableTestViewProps,

--- a/packages/react-native-nitro-test/src/specs/TestView.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestView.nitro.ts
@@ -13,6 +13,7 @@ export interface TestViewProps extends HybridViewProps {
   someCallback: () => void
 }
 export interface TestViewMethods extends HybridViewMethods {
+  getOnDropViewCount(): number
   someMethod(): void
 }
 


### PR DESCRIPTION
## Summary

- adds a dedicated React Native Harness suite for `TestView` and `RecyclableTestView`
- verifies every exposed prop, wrapped Hybrid refs and callbacks, native methods, mounting, resizing, rerendering, unmounting, and multiple-view isolation
- captures native Views through Harness UI and decodes PNG pixels to verify real dimensions and solid red/blue rendering
- adds test-only lifecycle observability so recycling, drop ordering, and native identity reuse can be asserted
- uses the existing Android Default and ASan matrix unchanged; both runs discover and execute the full View Harness suite

## Intent

This is intentionally a tests-only PR based directly on current `main`. It is the control baseline for determining whether `feat/move-props-into-core` changes existing View behavior.

It does not enable Android View recycling or fix any behavior exposed by the suite. Red Harness assertions are useful here because they represent current behavior on `main`.

The tests run through the existing Harness CI app and do not add a screen or control to the example app.

## Follow-up stack

1. #1497 enables Android View recycling in the Harness example app
2. #1493 resets recycled native View state before applying new props
3. #1494 reports the iOS drop lifecycle before a View enters the recycle pool
4. #1495 respects React Native's nullable Android recycle result

## Local validation

- `bun specs`
- `bun lint-all`
- `bun run build`
- `bun typecheck`
- Harness discovery lists both `nitro.harness.ts` and `nitro.views.harness.tsx`

## CI

CI is rerunning after rebasing this stack from `feat/move-props-into-core` onto current `main`. This section will be updated with the corrected baseline results.