### PR TITLE
fix: reset recyclable Views before prop updates

### DIFF
--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridRecyclableTestView.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridRecyclableTestView.kt
@@ -42,6 +42,10 @@ class HybridRecyclableTestView(
 
   override fun getPrepareForRecycleCount(): Double = prepareForRecycleCount
 
+  override fun beforeUpdate() {
+    isRecycled = false
+  }
+
   // Recycling conformance
   override fun prepareForRecycle() {
     if (onDropViewCount != prepareForRecycleCount + 1) {

--- a/packages/react-native-nitro-test/ios/HybridRecyclableTestView.swift
+++ b/packages/react-native-nitro-test/ios/HybridRecyclableTestView.swift
@@ -42,6 +42,10 @@ class HybridRecyclableTestView: HybridRecyclableTestViewSpec, RecyclableView {
     return prepareForRecycleCount
   }
 
+  func beforeUpdate() {
+    isRecycled = false
+  }
+
   // Recycling conformance
   func prepareForRecycle() {
     if onDropViewCount != prepareForRecycleCount + 1 {


### PR DESCRIPTION
## Summary

- clears `HybridRecyclableTestView`'s recycled marker before a reused native View receives its next props
- keeps the yellow recycle marker limited to the time the View is in the pool
- lets the existing `isBlue` setter apply the new mount's color again

## Root cause

`prepareForRecycle()` marked the native View as recycled, and the color setter intentionally ignored updates while that marker was set. Nothing cleared the marker when React Native acquired the View for another mount, so the reused View remained yellow even though its Hybrid prop value changed.

## Stack

This atomic fix is stacked on #1497, which separately enables Android recycling for the tests introduced by #1492. The remaining platform-specific failures are handled by #1494 and #1495.

## CI

CI is rerunning after the full stack was rebased onto current `main`.