### PR TITLE
fix: report iOS View drops when recycling

### DIFF
--- a/packages/nitrogen/src/views/swift/SwiftHybridViewManager.ts
+++ b/packages/nitrogen/src/views/swift/SwiftHybridViewManager.ts
@@ -87,6 +87,7 @@ using namespace ${namespace}::views;
 
 @implementation ${component} {
   std::shared_ptr<${HybridTSpecSwift}> _hybridView;
+  BOOL _didDropView;
 }
 
 + (void) load {
@@ -119,8 +120,21 @@ using namespace ${namespace}::views;
   [self setContentView:view];
 }
 
+- (void) notifyOnDropView {
+  // A recycled component can later be invalidated. Notify only once per mount.
+  if (_didDropView) {
+    return;
+  }
+  ${swiftNamespace}::${HybridTSpecCxx}& swiftPart = _hybridView->getSwiftPart();
+  swiftPart.onDropView();
+  _didDropView = YES;
+}
+
 - (void) updateProps:(const std::shared_ptr<const react::Props>&)props
             oldProps:(const std::shared_ptr<const react::Props>&)oldProps {
+  // A props update marks a newly mounted or still-active component.
+  _didDropView = NO;
+
   // 1. Downcast props
   const auto& newViewPropsConst = *std::static_pointer_cast<${propsClassName} const>(props);
   auto& newViewProps = const_cast<${propsClassName}&>(newViewPropsConst);
@@ -152,6 +166,7 @@ using namespace ${namespace}::views;
 }
 
 - (void)prepareForRecycle {
+  [self notifyOnDropView];
   [super prepareForRecycle];
   ${swiftNamespace}::${HybridTSpecCxx}& swiftPart = _hybridView->getSwiftPart();
   swiftPart.maybePrepareForRecycle();
@@ -159,8 +174,7 @@ using namespace ${namespace}::views;
 
 #ifdef ENABLE_RCT_COMPONENT_VIEW_INVALIDATE
 - (void)invalidate {
-  ${swiftNamespace}::${HybridTSpecCxx}& swiftPart = _hybridView->getSwiftPart();
-  swiftPart.onDropView();
+  [self notifyOnDropView];
   [super invalidate];
 }
 #endif

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridRecyclableTestViewComponent.mm
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridRecyclableTestViewComponent.mm
@@ -37,6 +37,7 @@ using namespace margelo::nitro::test::views;
 
 @implementation HybridRecyclableTestViewComponent {
   std::shared_ptr<HybridRecyclableTestViewSpecSwift> _hybridView;
+  BOOL _didDropView;
 }
 
 + (void) load {
@@ -69,8 +70,21 @@ using namespace margelo::nitro::test::views;
   [self setContentView:view];
 }
 
+- (void) notifyOnDropView {
+  // A recycled component can later be invalidated. Notify only once per mount.
+  if (_didDropView) {
+    return;
+  }
+  NitroTest::HybridRecyclableTestViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
+  swiftPart.onDropView();
+  _didDropView = YES;
+}
+
 - (void) updateProps:(const std::shared_ptr<const react::Props>&)props
             oldProps:(const std::shared_ptr<const react::Props>&)oldProps {
+  // A props update marks a newly mounted or still-active component.
+  _didDropView = NO;
+
   // 1. Downcast props
   const auto& newViewPropsConst = *std::static_pointer_cast<HybridRecyclableTestViewProps const>(props);
   auto& newViewProps = const_cast<HybridRecyclableTestViewProps&>(newViewPropsConst);
@@ -106,6 +120,7 @@ using namespace margelo::nitro::test::views;
 }
 
 - (void)prepareForRecycle {
+  [self notifyOnDropView];
   [super prepareForRecycle];
   NitroTest::HybridRecyclableTestViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
   swiftPart.maybePrepareForRecycle();
@@ -113,8 +128,7 @@ using namespace margelo::nitro::test::views;
 
 #ifdef ENABLE_RCT_COMPONENT_VIEW_INVALIDATE
 - (void)invalidate {
-  NitroTest::HybridRecyclableTestViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
-  swiftPart.onDropView();
+  [self notifyOnDropView];
   [super invalidate];
 }
 #endif

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
@@ -37,6 +37,7 @@ using namespace margelo::nitro::test::views;
 
 @implementation HybridTestViewComponent {
   std::shared_ptr<HybridTestViewSpecSwift> _hybridView;
+  BOOL _didDropView;
 }
 
 + (void) load {
@@ -69,8 +70,21 @@ using namespace margelo::nitro::test::views;
   [self setContentView:view];
 }
 
+- (void) notifyOnDropView {
+  // A recycled component can later be invalidated. Notify only once per mount.
+  if (_didDropView) {
+    return;
+  }
+  NitroTest::HybridTestViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
+  swiftPart.onDropView();
+  _didDropView = YES;
+}
+
 - (void) updateProps:(const std::shared_ptr<const react::Props>&)props
             oldProps:(const std::shared_ptr<const react::Props>&)oldProps {
+  // A props update marks a newly mounted or still-active component.
+  _didDropView = NO;
+
   // 1. Downcast props
   const auto& newViewPropsConst = *std::static_pointer_cast<HybridTestViewProps const>(props);
   auto& newViewProps = const_cast<HybridTestViewProps&>(newViewPropsConst);
@@ -121,6 +135,7 @@ using namespace margelo::nitro::test::views;
 }
 
 - (void)prepareForRecycle {
+  [self notifyOnDropView];
   [super prepareForRecycle];
   NitroTest::HybridTestViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
   swiftPart.maybePrepareForRecycle();
@@ -128,8 +143,7 @@ using namespace margelo::nitro::test::views;
 
 #ifdef ENABLE_RCT_COMPONENT_VIEW_INVALIDATE
 - (void)invalidate {
-  NitroTest::HybridTestViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
-  swiftPart.onDropView();
+  [self notifyOnDropView];
   [super invalidate];
 }
 #endif


### PR DESCRIPTION
## Summary

- makes generated iOS Hybrid View components call `onDropView()` before React Native pools them
- deduplicates the drop callback when a recycled component is later invalidated
- resets the per-mount notification marker when the component receives props for a new mount
- regenerates both Nitro test View components from the generator change

## Root cause

The generated iOS component only forwarded `onDropView()` from `invalidate()`. React Native can call `prepareForRecycle()` instead of invalidating a component, so recyclable Views entered the pool without receiving their documented drop lifecycle callback. A later invalidation also means the callback must be guarded so each mount reports exactly one drop.

## Stack

This atomic fix is stacked on #1493. Android recycling setup is isolated in #1497, and the failing lifecycle coverage originates in #1492.

## CI

CI is rerunning after the full stack was rebased onto current `main`.