### PR TITLE
fix: respect React Native View recycling fallback

### DIFF
--- a/packages/nitrogen/src/views/kotlin/KotlinHybridViewManager.ts
+++ b/packages/nitrogen/src/views/kotlin/KotlinHybridViewManager.ts
@@ -94,8 +94,9 @@ public class ${manager}: SimpleViewManager<View>() {
   }
 
   protected override fun prepareToRecycleView(reactContext: ThemedReactContext, view: View): View? {
-    super.prepareToRecycleView(reactContext, view)
-    val hybridView = getHybridView(view)
+    val preparedView = super.prepareToRecycleView(reactContext, view)
+      ?: return null
+    val hybridView = getHybridView(preparedView)
       ?: return null
 
     @Suppress("USELESS_IS_CHECK")

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridRecyclableTestViewManager.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridRecyclableTestViewManager.kt
@@ -58,8 +58,9 @@ public class HybridRecyclableTestViewManager: SimpleViewManager<View>() {
   }
 
   protected override fun prepareToRecycleView(reactContext: ThemedReactContext, view: View): View? {
-    super.prepareToRecycleView(reactContext, view)
-    val hybridView = getHybridView(view)
+    val preparedView = super.prepareToRecycleView(reactContext, view)
+      ?: return null
+    val hybridView = getHybridView(preparedView)
       ?: return null
 
     @Suppress("USELESS_IS_CHECK")

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridTestViewManager.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridTestViewManager.kt
@@ -58,8 +58,9 @@ public class HybridTestViewManager: SimpleViewManager<View>() {
   }
 
   protected override fun prepareToRecycleView(reactContext: ThemedReactContext, view: View): View? {
-    super.prepareToRecycleView(reactContext, view)
-    val hybridView = getHybridView(view)
+    val preparedView = super.prepareToRecycleView(reactContext, view)
+      ?: return null
+    val hybridView = getHybridView(preparedView)
       ?: return null
 
     @Suppress("USELESS_IS_CHECK")


### PR DESCRIPTION
## Summary

- propagates React Native's nullable `prepareToRecycleView()` result from generated Android Hybrid View managers
- skips the Nitro recycle hook when React Native rejects a View for pooling
- performs the Hybrid View lookup on the prepared View returned by the superclass
- regenerates both Nitro test View managers from the generator change

## Root cause

React Native returns `null` from `BaseViewManager.prepareToRecycleView()` when it cannot safely reset the native View, including Android API levels below 28. The generated manager ignored that result, called Nitro's recycle hook anyway, and returned the original View, so it pooled a View that React Native had explicitly rejected.

## Stack

This atomic fix is stacked on #1494. Android recycling setup is isolated in #1497, and the regression coverage originates in #1492.

The standard PR matrix runs the complete View Harness suite on Android API 36 under Default and ASan. The API 26 fallback will be validated with a manual workflow dispatch rather than adding a third emulator row to the shared workflow.

## CI

CI is rerunning after the full stack was rebased onto current `main`.