### PR TITLE
test: enable Android View recycling for Harness

### DIFF
--- a/example/android/app/src/main/java/com/nitroexample/MainApplication.kt
+++ b/example/android/app/src/main/java/com/nitroexample/MainApplication.kt
@@ -8,7 +8,25 @@ import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
 import com.facebook.react.ReactPackage
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsProvider
 import com.nitroexample.exampleturbomodule.ExampleTurboModulePackage
+
+private val stableFlagsWithNitroViewRecycling: ReactNativeFeatureFlagsProvider =
+  object : ReactNativeFeatureFlagsProvider by ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android() {
+    override fun enablePreparedTextLayout(): Boolean = false
+
+    override fun enableViewRecycling(): Boolean = true
+
+    override fun enableViewRecyclingForImage(): Boolean = false
+
+    override fun enableViewRecyclingForScrollView(): Boolean = false
+
+    override fun enableViewRecyclingForText(): Boolean = false
+
+    override fun enableViewRecyclingForView(): Boolean = false
+  }
 
 class MainApplication : Application(), ReactApplication {
 
@@ -27,5 +45,14 @@ class MainApplication : Application(), ReactApplication {
   override fun onCreate() {
     super.onCreate()
     loadReactNative(this)
+    // RN 0.85 installs its Stable provider above. Replace it before reactHost is
+    // accessed, and re-audit these internal flags whenever RN or releaseLevel changes.
+    val previouslyAccessedFlags =
+      ReactNativeFeatureFlags.dangerouslyForceOverride(
+        stableFlagsWithNitroViewRecycling,
+      )
+    check(previouslyAccessedFlags == null) {
+      "Feature flags were accessed before enabling View recycling: $previouslyAccessedFlags"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- enables React Native's global View recycling gate in the Android example app
- keeps React Native's built-in Image, ScrollView, Text, and View managers out of the pool so the change is isolated to opt-in Nitro View managers
- installs the RN 0.85 Stable feature-flag override before the React host is accessed
- leaves the existing Android Default and ASan Harness matrix unchanged

## Why

The View Harness tests in #1492 only add coverage. React Native 0.85 keeps the global Android View recycling gate disabled by default, so `prepareForRecycle()` is not exercised without separate example-app setup.

This follow-up deliberately enables that behavior, allowing the recycling tests to expose and verify the native lifecycle independently from the tests-only PR.

## Stack

- Depends on #1492
- Followed by #1493, #1494, and #1495

## CI

CI is rerunning after the full stack was rebased onto current `main`.