### PR TITLE
fix: Call base `ViewComponentDescriptor::adopt`

### DIFF
--- a/packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp
@@ -54,6 +54,8 @@ public:
 
 #ifdef ANDROID
   void adopt(react::ShadowNode& shadowNode) const override {
+    Base::adopt(shadowNode);
+
     // This is called immediately after `ShadowNode` is created, cloned or in progress.
     // On Android, we need to wrap props in our state, which gets routed through Java and later unwrapped in JNI/C++.
     auto& concreteShadowNode = static_cast<TShadowNode&>(shadowNode);


### PR DESCRIPTION
## Summary

- Call `ConcreteComponentDescriptor::adopt(...)` before Nitro's Android-specific state transfer.
- Preserve React Native's component-handle validation before casting the Shadow Node.

## Why

`ViewComponentDescriptor` overrides the adoption hook, so the base implementation does not run unless it is called explicitly. React Native currently validates that the Shadow Node's component handle matches this descriptor, and future versions may add more base behavior.

This PR is stacked on #1491.

## Validation

- Formatted `ViewComponentDescriptor.hpp` with the repository clang-format configuration.
- Ran `git diff --check`.
