### PR TITLE
fix: Require props-constructible View state on Android

### DIFF
--- a/packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <cxxreact/ReactNativeVersion.h>
 #include <memory>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
@@ -31,6 +32,12 @@ class ViewComponentDescriptor final : public react::ConcreteComponentDescriptor<
   using Base = react::ConcreteComponentDescriptor<TShadowNode>;
   using Props = typename TShadowNode::ConcreteProps;
   using State = typename TShadowNode::ConcreteStateData;
+
+#ifdef ANDROID
+  static_assert(std::constructible_from<State, const std::shared_ptr<Props>&>,
+                "TShadowNode::ConcreteStateData must be constructible from "
+                "const std::shared_ptr<TShadowNode::ConcreteProps>& on Android.");
+#endif
 
 public:
 #ifdef RAW_PROPS_PARSER_USES_JSI_BY_DEFAULT


### PR DESCRIPTION
## Summary

- Add an Android-only compile-time contract for Nitro View state data.
- Require `ConcreteStateData` to satisfy `std::constructible_from<State, const std::shared_ptr<Props>&>`.
- Emit a targeted diagnostic when a Shadow Node uses an incompatible state type.

## Why

Android's Nitro View adoption path always constructs state data from the View's mutable Props pointer. Without an explicit requirement, an incompatible Fabric state produces an opaque template-construction error at the call site.

A class-scope `static_assert` using the C++20 `std::constructible_from` concept keeps the requirement Android-only and documents the exact expression used by `adopt(...)`.

This PR is stacked on #1500.

## Validation

- `clang-format --dry-run --Werror -style=file:./config/.clang-format packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp`
- `git diff --check`
- `./gradlew ':react-native-nitro-test:buildCMakeDebug[arm64-v8a]' --no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a`
