### PR TITLE
fix: Avoid dangling View props reference

### DIFF
--- a/packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp
@@ -66,9 +66,10 @@ public:
     // This is called immediately after `ShadowNode` is created, cloned or in progress.
     // On Android, we need to wrap props in our state, which gets routed through Java and later unwrapped in JNI/C++.
     auto& concreteShadowNode = static_cast<TShadowNode&>(shadowNode);
-    const std::shared_ptr<const Props>& constProps = concreteShadowNode.getConcreteSharedProps();
-    const std::shared_ptr<Props>& props = std::const_pointer_cast<Props>(constProps);
-    State state{props};
+    // Start from the stable shared pointer stored by ShadowNode. Some React Native versions implement
+    // `getConcreteSharedProps()` by returning a reference to a temporary cast result.
+    std::shared_ptr<Props> props = std::const_pointer_cast<Props>(std::static_pointer_cast<const Props>(concreteShadowNode.getProps()));
+    State state{std::move(props)};
     concreteShadowNode.setStateData(std::move(state));
   }
 #endif

--- a/packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp
@@ -68,7 +68,9 @@ public:
     auto& concreteShadowNode = static_cast<TShadowNode&>(shadowNode);
     // Start from the stable shared pointer stored by ShadowNode. Some React Native versions implement
     // `getConcreteSharedProps()` by returning a reference to a temporary cast result.
-    std::shared_ptr<Props> props = std::const_pointer_cast<Props>(std::static_pointer_cast<const Props>(concreteShadowNode.getProps()));
+    auto constBaseProps = concreteShadowNode.getProps();
+    auto constProps = std::static_pointer_cast<const Props>(constBaseProps);
+    auto props = std::const_pointer_cast<Props>(std::move(constProps));
     State state{std::move(props)};
     concreteShadowNode.setStateData(std::move(state));
   }

--- a/packages/react-native-nitro-modules/cpp/views/ViewPropsHolderState.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/ViewPropsHolderState.hpp
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include <memory>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
+#include <utility>
 
 namespace margelo::nitro {
 
@@ -22,7 +24,7 @@ template <typename TProps>
 struct ViewPropsHolderState final {
 public:
   ViewPropsHolderState() = default;
-  explicit ViewPropsHolderState(const std::shared_ptr<TProps>& props) : _props(props) {}
+  explicit ViewPropsHolderState(std::shared_ptr<TProps> props) : _props(std::move(props)) {}
 
 public:
   [[nodiscard]]


### PR DESCRIPTION
## Summary

- Read View props from the stable `ShadowNode::getProps()` owner instead of `getConcreteSharedProps()`.
- Keep the static and const casts as separate, named `shared_ptr` values.
- Pass the resulting `shared_ptr` into `ViewPropsHolderState` by value and move it into storage.
- Keep the actual Props object shared and avoid an extra reference-count increment/decrement.

## Root cause

React Native 0.79 through the current 0.87.0 declare `getConcreteSharedProps()` as returning `const std::shared_ptr<...>&`, but construct that reference from a temporary `std::static_pointer_cast(...)` result. Nitro's Android `adopt()` path then reads the dangling `shared_ptr` reference.

The new path starts from `ShadowNode::getProps()`, whose reference points to the stored owner, then casts the `shared_ptr` by value. Only the ownership handle is copied once; the Props object itself is not copied.

## React Native compatibility

Nitro Views document React Native 0.78.0+ support. Official React Native source was audited for every released minor from 0.78.0 through the current stable 0.87.0:

- `ShadowNode::getProps()` has the same stable signature and returns the stored `props_` member throughout the range.
- `getConcreteSharedProps()` does not exist in 0.78.
- `getConcreteSharedProps()` has the dangling-reference implementation in every release from 0.79 through 0.87.

Using `getProps()` therefore removes the lifetime bug and restores source compatibility with the documented 0.78 minimum. The repository's build and CI coverage is currently pinned to React Native 0.85.3.

Stacked on #1486 so Harness CI exercises the original descriptor refactor plus this isolated lifetime fix.

## Validation

- `clang-format --dry-run --Werror` on both changed headers
- Generated Nitro View consumer compile for Android x86_64 on the repository's React Native 0.85.3
- `./gradlew :app:assembleDebug --no-daemon --console=plain -PreactNativeArchitectures=x86_64 -PnitroSanitizer=address`
- Android Harness CI, including ASan: 528/528 tests passed