### PR TITLE
feat: Track Nitro View prop identity

### DIFF
--- a/packages/nitrogen/src/views/kotlin/KotlinHybridViewManager.ts
+++ b/packages/nitrogen/src/views/kotlin/KotlinHybridViewManager.ts
@@ -195,7 +195,7 @@ public:
     const setter = p.getSetterName('other')
     return `
 if (props->${name}.isDirty) {
-  hybridView->${setter}(props->${name}.value);
+  hybridView->${setter}(props->${name}.get());
   props->${name}.isDirty = false;
 }
     `.trim()
@@ -241,7 +241,7 @@ void J${stateUpdaterName}::updateViewProps(jni::alias_ref<jni::JClass> /* class 
   // Update hybridRef if it changed
   if (props->hybridRef.isDirty) {
     // hybridRef changed - call it with new this
-    const auto& maybeFunc = props->hybridRef.value;
+    const auto& maybeFunc = props->hybridRef.get();
     if (maybeFunc.has_value()) {
       maybeFunc.value()(hybridView);
     }

--- a/packages/nitrogen/src/views/swift/SwiftHybridViewManager.ts
+++ b/packages/nitrogen/src/views/swift/SwiftHybridViewManager.ts
@@ -40,7 +40,7 @@ export function createSwiftHybridViewManager(
     const setter = p.getSetterName('swift')
     const bridge = new SwiftCxxBridgedType(p.type, false)
     const parse = bridge.parseFromCppToSwift(
-      `newViewProps.${name}.value`,
+      `newViewProps.${name}.get()`,
       'c++'
     )
     return `
@@ -150,7 +150,7 @@ using namespace ${namespace}::views;
   // 3. Update hybridRef if it changed
   if (newViewProps.hybridRef.isDirty) {
     // hybridRef changed - call it with new this
-    const auto& maybeFunc = newViewProps.hybridRef.value;
+    const auto& maybeFunc = newViewProps.hybridRef.get();
     if (maybeFunc.has_value()) {
       maybeFunc.value()(_hybridView);
     }

--- a/packages/react-native-nitro-modules/cpp/views/CachedProp.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/CachedProp.hpp
@@ -14,40 +14,65 @@
 #include <react/renderer/core/RawProps.h>
 #include <react/renderer/core/RawValue.h>
 
+#include <memory>
+#include <utility>
+
 namespace margelo::nitro {
 
 using namespace facebook;
 
 /**
- * A React prop (via `RawProps`) that can be cached against its previous
- * JS value (via `jsi::Value::strictEquals(...)`) and stores an `isDirty`
- * flag for incremental updates.
+ * A React prop (via `RawProps`) that caches its converted value against the
+ * original JS value (via `jsi::Value::strictEquals(...)`).
+ *
+ * Copies of an unchanged prop share the same immutable entry, which provides
+ * a stable identity for comparing two Fabric Props snapshots.
  */
 template <typename T>
-struct CachedProp {
+class CachedProp final {
+private:
+  struct Entry final {
+    T value{};
+    BorrowingReference<jsi::Value> jsiValue;
+
+    Entry() = default;
+    Entry(T&& value, BorrowingReference<jsi::Value>&& jsiValue) : value(std::move(value)), jsiValue(std::move(jsiValue)) {}
+  };
+
+  std::shared_ptr<const Entry> _entry;
+
 public:
-  T value;
   bool isDirty = false;
 
   // Default constructor
-  CachedProp() = default;
+  CachedProp() : _entry(std::make_shared<const Entry>()) {}
   // Constructor with value
   CachedProp(T&& value, BorrowingReference<jsi::Value>&& jsiValue)
-      : value(std::move(value)), isDirty(true), jsiValue(std::move(jsiValue)) {}
+      : _entry(std::make_shared<const Entry>(std::move(value), std::move(jsiValue))), isDirty(true) {}
   // Copy/Move/Destruct
   CachedProp(const CachedProp&) = default;
   CachedProp(CachedProp&&) = default;
+  CachedProp& operator=(const CachedProp&) = default;
+  CachedProp& operator=(CachedProp&&) = default;
   ~CachedProp() = default;
 
-private:
-  BorrowingReference<jsi::Value> jsiValue;
-
 public:
+  [[nodiscard]]
+  const T& get() const noexcept {
+    return _entry->value;
+  }
+
+  [[nodiscard]]
+  bool hasSameValue(const CachedProp<T>& other) const noexcept {
+    return _entry == other._entry;
+  }
+
+private:
   bool equals(jsi::Runtime& runtime, const jsi::Value& other) const {
-    if (jsiValue == nullptr) {
+    if (_entry->jsiValue == nullptr) {
       return false;
     }
-    return jsi::Value::strictEquals(runtime, *jsiValue, other);
+    return jsi::Value::strictEquals(runtime, *_entry->jsiValue, other);
   }
 
 public:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridRecyclableTestViewStateUpdater.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridRecyclableTestViewStateUpdater.cpp
@@ -39,14 +39,14 @@ void JHybridRecyclableTestViewStateUpdater::updateViewProps(jni::alias_ref<jni::
 
   // Update all props if they are dirty
   if (props->isBlue.isDirty) {
-    hybridView->setIsBlue(props->isBlue.value);
+    hybridView->setIsBlue(props->isBlue.get());
     props->isBlue.isDirty = false;
   }
 
   // Update hybridRef if it changed
   if (props->hybridRef.isDirty) {
     // hybridRef changed - call it with new this
-    const auto& maybeFunc = props->hybridRef.value;
+    const auto& maybeFunc = props->hybridRef.get();
     if (maybeFunc.has_value()) {
       maybeFunc.value()(hybridView);
     }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.cpp
@@ -39,26 +39,26 @@ void JHybridTestViewStateUpdater::updateViewProps(jni::alias_ref<jni::JClass> /*
 
   // Update all props if they are dirty
   if (props->isBlue.isDirty) {
-    hybridView->setIsBlue(props->isBlue.value);
+    hybridView->setIsBlue(props->isBlue.get());
     props->isBlue.isDirty = false;
   }
   if (props->hasBeenCalled.isDirty) {
-    hybridView->setHasBeenCalled(props->hasBeenCalled.value);
+    hybridView->setHasBeenCalled(props->hasBeenCalled.get());
     props->hasBeenCalled.isDirty = false;
   }
   if (props->colorScheme.isDirty) {
-    hybridView->setColorScheme(props->colorScheme.value);
+    hybridView->setColorScheme(props->colorScheme.get());
     props->colorScheme.isDirty = false;
   }
   if (props->someCallback.isDirty) {
-    hybridView->setSomeCallback(props->someCallback.value);
+    hybridView->setSomeCallback(props->someCallback.get());
     props->someCallback.isDirty = false;
   }
 
   // Update hybridRef if it changed
   if (props->hybridRef.isDirty) {
     // hybridRef changed - call it with new this
-    const auto& maybeFunc = props->hybridRef.value;
+    const auto& maybeFunc = props->hybridRef.get();
     if (maybeFunc.has_value()) {
       maybeFunc.value()(hybridView);
     }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridRecyclableTestViewComponent.mm
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridRecyclableTestViewComponent.mm
@@ -95,7 +95,7 @@ using namespace margelo::nitro::test::views;
 
   // isBlue: boolean
   if (newViewProps.isBlue.isDirty) {
-    swiftPart.setIsBlue(newViewProps.isBlue.value);
+    swiftPart.setIsBlue(newViewProps.isBlue.get());
     newViewProps.isBlue.isDirty = false;
   }
 
@@ -104,7 +104,7 @@ using namespace margelo::nitro::test::views;
   // 3. Update hybridRef if it changed
   if (newViewProps.hybridRef.isDirty) {
     // hybridRef changed - call it with new this
-    const auto& maybeFunc = newViewProps.hybridRef.value;
+    const auto& maybeFunc = newViewProps.hybridRef.get();
     if (maybeFunc.has_value()) {
       maybeFunc.value()(_hybridView);
     }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
@@ -95,22 +95,22 @@ using namespace margelo::nitro::test::views;
 
   // isBlue: boolean
   if (newViewProps.isBlue.isDirty) {
-    swiftPart.setIsBlue(newViewProps.isBlue.value);
+    swiftPart.setIsBlue(newViewProps.isBlue.get());
     newViewProps.isBlue.isDirty = false;
   }
   // hasBeenCalled: boolean
   if (newViewProps.hasBeenCalled.isDirty) {
-    swiftPart.setHasBeenCalled(newViewProps.hasBeenCalled.value);
+    swiftPart.setHasBeenCalled(newViewProps.hasBeenCalled.get());
     newViewProps.hasBeenCalled.isDirty = false;
   }
   // colorScheme: enum
   if (newViewProps.colorScheme.isDirty) {
-    swiftPart.setColorScheme(static_cast<int>(newViewProps.colorScheme.value));
+    swiftPart.setColorScheme(static_cast<int>(newViewProps.colorScheme.get()));
     newViewProps.colorScheme.isDirty = false;
   }
   // someCallback: function
   if (newViewProps.someCallback.isDirty) {
-    swiftPart.setSomeCallback(newViewProps.someCallback.value);
+    swiftPart.setSomeCallback(newViewProps.someCallback.get());
     newViewProps.someCallback.isDirty = false;
   }
 
@@ -119,7 +119,7 @@ using namespace margelo::nitro::test::views;
   // 3. Update hybridRef if it changed
   if (newViewProps.hybridRef.isDirty) {
     // hybridRef changed - call it with new this
-    const auto& maybeFunc = newViewProps.hybridRef.value;
+    const auto& maybeFunc = newViewProps.hybridRef.get();
     if (maybeFunc.has_value()) {
       maybeFunc.value()(_hybridView);
     }


### PR DESCRIPTION
## Summary

- store each CachedProp value and JSI cache reference in a shared immutable entry
- expose get() for native delivery and hasSameValue() for snapshot comparison
- update generated Swift and Kotlin delivery code without changing dirty-bit behavior yet

This is the behavior-preserving identity bridge for the next PR. It is stacked on #1501.

## Validation

- workspace and Nitrogen typechecks
- Nitrogen and example lint
- deterministic code generation
- C++, Swift, and Kotlin formatting
- React Native 0.85 iOS and Android native builds