### PR TITLE
feat: Generate incremental Nitro View prop setters

### DIFF
--- a/example/__tests__/nitro.views.harness.tsx
+++ b/example/__tests__/nitro.views.harness.tsx
@@ -212,15 +212,20 @@ describe('TestView', () => {
   it('updates every prop, changes pixels, and resizes the same native view', async () => {
     const initialRef = deferred<TestViewRef>()
     const initialCallback = fn()
+    const initialHybridRefCallback = fn((view: TestViewRef) =>
+      initialRef.resolve(view)
+    )
+    const initialHybridRef = callback(initialHybridRefCallback)
+    const initialSomeCallback = callback(initialCallback)
     const renderResult = await render(
       <TestView
         testID="test-view-updates"
         style={INITIAL_SIZE}
-        hybridRef={callback((view) => initialRef.resolve(view))}
+        hybridRef={initialHybridRef}
         isBlue={true}
         hasBeenCalled={false}
         colorScheme="dark"
-        someCallback={callback(initialCallback)}
+        someCallback={initialSomeCallback}
       />,
       { timeout: RENDER_TIMEOUT }
     )
@@ -229,6 +234,34 @@ describe('TestView', () => {
     const blueCapture = await captureView('test-view-updates')
     expectRenderedSize(blueCapture.size, INITIAL_SIZE)
     expectBlue(blueCapture.pixelCoverage)
+
+    await renderResult.rerender(
+      <TestView
+        testID="test-view-updates"
+        style={INITIAL_SIZE}
+        isBlue={true}
+        hasBeenCalled={true}
+        colorScheme="dark"
+        someCallback={initialSomeCallback}
+      />
+    )
+
+    expect(firstView.hasBeenCalled).toBe(true)
+    expect(initialHybridRefCallback).toHaveBeenCalledTimes(1)
+
+    await renderResult.rerender(
+      <TestView
+        testID="test-view-updates"
+        style={INITIAL_SIZE}
+        hybridRef={initialHybridRef}
+        isBlue={true}
+        hasBeenCalled={true}
+        colorScheme="dark"
+        someCallback={initialSomeCallback}
+      />
+    )
+
+    expect(initialHybridRefCallback).toHaveBeenCalledTimes(2)
 
     const updatedRef = deferred<TestViewRef>()
     const updatedCallbackFinished = deferred<void>()

--- a/packages/nitrogen/src/views/CppHybridViewComponent.ts
+++ b/packages/nitrogen/src/views/CppHybridViewComponent.ts
@@ -86,6 +86,13 @@ export function createViewComponentShadowNodeFiles(
     const name = escapeCppName(prop.name)
     return `${name}.isProvided()`
   })
+  const setterCases = props.map((prop) => {
+    const name = escapeCppName(prop.name)
+    const type = prop.type.getCode('c++')
+    return `case CONSTEXPR_RAW_PROPS_KEY_HASH("${prop.name}"):
+  ${name} = nitro::CachedProp<${type}>::fromRawValue("${spec.name}", "${prop.name}", value, ${name});
+  return;`
+  })
   const includes = props
     .flatMap((p) =>
       p.getRequiredImports('c++').map((i) => includeHeader(i, true))
@@ -102,6 +109,7 @@ ${createFileMetadataString(`${component}.hpp`)}
 #include <NitroModules/CachedProp.hpp>
 #include <NitroModules/ViewComponentDescriptor.hpp>
 #include <NitroModules/ViewPropsHolderState.hpp>
+#include <cxxreact/ReactNativeVersion.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
@@ -129,6 +137,20 @@ namespace ${namespace} {
     ${propsClassName}(const react::PropsParserContext& context,
   ${createIndentation(propsClassName.length)}   const ${propsClassName}& sourceProps,
   ${createIndentation(propsClassName.length)}   const react::RawProps& rawProps);
+
+#if REACT_NATIVE_VERSION_MAJOR != 0 || REACT_NATIVE_VERSION_MINOR >= 87
+    void setProp(const react::PropsParserContext& context,
+                 react::RawPropsPropNameHash hash,
+                 const char* propName,
+                 const react::RawValue& value);
+#endif
+
+#if defined(RN_SERIALIZABLE_STATE) && (REACT_NATIVE_VERSION_MAJOR != 0 || REACT_NATIVE_VERSION_MINOR >= 87)
+    void initializeDynamicProps(const ${propsClassName}& sourceProps,
+                                const react::RawProps& rawProps) {
+      react::ViewProps::initializeDynamicProps(sourceProps, rawProps, filterObjectKeys);
+    }
+#endif
 
   public:
     ${indent(properties.join('\n'), '    ')}
@@ -179,6 +201,7 @@ namespace ${namespace} {
     }),
   ]
   const ctorIndent = createIndentation(propsClassName.length * 2)
+  const setterIndent = createIndentation(propsClassName.length + 17)
   const componentCode = `
 ${createFileMetadataString(`${component}.cpp`)}
 
@@ -186,6 +209,7 @@ ${createFileMetadataString(`${component}.cpp`)}
 
 #include <NitroModules/NitroHash.hpp>
 #include <NitroModules/CachedProp.hpp>
+#include <react/renderer/core/PropsMacros.h>
 
 namespace ${namespace} {
 
@@ -197,6 +221,21 @@ namespace ${namespace} {
   ${ctorIndent}   const ${propsClassName}& sourceProps,
   ${ctorIndent}   const react::RawProps& rawProps):
     ${indent(propInitializers.join(',\n'), '    ')} { }
+
+#if REACT_NATIVE_VERSION_MAJOR != 0 || REACT_NATIVE_VERSION_MINOR >= 87
+  void ${propsClassName}::setProp(const react::PropsParserContext& context,
+${setterIndent}react::RawPropsPropNameHash hash,
+${setterIndent}const char* propName,
+${setterIndent}const react::RawValue& value) {
+    react::ViewProps::setProp(context, hash, propName, value);
+
+    using react::RawPropsPropNameHash;
+    switch (hash) {
+      ${indent(setterCases.join('\n'), '      ')}
+      default: return;
+    }
+  }
+#endif
 
   bool ${propsClassName}::filterObjectKeys(const std::string& propName) {
     switch (hashString(propName)) {

--- a/packages/react-native-nitro-modules/cpp/views/CachedProp.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/CachedProp.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "BorrowingReference.hpp"
+#include "CountTrailingOptionals.hpp"
 #include "IsFunctionProp.hpp"
 #include "JSIConverter.hpp"
 #include "NitroDefines.hpp"
@@ -89,14 +90,29 @@ private:
 public:
   static CachedProp<T> fromRawValue(const char* viewName, const char* propName, const react::RawProps& rawProps,
                                     const CachedProp<T>& previousProp) {
+    const react::RawValue* rawValue = RawPropsCompat::at(rawProps, propName);
+    if (rawValue == nullptr) {
+      // This RawValue pack does not contain our prop, so skip it - it's still the same from before
+      return previousProp;
+    }
+    return fromRawValue(viewName, propName, *rawValue, previousProp);
+  }
+
+  static CachedProp<T> fromRawValue(const char* viewName, const char* propName, const react::RawValue& rawValue,
+                                    const CachedProp<T>& previousProp) {
     try {
-      const react::RawValue* rawValue = RawPropsCompat::at(rawProps, propName);
-      if (rawValue == nullptr) {
-        // This RawValue pack does not contain our prop, so skip it - it's still the same from before
-        return previousProp;
+      if (!rawValue.hasValue()) {
+        if constexpr (is_optional<std::remove_cvref_t<T>>::value) {
+          if (!previousProp.get().has_value()) {
+            return previousProp;
+          }
+          return CachedProp<T>{};
+        } else {
+          throw std::runtime_error("Required view prop cannot be removed/reset.");
+        }
       }
 
-      auto [runtime, value] = static_cast<std::pair<jsi::Runtime*, jsi::Value>>(*rawValue);
+      auto [runtime, value] = static_cast<std::pair<jsi::Runtime*, jsi::Value>>(rawValue);
 
       if constexpr (IsFunctionProp<std::remove_cv_t<T>>::value) {
         // React Native cannot transport functions as regular props. Nitrogen

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridRecyclableTestViewComponent.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridRecyclableTestViewComponent.cpp
@@ -9,6 +9,7 @@
 
 #include <NitroModules/NitroHash.hpp>
 #include <NitroModules/CachedProp.hpp>
+#include <react/renderer/core/PropsMacros.h>
 
 namespace margelo::nitro::test::views {
 
@@ -23,6 +24,29 @@ namespace margelo::nitro::test::views {
     isBlue(nitro::CachedProp<bool>::fromRawValue("RecyclableTestView", "isBlue", rawProps, sourceProps.isBlue)),
     nativeDefaultValue(nitro::CachedProp<std::optional<double>>::fromRawValue("RecyclableTestView", "nativeDefaultValue", rawProps, sourceProps.nativeDefaultValue)),
     hybridRef(nitro::CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridRecyclableTestViewSpec>& /* ref */)>>>::fromRawValue("RecyclableTestView", "hybridRef", rawProps, sourceProps.hybridRef)) { }
+
+#if REACT_NATIVE_VERSION_MAJOR != 0 || REACT_NATIVE_VERSION_MINOR >= 87
+  void HybridRecyclableTestViewProps::setProp(const react::PropsParserContext& context,
+                                              react::RawPropsPropNameHash hash,
+                                              const char* propName,
+                                              const react::RawValue& value) {
+    react::ViewProps::setProp(context, hash, propName, value);
+
+    using react::RawPropsPropNameHash;
+    switch (hash) {
+      case CONSTEXPR_RAW_PROPS_KEY_HASH("isBlue"):
+        isBlue = nitro::CachedProp<bool>::fromRawValue("RecyclableTestView", "isBlue", value, isBlue);
+        return;
+      case CONSTEXPR_RAW_PROPS_KEY_HASH("nativeDefaultValue"):
+        nativeDefaultValue = nitro::CachedProp<std::optional<double>>::fromRawValue("RecyclableTestView", "nativeDefaultValue", value, nativeDefaultValue);
+        return;
+      case CONSTEXPR_RAW_PROPS_KEY_HASH("hybridRef"):
+        hybridRef = nitro::CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridRecyclableTestViewSpec>& /* ref */)>>>::fromRawValue("RecyclableTestView", "hybridRef", value, hybridRef);
+        return;
+      default: return;
+    }
+  }
+#endif
 
   bool HybridRecyclableTestViewProps::filterObjectKeys(const std::string& propName) {
     switch (hashString(propName)) {

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridRecyclableTestViewComponent.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridRecyclableTestViewComponent.hpp
@@ -10,6 +10,7 @@
 #include <NitroModules/CachedProp.hpp>
 #include <NitroModules/ViewComponentDescriptor.hpp>
 #include <NitroModules/ViewPropsHolderState.hpp>
+#include <cxxreact/ReactNativeVersion.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
@@ -40,6 +41,20 @@ namespace margelo::nitro::test::views {
     HybridRecyclableTestViewProps(const react::PropsParserContext& context,
                                   const HybridRecyclableTestViewProps& sourceProps,
                                   const react::RawProps& rawProps);
+
+#if REACT_NATIVE_VERSION_MAJOR != 0 || REACT_NATIVE_VERSION_MINOR >= 87
+    void setProp(const react::PropsParserContext& context,
+                 react::RawPropsPropNameHash hash,
+                 const char* propName,
+                 const react::RawValue& value);
+#endif
+
+#if defined(RN_SERIALIZABLE_STATE) && (REACT_NATIVE_VERSION_MAJOR != 0 || REACT_NATIVE_VERSION_MINOR >= 87)
+    void initializeDynamicProps(const HybridRecyclableTestViewProps& sourceProps,
+                                const react::RawProps& rawProps) {
+      react::ViewProps::initializeDynamicProps(sourceProps, rawProps, filterObjectKeys);
+    }
+#endif
 
   public:
     nitro::CachedProp<bool> isBlue;

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
@@ -9,6 +9,7 @@
 
 #include <NitroModules/NitroHash.hpp>
 #include <NitroModules/CachedProp.hpp>
+#include <react/renderer/core/PropsMacros.h>
 
 namespace margelo::nitro::test::views {
 
@@ -26,6 +27,38 @@ namespace margelo::nitro::test::views {
     someCallback(nitro::CachedProp<std::function<void()>>::fromRawValue("TestView", "someCallback", rawProps, sourceProps.someCallback)),
     nativeDefaultValue(nitro::CachedProp<std::optional<double>>::fromRawValue("TestView", "nativeDefaultValue", rawProps, sourceProps.nativeDefaultValue)),
     hybridRef(nitro::CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridTestViewSpec>& /* ref */)>>>::fromRawValue("TestView", "hybridRef", rawProps, sourceProps.hybridRef)) { }
+
+#if REACT_NATIVE_VERSION_MAJOR != 0 || REACT_NATIVE_VERSION_MINOR >= 87
+  void HybridTestViewProps::setProp(const react::PropsParserContext& context,
+                                    react::RawPropsPropNameHash hash,
+                                    const char* propName,
+                                    const react::RawValue& value) {
+    react::ViewProps::setProp(context, hash, propName, value);
+
+    using react::RawPropsPropNameHash;
+    switch (hash) {
+      case CONSTEXPR_RAW_PROPS_KEY_HASH("isBlue"):
+        isBlue = nitro::CachedProp<bool>::fromRawValue("TestView", "isBlue", value, isBlue);
+        return;
+      case CONSTEXPR_RAW_PROPS_KEY_HASH("hasBeenCalled"):
+        hasBeenCalled = nitro::CachedProp<bool>::fromRawValue("TestView", "hasBeenCalled", value, hasBeenCalled);
+        return;
+      case CONSTEXPR_RAW_PROPS_KEY_HASH("colorScheme"):
+        colorScheme = nitro::CachedProp<ColorScheme>::fromRawValue("TestView", "colorScheme", value, colorScheme);
+        return;
+      case CONSTEXPR_RAW_PROPS_KEY_HASH("someCallback"):
+        someCallback = nitro::CachedProp<std::function<void()>>::fromRawValue("TestView", "someCallback", value, someCallback);
+        return;
+      case CONSTEXPR_RAW_PROPS_KEY_HASH("nativeDefaultValue"):
+        nativeDefaultValue = nitro::CachedProp<std::optional<double>>::fromRawValue("TestView", "nativeDefaultValue", value, nativeDefaultValue);
+        return;
+      case CONSTEXPR_RAW_PROPS_KEY_HASH("hybridRef"):
+        hybridRef = nitro::CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridTestViewSpec>& /* ref */)>>>::fromRawValue("TestView", "hybridRef", value, hybridRef);
+        return;
+      default: return;
+    }
+  }
+#endif
 
   bool HybridTestViewProps::filterObjectKeys(const std::string& propName) {
     switch (hashString(propName)) {

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.hpp
@@ -10,6 +10,7 @@
 #include <NitroModules/CachedProp.hpp>
 #include <NitroModules/ViewComponentDescriptor.hpp>
 #include <NitroModules/ViewPropsHolderState.hpp>
+#include <cxxreact/ReactNativeVersion.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
@@ -41,6 +42,20 @@ namespace margelo::nitro::test::views {
     HybridTestViewProps(const react::PropsParserContext& context,
                         const HybridTestViewProps& sourceProps,
                         const react::RawProps& rawProps);
+
+#if REACT_NATIVE_VERSION_MAJOR != 0 || REACT_NATIVE_VERSION_MINOR >= 87
+    void setProp(const react::PropsParserContext& context,
+                 react::RawPropsPropNameHash hash,
+                 const char* propName,
+                 const react::RawValue& value);
+#endif
+
+#if defined(RN_SERIALIZABLE_STATE) && (REACT_NATIVE_VERSION_MAJOR != 0 || REACT_NATIVE_VERSION_MINOR >= 87)
+    void initializeDynamicProps(const HybridTestViewProps& sourceProps,
+                                const react::RawProps& rawProps) {
+      react::ViewProps::initializeDynamicProps(sourceProps, rawProps, filterObjectKeys);
+    }
+#endif
 
   public:
     nitro::CachedProp<bool> isBlue;


### PR DESCRIPTION
## Summary

- generate the concrete nonvirtual setProp hook for React Native 0.87+
- always chain ViewProps::setProp before dispatching Nitro props
- use the React Native 32-bit prop hash macros
- convert directly from RawValue while preserving JSI functions, HybridObjects, and cached identity
- reset optional props on null or undefined and reject required-prop removal with a labeled error
- generate filtered Android initializeDynamicProps support
- strengthen the View harness to remove and re-add the exact same hybridRef callback

This PR depends on feat/view-props-iterator-fast-path and activates its changed-key-only clone path.

## Validation

- React Native 0.87 Nitro CMake target build with HasIteratorSetterCtor enabled
- React Native 0.85 iOS and Android native builds
- full Nitro View harness on iOS 18.4: 6 of 6 passing
- full Nitro View harness on Android API 35: 6 of 6 passing
- workspace typecheck, lint, deterministic generation, and native formatting