### PR TITLE
feat: Add incremental Nitro View prop clone path

### DIFF
--- a/packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp
@@ -8,6 +8,7 @@
 #include <cxxreact/ReactNativeVersion.h>
 #include <memory>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
+#include <string_view>
 #include <utility>
 
 #if REACT_NATIVE_VERSION_MAJOR != 0 || REACT_NATIVE_VERSION_MINOR >= 85
@@ -53,9 +54,34 @@ public:
    */
   std::shared_ptr<const react::Props> cloneProps(const react::PropsParserContext& context, const std::shared_ptr<const react::Props>& props,
                                                  react::RawProps rawProps) const override {
-    // 1. Prepare raw props parser
+    if (!props && rawProps.isEmpty()) {
+      return TShadowNode::defaultSharedProps();
+    }
+
+    if constexpr (react::RawPropsFilterable<TShadowNode>) {
+      TShadowNode::filterRawProps(rawProps);
+    }
+
+#if REACT_NATIVE_VERSION_MAJOR != 0 || REACT_NATIVE_VERSION_MINOR >= 87
+    if constexpr (react::HasIteratorSetterCtor<Props>) {
+      // Copy the previous immutable snapshot, then apply only the keys present
+      // in this RawProps patch. This keeps Nitro's JSI-backed RawValues intact.
+      auto shadowNodeProps = TShadowNode::Props(props);
+
+#ifdef RN_SERIALIZABLE_STATE
+      TShadowNode::initializeDynamicProps(shadowNodeProps, rawProps, props);
+#endif
+
+      rawProps.forEachItem([&](std::string_view name, const react::RawValue& value) {
+        shadowNodeProps->setProp(context, RAW_PROPS_KEY_HASH(name), name.data(), value);
+      });
+      return shadowNodeProps;
+    }
+#endif
+
+    // React Native 0.79 through 0.86, and generated Props without an iterator
+    // setter, keep using Nitro's JSI-backed three-argument constructor.
     rawProps.parse(this->rawPropsParser_);
-    // 2. Copy props with Nitro's cached copy constructor
     return TShadowNode::Props(context, /* & */ rawProps, props);
   }
 


### PR DESCRIPTION
## Summary

- add a Nitro-local React Native 0.87+ clone path
- copy the previous immutable Props snapshot
- iterate only RawProps keys present in the patch
- dispatch each key through the concrete Props setProp method
- preserve filtered Android dynamic props initialization
- retain the classic JSI constructor for older React Native versions and older generated Nitro Props

The branch is dormant until a concrete generated Props class provides setProp in the next PR. It does not require apps to enable the global experimental React Native feature flag.

This draft PR is intentionally kept at the back of the stack and depends on #1510.

## Validation

- generated Android C++ syntax checks against React Native 0.79, 0.85, 0.86, and 0.87 headers
- React Native 0.87 Nitro CMake target build
- React Native 0.85 iOS and Android native builds

## Note

With the global React Native iterator flag disabled, React Native can still perform its one-time RawPropsParser preparation in the descriptor constructor. This PR removes repeated per-update parsing for Nitro Props, not that startup cost.