### PR TITLE
fix: Make View prop snapshots truly immutable via diffing

### DIFF
--- a/packages/nitrogen/src/views/CppHybridViewComponent.ts
+++ b/packages/nitrogen/src/views/CppHybridViewComponent.ts
@@ -78,6 +78,10 @@ export function createViewComponentShadowNodeFiles(
   const filterCases = props.map(
     (prop) => `case hashString("${prop.name}"): return true;`
   )
+  const comparisons = props.map((prop) => {
+    const name = escapeCppName(prop.name)
+    return `${name}.hasSameValue(other.${name})`
+  })
   const includes = props
     .flatMap((p) =>
       p.getRequiredImports('c++').map((i) => includeHeader(i, true))
@@ -124,6 +128,11 @@ namespace ${namespace} {
 
   public:
     ${indent(properties.join('\n'), '    ')}
+
+    [[nodiscard]]
+    bool hasSameProps(const ${propsClassName}& other) const noexcept {
+      return ${comparisons.join(' &&\n             ')};
+    }
 
   private:
     static bool filterObjectKeys(const std::string& propName);

--- a/packages/nitrogen/src/views/kotlin/KotlinHybridViewManager.ts
+++ b/packages/nitrogen/src/views/kotlin/KotlinHybridViewManager.ts
@@ -56,6 +56,14 @@ import ${javaNamespace}.*
  * Represents the React Native \`ViewManager\` for the "${spec.name}" Nitro HybridView.
  */
 public class ${manager}: SimpleViewManager<View>() {
+  /**
+   * Represents the View and its last state snapshot (mutable)
+   */
+  private class HybridViewHolder(
+    val hybridView: ${viewImplementation},
+    var lastState: StateWrapper? = null,
+  )
+
   init {
     if (RecyclableView::class.java.isAssignableFrom(${viewImplementation}::class.java)) {
       // Enable view recycling
@@ -70,34 +78,41 @@ public class ${manager}: SimpleViewManager<View>() {
   override fun createViewInstance(reactContext: ThemedReactContext): View {
     val hybridView = ${viewImplementation}(reactContext)
     val view = hybridView.view
-    view.setTag(associated_hybrid_view_tag, hybridView)
+    view.setTag(associated_hybrid_view_tag, HybridViewHolder(hybridView))
     return view
   }
 
   override fun updateState(view: View, props: ReactStylesDiffMap, stateWrapper: StateWrapper): Any? {
-    val hybridView = getHybridView(view)
+    val holder = getHybridViewHolder(view)
       ?: throw Error("Couldn't find view $view in local views table!")
+    val hybridView = holder.hybridView
+    val oldState = holder.lastState
+    val newState = stateWrapper
 
     // 1. Update each prop individually
     hybridView.beforeUpdate()
-    ${stateUpdaterName}.updateViewProps(hybridView, stateWrapper)
+    ${stateUpdaterName}.updateViewProps(hybridView, newState, oldState)
     hybridView.afterUpdate()
+    holder.lastState = newState
 
     // 2. Continue in base View props
-    return super.updateState(view, props, stateWrapper)
+    return super.updateState(view, props, newState)
   }
 
   override fun onDropViewInstance(view: View) {
-    val hybridView = getHybridView(view)
-    hybridView?.onDropView()
+    val holder = getHybridViewHolder(view)
+    holder?.lastState = null
+    holder?.hybridView?.onDropView()
     return super.onDropViewInstance(view)
   }
 
   protected override fun prepareToRecycleView(reactContext: ThemedReactContext, view: View): View? {
     val preparedView = super.prepareToRecycleView(reactContext, view)
       ?: return null
-    val hybridView = getHybridView(preparedView)
+    val holder = getHybridViewHolder(preparedView)
       ?: return null
+    val hybridView = holder.hybridView
+    holder.lastState = null
 
     @Suppress("USELESS_IS_CHECK")
     if (hybridView is RecyclableView) {
@@ -111,8 +126,8 @@ public class ${manager}: SimpleViewManager<View>() {
     }
   }
 
-  private fun getHybridView(view: View): ${viewImplementation}? {
-    return view.getTag(associated_hybrid_view_tag) as? ${viewImplementation}
+  private fun getHybridViewHolder(view: View): HybridViewHolder? {
+    return view.getTag(associated_hybrid_view_tag) as? HybridViewHolder
   }
 }
   `.trim()
@@ -129,11 +144,11 @@ internal class ${stateUpdaterName} {
   companion object {
     /**
      * Updates the props for [view] through C++.
-     * The [state] prop is expected to contain [view]'s props as wrapped Fabric state.
+     * The [newState] prop is expected to contain [view]'s props as wrapped Fabric state.
      */
     @Suppress("KotlinJniMissingFunction")
     @JvmStatic
-    external fun updateViewProps(view: ${HybridTSpec}, state: StateWrapper)
+    external fun updateViewProps(view: ${HybridTSpec}, newState: StateWrapper, oldState: StateWrapper?)
   }
 }
   `.trim()
@@ -172,7 +187,12 @@ public:
 public:
   static void updateViewProps(jni::alias_ref<jni::JClass> /* class */,
                               jni::alias_ref<${JHybridTSpec}::JavaPart> view,
-                              jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface);
+                              jni::alias_ref<JStateWrapper::javaobject> newState,
+                              jni::alias_ref<JStateWrapper::javaobject> oldState);
+
+private:
+  static std::shared_ptr<const ${propsClassName}> getPropsFromStateWrapper(
+      jni::alias_ref<JStateWrapper::javaobject> stateWrapper);
 
 public:
   static void registerNatives() {
@@ -194,9 +214,8 @@ public:
     const name = escapeCppName(p.name)
     const setter = p.getSetterName('other')
     return `
-if (props->${name}.isDirty) {
-  hybridView->${setter}(props->${name}.get());
-  props->${name}.isDirty = false;
+if (oldProps == nullptr || !newProps->${name}.hasSameValue(oldProps->${name})) {
+  hybridView->${setter}(newProps->${name}.get());
 }
     `.trim()
   })
@@ -213,39 +232,53 @@ namespace ${cxxNamespace} {
 using namespace facebook;
 using ConcreteStateData = react::ConcreteState<${stateClassName}>;
 
-void J${stateUpdaterName}::updateViewProps(jni::alias_ref<jni::JClass> /* class */,
-                                           jni::alias_ref<${JHybridTSpec}::JavaPart> javaView,
-                                           jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface) {
-  std::shared_ptr<${JHybridTSpec}> hybridView = javaView->get${JHybridTSpec}();
-
-  // Get concrete StateWrapperImpl from passed StateWrapper interface object
-  jobject rawStateWrapper = stateWrapperInterface.get();
-  if (!stateWrapperInterface->isInstanceOf(react::StateWrapperImpl::javaClassStatic())) [[unlikely]] {
-      throw std::runtime_error("StateWrapper is not a StateWrapperImpl");
+std::shared_ptr<const ${propsClassName}> J${stateUpdaterName}::getPropsFromStateWrapper(
+    jni::alias_ref<JStateWrapper::javaobject> stateWrapper) {
+  if (stateWrapper.get() == nullptr) {
+    return nullptr;
   }
-  auto stateWrapper = jni::alias_ref<react::StateWrapperImpl::javaobject>{
+  // Get concrete StateWrapperImpl from passed StateWrapper interface object
+  jobject rawStateWrapper = stateWrapper.get();
+  if (!stateWrapper->isInstanceOf(react::StateWrapperImpl::javaClassStatic())) [[unlikely]] {
+    throw std::runtime_error("StateWrapper is not a StateWrapperImpl");
+  }
+  auto stateWrapperImpl = jni::alias_ref<react::StateWrapperImpl::javaobject>{
     static_cast<react::StateWrapperImpl::javaobject>(rawStateWrapper)
   };
-  std::shared_ptr<const react::State> state = stateWrapper->cthis()->getState();
+  std::shared_ptr<const react::State> state = stateWrapperImpl->cthis()->getState();
+  if (state == nullptr) {
+    return nullptr;
+  }
   auto concreteState = std::static_pointer_cast<const ConcreteStateData>(state);
   const ${stateClassName}& data = concreteState->getData();
-  const std::shared_ptr<${propsClassName}>& props = data.getProps();
+  const std::shared_ptr<const ${propsClassName}>& props = data.getProps();
   if (props == nullptr) [[unlikely]] {
-    // Props aren't set yet!
     throw std::runtime_error("${stateClassName}'s data doesn't contain any props!");
   }
+  return props;
+}
 
-  // Update all props if they are dirty
+void J${stateUpdaterName}::updateViewProps(jni::alias_ref<jni::JClass> /* class */,
+                                           jni::alias_ref<${JHybridTSpec}::JavaPart> javaView,
+                                           jni::alias_ref<JStateWrapper::javaobject> newState,
+                                           jni::alias_ref<JStateWrapper::javaobject> oldState) {
+  std::shared_ptr<${JHybridTSpec}> hybridView = javaView->get${JHybridTSpec}();
+  std::shared_ptr<const ${propsClassName}> newProps = getPropsFromStateWrapper(newState);
+  std::shared_ptr<const ${propsClassName}> oldProps = getPropsFromStateWrapper(oldState);
+  if (newProps == nullptr) [[unlikely]] {
+    throw std::runtime_error("Current StateWrapper doesn't contain any props!");
+  }
+
+  // Update only props that differ from the previous State snapshot.
   ${indent(propsUpdaterCalls.join('\n'), '  ')}
 
   // Update hybridRef if it changed
-  if (props->hybridRef.isDirty) {
+  if (oldProps == nullptr || !newProps->hybridRef.hasSameValue(oldProps->hybridRef)) {
     // hybridRef changed - call it with new this
-    const auto& maybeFunc = props->hybridRef.get();
+    const auto& maybeFunc = newProps->hybridRef.get();
     if (maybeFunc.has_value()) {
       maybeFunc.value()(hybridView);
     }
-    props->hybridRef.isDirty = false;
   }
 }
 

--- a/packages/nitrogen/src/views/swift/SwiftHybridViewManager.ts
+++ b/packages/nitrogen/src/views/swift/SwiftHybridViewManager.ts
@@ -26,8 +26,12 @@ export function createSwiftHybridViewManager(
   const { HybridTSpec, HybridTSpecSwift, HybridTSpecCxx } = getHybridObjectName(
     spec.name
   )
-  const { component, descriptorClassName, propsClassName } =
-    getViewComponentNames(spec)
+  const {
+    component,
+    descriptorClassName,
+    propsClassName,
+    shadowNodeClassName,
+  } = getViewComponentNames(spec)
   const implementation = spec.config.getIosAutolinkedImplementation(spec.name)
   if (implementation?.language !== 'swift') {
     throw new Error(
@@ -45,12 +49,13 @@ export function createSwiftHybridViewManager(
     )
     return `
 // ${p.jsSignature}
-if (newViewProps.${name}.isDirty) {
+if (oldViewProps == nullptr || !newViewProps.${name}.hasSameValue(oldViewProps->${name})) {
   swiftPart.${setter}(${indent(parse, '  ')});
-  newViewProps.${name}.isDirty = false;
 }
 `.trim()
   })
+  const hasTransactionPropChanges =
+    'oldViewProps == nullptr || !newViewProps.hasSameProps(*oldViewProps)'
 
   const mmFile = `
 ${createFileMetadataString(`${component}.mm`)}
@@ -101,6 +106,7 @@ using namespace ${namespace}::views;
 
 - (instancetype) init {
   if (self = [super init]) {
+    _props = ${shadowNodeClassName}::defaultSharedProps();
     std::shared_ptr<${HybridTSpec}> hybridView = ${getHybridObjectConstructorCall(spec.name)}
     _hybridView = std::dynamic_pointer_cast<${HybridTSpecSwift}>(hybridView);
     [self updateView];
@@ -136,28 +142,30 @@ using namespace ${namespace}::views;
   _didDropView = NO;
 
   // 1. Downcast props
-  const ${propsClassName}& newViewPropsConst = *std::static_pointer_cast<${propsClassName} const>(props);
-  ${propsClassName}& newViewProps = const_cast<${propsClassName}&>(newViewPropsConst);
+  const auto& newViewProps = *std::static_pointer_cast<const ${propsClassName}>(props);
+  const auto* oldViewProps = static_cast<const ${propsClassName}*>(oldProps.get());
   ${swiftNamespace}::${HybridTSpecCxx}& swiftPart = _hybridView->getSwiftPart();
 
-  // 2. Update each prop individually
-  swiftPart.beforeUpdate();
+  // 2. Update only props that differ from the previous Props snapshot.
+  const bool hasTransactionPropChanges = ${hasTransactionPropChanges};
+  if (hasTransactionPropChanges) {
+    swiftPart.beforeUpdate();
 
-  ${indent(propAssignments.join('\n'), '  ')}
+    ${indent(propAssignments.join('\n'), '    ')}
 
-  swiftPart.afterUpdate();
-
-  // 3. Update hybridRef if it changed
-  if (newViewProps.hybridRef.isDirty) {
-    // hybridRef changed - call it with new this
-    const auto& maybeFunc = newViewProps.hybridRef.get();
-    if (maybeFunc.has_value()) {
-      maybeFunc.value()(_hybridView);
+    // Update hybridRef if it changed
+    if (oldViewProps == nullptr || !newViewProps.hybridRef.hasSameValue(oldViewProps->hybridRef)) {
+      // hybridRef changed - call it with new this
+      const auto& maybeFunc = newViewProps.hybridRef.get();
+      if (maybeFunc.has_value()) {
+        maybeFunc.value()(_hybridView);
+      }
     }
-    newViewProps.hybridRef.isDirty = false;
+
+    swiftPart.afterUpdate();
   }
 
-  // 4. Continue in base class
+  // 3. Continue in base class
   [super updateProps:props oldProps:oldProps];
 }
 

--- a/packages/nitrogen/src/views/swift/SwiftHybridViewManager.ts
+++ b/packages/nitrogen/src/views/swift/SwiftHybridViewManager.ts
@@ -54,9 +54,6 @@ if (oldViewProps == nullptr || !newViewProps.${name}.hasSameValue(oldViewProps->
 }
 `.trim()
   })
-  const hasTransactionPropChanges =
-    'oldViewProps == nullptr || !newViewProps.hasSameProps(*oldViewProps)'
-
   const mmFile = `
 ${createFileMetadataString(`${component}.mm`)}
 
@@ -147,7 +144,7 @@ using namespace ${namespace}::views;
   ${swiftNamespace}::${HybridTSpecCxx}& swiftPart = _hybridView->getSwiftPart();
 
   // 2. Update only props that differ from the previous Props snapshot.
-  const bool hasTransactionPropChanges = ${hasTransactionPropChanges};
+  const bool hasTransactionPropChanges = oldViewProps == nullptr || !newViewProps.hasSameProps(*oldViewProps);
   if (hasTransactionPropChanges) {
     swiftPart.beforeUpdate();
 

--- a/packages/react-native-nitro-modules/cpp/views/CachedProp.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/CachedProp.hpp
@@ -43,13 +43,11 @@ private:
   std::shared_ptr<const Entry> _entry;
 
 public:
-  bool isDirty = false;
-
   // Default constructor
   CachedProp() : _entry(std::make_shared<const Entry>()) {}
   // Constructor with value
   CachedProp(T&& value, BorrowingReference<jsi::Value>&& jsiValue)
-      : _entry(std::make_shared<const Entry>(std::move(value), std::move(jsiValue))), isDirty(true) {}
+      : _entry(std::make_shared<const Entry>(std::move(value), std::move(jsiValue))) {}
   // Copy/Move/Destruct
   CachedProp(const CachedProp&) = default;
   CachedProp(CachedProp&&) = default;

--- a/packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp
@@ -34,9 +34,9 @@ class ViewComponentDescriptor final : public react::ConcreteComponentDescriptor<
   using State = typename TShadowNode::ConcreteStateData;
 
 #ifdef ANDROID
-  static_assert(std::constructible_from<State, const std::shared_ptr<Props>&>,
+  static_assert(std::constructible_from<State, const std::shared_ptr<const Props>&>,
                 "TShadowNode::ConcreteStateData must be constructible from "
-                "const std::shared_ptr<TShadowNode::ConcreteProps>& on Android.");
+                "const std::shared_ptr<const TShadowNode::ConcreteProps>& on Android.");
 #endif
 
 public:
@@ -70,8 +70,14 @@ public:
     // `getConcreteSharedProps()` by returning a reference to a temporary cast result.
     auto constBaseProps = concreteShadowNode.getProps();
     auto constProps = std::static_pointer_cast<const Props>(constBaseProps);
-    auto props = std::const_pointer_cast<Props>(std::move(constProps));
-    State state{std::move(props)};
+    const std::shared_ptr<const Props>& previousProps = concreteShadowNode.getStateData().getProps();
+    if (previousProps != nullptr && constProps->hasSameProps(*previousProps)) {
+      // None of the Nitro props changed. Keep the existing State identity so
+      // Fabric does not schedule an Android State update for base View props.
+      return;
+    }
+
+    State state{std::move(constProps)};
     concreteShadowNode.setStateData(std::move(state));
   }
 #endif

--- a/packages/react-native-nitro-modules/cpp/views/ViewPropsHolderState.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/ViewPropsHolderState.hpp
@@ -24,11 +24,11 @@ template <typename TProps>
 struct ViewPropsHolderState final {
 public:
   ViewPropsHolderState() = default;
-  explicit ViewPropsHolderState(std::shared_ptr<TProps> props) : _props(std::move(props)) {}
+  explicit ViewPropsHolderState(std::shared_ptr<const TProps> props) : _props(std::move(props)) {}
 
 public:
   [[nodiscard]]
-  const std::shared_ptr<TProps>& getProps() const {
+  const std::shared_ptr<const TProps>& getProps() const {
     return _props;
   }
 
@@ -44,7 +44,7 @@ public:
 #endif
 
 private:
-  std::shared_ptr<TProps> _props;
+  std::shared_ptr<const TProps> _props;
 };
 
 } // namespace margelo::nitro

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridRecyclableTestViewStateUpdater.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridRecyclableTestViewStateUpdater.cpp
@@ -15,42 +15,55 @@ namespace margelo::nitro::test::views {
 using namespace facebook;
 using ConcreteStateData = react::ConcreteState<HybridRecyclableTestViewState>;
 
-void JHybridRecyclableTestViewStateUpdater::updateViewProps(jni::alias_ref<jni::JClass> /* class */,
-                                           jni::alias_ref<JHybridRecyclableTestViewSpec::JavaPart> javaView,
-                                           jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface) {
-  std::shared_ptr<JHybridRecyclableTestViewSpec> hybridView = javaView->getJHybridRecyclableTestViewSpec();
-
-  // Get concrete StateWrapperImpl from passed StateWrapper interface object
-  jobject rawStateWrapper = stateWrapperInterface.get();
-  if (!stateWrapperInterface->isInstanceOf(react::StateWrapperImpl::javaClassStatic())) [[unlikely]] {
-      throw std::runtime_error("StateWrapper is not a StateWrapperImpl");
+std::shared_ptr<const HybridRecyclableTestViewProps> JHybridRecyclableTestViewStateUpdater::getPropsFromStateWrapper(
+    jni::alias_ref<JStateWrapper::javaobject> stateWrapper) {
+  if (stateWrapper.get() == nullptr) {
+    return nullptr;
   }
-  auto stateWrapper = jni::alias_ref<react::StateWrapperImpl::javaobject>{
+  // Get concrete StateWrapperImpl from passed StateWrapper interface object
+  jobject rawStateWrapper = stateWrapper.get();
+  if (!stateWrapper->isInstanceOf(react::StateWrapperImpl::javaClassStatic())) [[unlikely]] {
+    throw std::runtime_error("StateWrapper is not a StateWrapperImpl");
+  }
+  auto stateWrapperImpl = jni::alias_ref<react::StateWrapperImpl::javaobject>{
     static_cast<react::StateWrapperImpl::javaobject>(rawStateWrapper)
   };
-  std::shared_ptr<const react::State> state = stateWrapper->cthis()->getState();
+  std::shared_ptr<const react::State> state = stateWrapperImpl->cthis()->getState();
+  if (state == nullptr) {
+    return nullptr;
+  }
   auto concreteState = std::static_pointer_cast<const ConcreteStateData>(state);
   const HybridRecyclableTestViewState& data = concreteState->getData();
-  const std::shared_ptr<HybridRecyclableTestViewProps>& props = data.getProps();
+  const std::shared_ptr<const HybridRecyclableTestViewProps>& props = data.getProps();
   if (props == nullptr) [[unlikely]] {
-    // Props aren't set yet!
     throw std::runtime_error("HybridRecyclableTestViewState's data doesn't contain any props!");
   }
+  return props;
+}
 
-  // Update all props if they are dirty
-  if (props->isBlue.isDirty) {
-    hybridView->setIsBlue(props->isBlue.get());
-    props->isBlue.isDirty = false;
+void JHybridRecyclableTestViewStateUpdater::updateViewProps(jni::alias_ref<jni::JClass> /* class */,
+                                           jni::alias_ref<JHybridRecyclableTestViewSpec::JavaPart> javaView,
+                                           jni::alias_ref<JStateWrapper::javaobject> newState,
+                                           jni::alias_ref<JStateWrapper::javaobject> oldState) {
+  std::shared_ptr<JHybridRecyclableTestViewSpec> hybridView = javaView->getJHybridRecyclableTestViewSpec();
+  std::shared_ptr<const HybridRecyclableTestViewProps> newProps = getPropsFromStateWrapper(newState);
+  std::shared_ptr<const HybridRecyclableTestViewProps> oldProps = getPropsFromStateWrapper(oldState);
+  if (newProps == nullptr) [[unlikely]] {
+    throw std::runtime_error("Current StateWrapper doesn't contain any props!");
+  }
+
+  // Update only props that differ from the previous State snapshot.
+  if (oldProps == nullptr || !newProps->isBlue.hasSameValue(oldProps->isBlue)) {
+    hybridView->setIsBlue(newProps->isBlue.get());
   }
 
   // Update hybridRef if it changed
-  if (props->hybridRef.isDirty) {
+  if (oldProps == nullptr || !newProps->hybridRef.hasSameValue(oldProps->hybridRef)) {
     // hybridRef changed - call it with new this
-    const auto& maybeFunc = props->hybridRef.get();
+    const auto& maybeFunc = newProps->hybridRef.get();
     if (maybeFunc.has_value()) {
       maybeFunc.value()(hybridView);
     }
-    props->hybridRef.isDirty = false;
   }
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridRecyclableTestViewStateUpdater.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridRecyclableTestViewStateUpdater.hpp
@@ -31,7 +31,12 @@ public:
 public:
   static void updateViewProps(jni::alias_ref<jni::JClass> /* class */,
                               jni::alias_ref<JHybridRecyclableTestViewSpec::JavaPart> view,
-                              jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface);
+                              jni::alias_ref<JStateWrapper::javaobject> newState,
+                              jni::alias_ref<JStateWrapper::javaobject> oldState);
+
+private:
+  static std::shared_ptr<const HybridRecyclableTestViewProps> getPropsFromStateWrapper(
+      jni::alias_ref<JStateWrapper::javaobject> stateWrapper);
 
 public:
   static void registerNatives() {

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.cpp
@@ -15,54 +15,64 @@ namespace margelo::nitro::test::views {
 using namespace facebook;
 using ConcreteStateData = react::ConcreteState<HybridTestViewState>;
 
-void JHybridTestViewStateUpdater::updateViewProps(jni::alias_ref<jni::JClass> /* class */,
-                                           jni::alias_ref<JHybridTestViewSpec::JavaPart> javaView,
-                                           jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface) {
-  std::shared_ptr<JHybridTestViewSpec> hybridView = javaView->getJHybridTestViewSpec();
-
-  // Get concrete StateWrapperImpl from passed StateWrapper interface object
-  jobject rawStateWrapper = stateWrapperInterface.get();
-  if (!stateWrapperInterface->isInstanceOf(react::StateWrapperImpl::javaClassStatic())) [[unlikely]] {
-      throw std::runtime_error("StateWrapper is not a StateWrapperImpl");
+std::shared_ptr<const HybridTestViewProps> JHybridTestViewStateUpdater::getPropsFromStateWrapper(
+    jni::alias_ref<JStateWrapper::javaobject> stateWrapper) {
+  if (stateWrapper.get() == nullptr) {
+    return nullptr;
   }
-  auto stateWrapper = jni::alias_ref<react::StateWrapperImpl::javaobject>{
+  // Get concrete StateWrapperImpl from passed StateWrapper interface object
+  jobject rawStateWrapper = stateWrapper.get();
+  if (!stateWrapper->isInstanceOf(react::StateWrapperImpl::javaClassStatic())) [[unlikely]] {
+    throw std::runtime_error("StateWrapper is not a StateWrapperImpl");
+  }
+  auto stateWrapperImpl = jni::alias_ref<react::StateWrapperImpl::javaobject>{
     static_cast<react::StateWrapperImpl::javaobject>(rawStateWrapper)
   };
-  std::shared_ptr<const react::State> state = stateWrapper->cthis()->getState();
+  std::shared_ptr<const react::State> state = stateWrapperImpl->cthis()->getState();
+  if (state == nullptr) {
+    return nullptr;
+  }
   auto concreteState = std::static_pointer_cast<const ConcreteStateData>(state);
   const HybridTestViewState& data = concreteState->getData();
-  const std::shared_ptr<HybridTestViewProps>& props = data.getProps();
+  const std::shared_ptr<const HybridTestViewProps>& props = data.getProps();
   if (props == nullptr) [[unlikely]] {
-    // Props aren't set yet!
     throw std::runtime_error("HybridTestViewState's data doesn't contain any props!");
   }
+  return props;
+}
 
-  // Update all props if they are dirty
-  if (props->isBlue.isDirty) {
-    hybridView->setIsBlue(props->isBlue.get());
-    props->isBlue.isDirty = false;
+void JHybridTestViewStateUpdater::updateViewProps(jni::alias_ref<jni::JClass> /* class */,
+                                           jni::alias_ref<JHybridTestViewSpec::JavaPart> javaView,
+                                           jni::alias_ref<JStateWrapper::javaobject> newState,
+                                           jni::alias_ref<JStateWrapper::javaobject> oldState) {
+  std::shared_ptr<JHybridTestViewSpec> hybridView = javaView->getJHybridTestViewSpec();
+  std::shared_ptr<const HybridTestViewProps> newProps = getPropsFromStateWrapper(newState);
+  std::shared_ptr<const HybridTestViewProps> oldProps = getPropsFromStateWrapper(oldState);
+  if (newProps == nullptr) [[unlikely]] {
+    throw std::runtime_error("Current StateWrapper doesn't contain any props!");
   }
-  if (props->hasBeenCalled.isDirty) {
-    hybridView->setHasBeenCalled(props->hasBeenCalled.get());
-    props->hasBeenCalled.isDirty = false;
+
+  // Update only props that differ from the previous State snapshot.
+  if (oldProps == nullptr || !newProps->isBlue.hasSameValue(oldProps->isBlue)) {
+    hybridView->setIsBlue(newProps->isBlue.get());
   }
-  if (props->colorScheme.isDirty) {
-    hybridView->setColorScheme(props->colorScheme.get());
-    props->colorScheme.isDirty = false;
+  if (oldProps == nullptr || !newProps->hasBeenCalled.hasSameValue(oldProps->hasBeenCalled)) {
+    hybridView->setHasBeenCalled(newProps->hasBeenCalled.get());
   }
-  if (props->someCallback.isDirty) {
-    hybridView->setSomeCallback(props->someCallback.get());
-    props->someCallback.isDirty = false;
+  if (oldProps == nullptr || !newProps->colorScheme.hasSameValue(oldProps->colorScheme)) {
+    hybridView->setColorScheme(newProps->colorScheme.get());
+  }
+  if (oldProps == nullptr || !newProps->someCallback.hasSameValue(oldProps->someCallback)) {
+    hybridView->setSomeCallback(newProps->someCallback.get());
   }
 
   // Update hybridRef if it changed
-  if (props->hybridRef.isDirty) {
+  if (oldProps == nullptr || !newProps->hybridRef.hasSameValue(oldProps->hybridRef)) {
     // hybridRef changed - call it with new this
-    const auto& maybeFunc = props->hybridRef.get();
+    const auto& maybeFunc = newProps->hybridRef.get();
     if (maybeFunc.has_value()) {
       maybeFunc.value()(hybridView);
     }
-    props->hybridRef.isDirty = false;
   }
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.hpp
@@ -31,7 +31,12 @@ public:
 public:
   static void updateViewProps(jni::alias_ref<jni::JClass> /* class */,
                               jni::alias_ref<JHybridTestViewSpec::JavaPart> view,
-                              jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface);
+                              jni::alias_ref<JStateWrapper::javaobject> newState,
+                              jni::alias_ref<JStateWrapper::javaobject> oldState);
+
+private:
+  static std::shared_ptr<const HybridTestViewProps> getPropsFromStateWrapper(
+      jni::alias_ref<JStateWrapper::javaobject> stateWrapper);
 
 public:
   static void registerNatives() {

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridRecyclableTestViewManager.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridRecyclableTestViewManager.kt
@@ -20,6 +20,14 @@ import com.margelo.nitro.test.*
  * Represents the React Native `ViewManager` for the "RecyclableTestView" Nitro HybridView.
  */
 public class HybridRecyclableTestViewManager: SimpleViewManager<View>() {
+  /**
+   * Represents the View and its last state snapshot (mutable)
+   */
+  private class HybridViewHolder(
+    val hybridView: HybridRecyclableTestView,
+    var lastState: StateWrapper? = null,
+  )
+
   init {
     if (RecyclableView::class.java.isAssignableFrom(HybridRecyclableTestView::class.java)) {
       // Enable view recycling
@@ -34,34 +42,41 @@ public class HybridRecyclableTestViewManager: SimpleViewManager<View>() {
   override fun createViewInstance(reactContext: ThemedReactContext): View {
     val hybridView = HybridRecyclableTestView(reactContext)
     val view = hybridView.view
-    view.setTag(associated_hybrid_view_tag, hybridView)
+    view.setTag(associated_hybrid_view_tag, HybridViewHolder(hybridView))
     return view
   }
 
   override fun updateState(view: View, props: ReactStylesDiffMap, stateWrapper: StateWrapper): Any? {
-    val hybridView = getHybridView(view)
+    val holder = getHybridViewHolder(view)
       ?: throw Error("Couldn't find view $view in local views table!")
+    val hybridView = holder.hybridView
+    val oldState = holder.lastState
+    val newState = stateWrapper
 
     // 1. Update each prop individually
     hybridView.beforeUpdate()
-    HybridRecyclableTestViewStateUpdater.updateViewProps(hybridView, stateWrapper)
+    HybridRecyclableTestViewStateUpdater.updateViewProps(hybridView, newState, oldState)
     hybridView.afterUpdate()
+    holder.lastState = newState
 
     // 2. Continue in base View props
-    return super.updateState(view, props, stateWrapper)
+    return super.updateState(view, props, newState)
   }
 
   override fun onDropViewInstance(view: View) {
-    val hybridView = getHybridView(view)
-    hybridView?.onDropView()
+    val holder = getHybridViewHolder(view)
+    holder?.lastState = null
+    holder?.hybridView?.onDropView()
     return super.onDropViewInstance(view)
   }
 
   protected override fun prepareToRecycleView(reactContext: ThemedReactContext, view: View): View? {
     val preparedView = super.prepareToRecycleView(reactContext, view)
       ?: return null
-    val hybridView = getHybridView(preparedView)
+    val holder = getHybridViewHolder(preparedView)
       ?: return null
+    val hybridView = holder.hybridView
+    holder.lastState = null
 
     @Suppress("USELESS_IS_CHECK")
     if (hybridView is RecyclableView) {
@@ -75,7 +90,7 @@ public class HybridRecyclableTestViewManager: SimpleViewManager<View>() {
     }
   }
 
-  private fun getHybridView(view: View): HybridRecyclableTestView? {
-    return view.getTag(associated_hybrid_view_tag) as? HybridRecyclableTestView
+  private fun getHybridViewHolder(view: View): HybridViewHolder? {
+    return view.getTag(associated_hybrid_view_tag) as? HybridViewHolder
   }
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridRecyclableTestViewStateUpdater.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridRecyclableTestViewStateUpdater.kt
@@ -14,10 +14,10 @@ internal class HybridRecyclableTestViewStateUpdater {
   companion object {
     /**
      * Updates the props for [view] through C++.
-     * The [state] prop is expected to contain [view]'s props as wrapped Fabric state.
+     * The [newState] prop is expected to contain [view]'s props as wrapped Fabric state.
      */
     @Suppress("KotlinJniMissingFunction")
     @JvmStatic
-    external fun updateViewProps(view: HybridRecyclableTestViewSpec, state: StateWrapper)
+    external fun updateViewProps(view: HybridRecyclableTestViewSpec, newState: StateWrapper, oldState: StateWrapper?)
   }
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridTestViewManager.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridTestViewManager.kt
@@ -20,6 +20,14 @@ import com.margelo.nitro.test.*
  * Represents the React Native `ViewManager` for the "TestView" Nitro HybridView.
  */
 public class HybridTestViewManager: SimpleViewManager<View>() {
+  /**
+   * Represents the View and its last state snapshot (mutable)
+   */
+  private class HybridViewHolder(
+    val hybridView: HybridTestView,
+    var lastState: StateWrapper? = null,
+  )
+
   init {
     if (RecyclableView::class.java.isAssignableFrom(HybridTestView::class.java)) {
       // Enable view recycling
@@ -34,34 +42,41 @@ public class HybridTestViewManager: SimpleViewManager<View>() {
   override fun createViewInstance(reactContext: ThemedReactContext): View {
     val hybridView = HybridTestView(reactContext)
     val view = hybridView.view
-    view.setTag(associated_hybrid_view_tag, hybridView)
+    view.setTag(associated_hybrid_view_tag, HybridViewHolder(hybridView))
     return view
   }
 
   override fun updateState(view: View, props: ReactStylesDiffMap, stateWrapper: StateWrapper): Any? {
-    val hybridView = getHybridView(view)
+    val holder = getHybridViewHolder(view)
       ?: throw Error("Couldn't find view $view in local views table!")
+    val hybridView = holder.hybridView
+    val oldState = holder.lastState
+    val newState = stateWrapper
 
     // 1. Update each prop individually
     hybridView.beforeUpdate()
-    HybridTestViewStateUpdater.updateViewProps(hybridView, stateWrapper)
+    HybridTestViewStateUpdater.updateViewProps(hybridView, newState, oldState)
     hybridView.afterUpdate()
+    holder.lastState = newState
 
     // 2. Continue in base View props
-    return super.updateState(view, props, stateWrapper)
+    return super.updateState(view, props, newState)
   }
 
   override fun onDropViewInstance(view: View) {
-    val hybridView = getHybridView(view)
-    hybridView?.onDropView()
+    val holder = getHybridViewHolder(view)
+    holder?.lastState = null
+    holder?.hybridView?.onDropView()
     return super.onDropViewInstance(view)
   }
 
   protected override fun prepareToRecycleView(reactContext: ThemedReactContext, view: View): View? {
     val preparedView = super.prepareToRecycleView(reactContext, view)
       ?: return null
-    val hybridView = getHybridView(preparedView)
+    val holder = getHybridViewHolder(preparedView)
       ?: return null
+    val hybridView = holder.hybridView
+    holder.lastState = null
 
     @Suppress("USELESS_IS_CHECK")
     if (hybridView is RecyclableView) {
@@ -75,7 +90,7 @@ public class HybridTestViewManager: SimpleViewManager<View>() {
     }
   }
 
-  private fun getHybridView(view: View): HybridTestView? {
-    return view.getTag(associated_hybrid_view_tag) as? HybridTestView
+  private fun getHybridViewHolder(view: View): HybridViewHolder? {
+    return view.getTag(associated_hybrid_view_tag) as? HybridViewHolder
   }
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridTestViewStateUpdater.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/views/HybridTestViewStateUpdater.kt
@@ -14,10 +14,10 @@ internal class HybridTestViewStateUpdater {
   companion object {
     /**
      * Updates the props for [view] through C++.
-     * The [state] prop is expected to contain [view]'s props as wrapped Fabric state.
+     * The [newState] prop is expected to contain [view]'s props as wrapped Fabric state.
      */
     @Suppress("KotlinJniMissingFunction")
     @JvmStatic
-    external fun updateViewProps(view: HybridTestViewSpec, state: StateWrapper)
+    external fun updateViewProps(view: HybridTestViewSpec, newState: StateWrapper, oldState: StateWrapper?)
   }
 }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridRecyclableTestViewComponent.mm
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridRecyclableTestViewComponent.mm
@@ -51,6 +51,7 @@ using namespace margelo::nitro::test::views;
 
 - (instancetype) init {
   if (self = [super init]) {
+    _props = HybridRecyclableTestViewShadowNode::defaultSharedProps();
     std::shared_ptr<HybridRecyclableTestViewSpec> hybridView = NitroTest::NitroTestAutolinking::createRecyclableTestView();
     _hybridView = std::dynamic_pointer_cast<HybridRecyclableTestViewSpecSwift>(hybridView);
     [self updateView];
@@ -86,32 +87,33 @@ using namespace margelo::nitro::test::views;
   _didDropView = NO;
 
   // 1. Downcast props
-  const HybridRecyclableTestViewProps& newViewPropsConst = *std::static_pointer_cast<HybridRecyclableTestViewProps const>(props);
-  HybridRecyclableTestViewProps& newViewProps = const_cast<HybridRecyclableTestViewProps&>(newViewPropsConst);
+  const auto& newViewProps = *std::static_pointer_cast<const HybridRecyclableTestViewProps>(props);
+  const auto* oldViewProps = static_cast<const HybridRecyclableTestViewProps*>(oldProps.get());
   NitroTest::HybridRecyclableTestViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
 
-  // 2. Update each prop individually
-  swiftPart.beforeUpdate();
+  // 2. Update only props that differ from the previous Props snapshot.
+  const bool hasTransactionPropChanges = oldViewProps == nullptr || !newViewProps.hasSameProps(*oldViewProps);
+  if (hasTransactionPropChanges) {
+    swiftPart.beforeUpdate();
 
-  // isBlue: boolean
-  if (newViewProps.isBlue.isDirty) {
-    swiftPart.setIsBlue(newViewProps.isBlue.get());
-    newViewProps.isBlue.isDirty = false;
-  }
-
-  swiftPart.afterUpdate();
-
-  // 3. Update hybridRef if it changed
-  if (newViewProps.hybridRef.isDirty) {
-    // hybridRef changed - call it with new this
-    const auto& maybeFunc = newViewProps.hybridRef.get();
-    if (maybeFunc.has_value()) {
-      maybeFunc.value()(_hybridView);
+    // isBlue: boolean
+    if (oldViewProps == nullptr || !newViewProps.isBlue.hasSameValue(oldViewProps->isBlue)) {
+      swiftPart.setIsBlue(newViewProps.isBlue.get());
     }
-    newViewProps.hybridRef.isDirty = false;
+
+    // Update hybridRef if it changed
+    if (oldViewProps == nullptr || !newViewProps.hybridRef.hasSameValue(oldViewProps->hybridRef)) {
+      // hybridRef changed - call it with new this
+      const auto& maybeFunc = newViewProps.hybridRef.get();
+      if (maybeFunc.has_value()) {
+        maybeFunc.value()(_hybridView);
+      }
+    }
+
+    swiftPart.afterUpdate();
   }
 
-  // 4. Continue in base class
+  // 3. Continue in base class
   [super updateProps:props oldProps:oldProps];
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
@@ -51,6 +51,7 @@ using namespace margelo::nitro::test::views;
 
 - (instancetype) init {
   if (self = [super init]) {
+    _props = HybridTestViewShadowNode::defaultSharedProps();
     std::shared_ptr<HybridTestViewSpec> hybridView = NitroTest::NitroTestAutolinking::createTestView();
     _hybridView = std::dynamic_pointer_cast<HybridTestViewSpecSwift>(hybridView);
     [self updateView];
@@ -86,47 +87,45 @@ using namespace margelo::nitro::test::views;
   _didDropView = NO;
 
   // 1. Downcast props
-  const HybridTestViewProps& newViewPropsConst = *std::static_pointer_cast<HybridTestViewProps const>(props);
-  HybridTestViewProps& newViewProps = const_cast<HybridTestViewProps&>(newViewPropsConst);
+  const auto& newViewProps = *std::static_pointer_cast<const HybridTestViewProps>(props);
+  const auto* oldViewProps = static_cast<const HybridTestViewProps*>(oldProps.get());
   NitroTest::HybridTestViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
 
-  // 2. Update each prop individually
-  swiftPart.beforeUpdate();
+  // 2. Update only props that differ from the previous Props snapshot.
+  const bool hasTransactionPropChanges = oldViewProps == nullptr || !newViewProps.hasSameProps(*oldViewProps);
+  if (hasTransactionPropChanges) {
+    swiftPart.beforeUpdate();
 
-  // isBlue: boolean
-  if (newViewProps.isBlue.isDirty) {
-    swiftPart.setIsBlue(newViewProps.isBlue.get());
-    newViewProps.isBlue.isDirty = false;
-  }
-  // hasBeenCalled: boolean
-  if (newViewProps.hasBeenCalled.isDirty) {
-    swiftPart.setHasBeenCalled(newViewProps.hasBeenCalled.get());
-    newViewProps.hasBeenCalled.isDirty = false;
-  }
-  // colorScheme: enum
-  if (newViewProps.colorScheme.isDirty) {
-    swiftPart.setColorScheme(static_cast<int>(newViewProps.colorScheme.get()));
-    newViewProps.colorScheme.isDirty = false;
-  }
-  // someCallback: function
-  if (newViewProps.someCallback.isDirty) {
-    swiftPart.setSomeCallback(newViewProps.someCallback.get());
-    newViewProps.someCallback.isDirty = false;
-  }
-
-  swiftPart.afterUpdate();
-
-  // 3. Update hybridRef if it changed
-  if (newViewProps.hybridRef.isDirty) {
-    // hybridRef changed - call it with new this
-    const auto& maybeFunc = newViewProps.hybridRef.get();
-    if (maybeFunc.has_value()) {
-      maybeFunc.value()(_hybridView);
+    // isBlue: boolean
+    if (oldViewProps == nullptr || !newViewProps.isBlue.hasSameValue(oldViewProps->isBlue)) {
+      swiftPart.setIsBlue(newViewProps.isBlue.get());
     }
-    newViewProps.hybridRef.isDirty = false;
+    // hasBeenCalled: boolean
+    if (oldViewProps == nullptr || !newViewProps.hasBeenCalled.hasSameValue(oldViewProps->hasBeenCalled)) {
+      swiftPart.setHasBeenCalled(newViewProps.hasBeenCalled.get());
+    }
+    // colorScheme: enum
+    if (oldViewProps == nullptr || !newViewProps.colorScheme.hasSameValue(oldViewProps->colorScheme)) {
+      swiftPart.setColorScheme(static_cast<int>(newViewProps.colorScheme.get()));
+    }
+    // someCallback: function
+    if (oldViewProps == nullptr || !newViewProps.someCallback.hasSameValue(oldViewProps->someCallback)) {
+      swiftPart.setSomeCallback(newViewProps.someCallback.get());
+    }
+
+    // Update hybridRef if it changed
+    if (oldViewProps == nullptr || !newViewProps.hybridRef.hasSameValue(oldViewProps->hybridRef)) {
+      // hybridRef changed - call it with new this
+      const auto& maybeFunc = newViewProps.hybridRef.get();
+      if (maybeFunc.has_value()) {
+        maybeFunc.value()(_hybridView);
+      }
+    }
+
+    swiftPart.afterUpdate();
   }
 
-  // 4. Continue in base class
+  // 3. Continue in base class
   [super updateProps:props oldProps:oldProps];
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridRecyclableTestViewComponent.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridRecyclableTestViewComponent.hpp
@@ -45,6 +45,12 @@ namespace margelo::nitro::test::views {
     nitro::CachedProp<bool> isBlue;
     nitro::CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridRecyclableTestViewSpec>& /* ref */)>>> hybridRef;
 
+    [[nodiscard]]
+    bool hasSameProps(const HybridRecyclableTestViewProps& other) const noexcept {
+      return isBlue.hasSameValue(other.isBlue) &&
+             hybridRef.hasSameValue(other.hybridRef);
+    }
+
   private:
     static bool filterObjectKeys(const std::string& propName);
   };

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.hpp
@@ -49,6 +49,15 @@ namespace margelo::nitro::test::views {
     nitro::CachedProp<std::function<void()>> someCallback;
     nitro::CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridTestViewSpec>& /* ref */)>>> hybridRef;
 
+    [[nodiscard]]
+    bool hasSameProps(const HybridTestViewProps& other) const noexcept {
+      return isBlue.hasSameValue(other.isBlue) &&
+             hasBeenCalled.hasSameValue(other.hasBeenCalled) &&
+             colorScheme.hasSameValue(other.colorScheme) &&
+             someCallback.hasSameValue(other.someCallback) &&
+             hybridRef.hasSameValue(other.hybridRef);
+    }
+
   private:
     static bool filterObjectKeys(const std::string& propName);
   };


### PR DESCRIPTION
Before, we did a lot of messy voodoo magic like `const_cast` to make React `Props` mutable (even though they are immutable by design), and then tracked a `isDirty` flag on them which was cleared after we set a prop in Swift/Kotlin.

This had a few issues;

1. `Props` really should be immutable (`const Props`) by React's design. Making it mutable could cause issues with React internals, or breaks in future versions
2. `isDirty` can _theoretically_ go out of sync (potentially with concurrent rendering?). In practice, that would probably never happen today because React creates new `Props` everytime.
3. I _think_ `isDirty` didn't even work before on Android (because we couldn't set it back on `Props` via `State`), **so this is now a performance improvement for Nitro Views on Android too**.