### PR TITLE
fix: Preserve classic View prop parsing across React Native versions

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2254,7 +2254,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
   HarnessUI: bb94ae23e70e83983e4e914a8d7573969e33b930
   hermes-engine: 411df881c1affac35ba53c66e3317eca368c0678
-  NitroModules: 2f4f1e6148ce404a9260e181a00ce8d19642ad62
+  NitroModules: bbc1df38c2317e3ecaf470afd91429a5df2814c2
   NitroTest: 0afe14464750e8e44fc5976c4fe6440b0cd811f1
   NitroTestExternal: 8f0567301acef980a553d93763e3f6059a5c2fed
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12

--- a/packages/react-native-nitro-modules/NitroModules.podspec
+++ b/packages/react-native-nitro-modules/NitroModules.podspec
@@ -51,7 +51,7 @@ Pod::Spec.new do |s|
     "cpp/utils/NitroDefines.hpp",
     "cpp/utils/PropNameIDCache.hpp",
     "cpp/views/CachedProp.hpp",
-    "cpp/views/ViewPropParser.hpp",
+    "cpp/views/RawPropsCompat.hpp",
     "cpp/views/ViewComponentDescriptor.hpp",
     "cpp/views/ViewPropsHolderState.hpp",
     # Public iOS-specific headers that will be exposed in modulemap (for Swift)

--- a/packages/react-native-nitro-modules/cpp/views/CachedProp.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/CachedProp.hpp
@@ -9,6 +9,7 @@
 #include "JSIConverter.hpp"
 #include "NitroDefines.hpp"
 #include "PropNameIDCache.hpp"
+#include "RawPropsCompat.hpp"
 #include <jsi/jsi.h>
 
 #include <react/renderer/core/RawProps.h>
@@ -79,7 +80,7 @@ public:
   static CachedProp<T> fromRawValue(const char* viewName, const char* propName, const react::RawProps& rawProps,
                                     const CachedProp<T>& previousProp) {
     try {
-      const react::RawValue* rawValue = rawProps.at(propName, nullptr, nullptr);
+      const react::RawValue* rawValue = RawPropsCompat::at(rawProps, propName);
       if (rawValue == nullptr) {
         // This RawValue pack does not contain our prop, so skip it - it's still the same from before
         return previousProp;

--- a/packages/react-native-nitro-modules/cpp/views/RawPropsCompat.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/RawPropsCompat.hpp
@@ -1,0 +1,27 @@
+//
+// Created by Marc Rousavy on 29.06.26.
+//
+
+#pragma once
+
+#if __has_include(<cxxreact/ReactNativeVersion.h>)
+#include <cxxreact/ReactNativeVersion.h>
+#endif
+#include <react/renderer/core/RawProps.h>
+
+namespace margelo::nitro::RawPropsCompat {
+
+/**
+ * Same as `props.at(name)`, with compatibility for React Native 0.79 through
+ * 0.86, where `RawProps::at(...)` requires prefix and suffix arguments.
+ */
+inline const facebook::react::RawValue* at(const facebook::react::RawProps& props, const char* name) {
+#if defined(REACT_NATIVE_VERSION_MAJOR) && (REACT_NATIVE_VERSION_MAJOR > 0 || REACT_NATIVE_VERSION_MINOR > 86)
+  // React Native 0.87 introduced the canonical single-argument overload.
+  return props.at(name);
+#else
+  return props.at(name, nullptr, nullptr);
+#endif
+}
+
+} // namespace margelo::nitro::RawPropsCompat


### PR DESCRIPTION
## Summary

- centralize RawProps lookup behind a small RawPropsCompat helper
- use the three-argument at() API on React Native 0.79 through 0.86
- use the canonical one-argument at() API on React Native 0.87+
- keep Nitro JSI-backed conversion and absent-key identity semantics intact
- expose the compatibility header through the podspec

This is a standalone compatibility fix and intentionally drops support for React Native 0.78 and below.

## Validation

- React Native 0.85 iOS and Android native builds
- React Native 0.87 generated native compilation
- deterministic generation and clean C++ formatting