### PR TITLE
fix: Preserve native View prop defaults

### DIFF
--- a/example/__tests__/nitro.views.harness.tsx
+++ b/example/__tests__/nitro.views.harness.tsx
@@ -739,6 +739,9 @@ describe('RecyclableTestView', () => {
       { timeout: RENDER_TIMEOUT }
     )
     const firstView = await firstRef.promise
+    expect(firstView.isBlue).toBe(true)
+    expect(firstView.nativeDefaultValue).toBe(42)
+    expect(firstView.getNativeDefaultValueSetterCallCount()).toBe(0)
     const initialOnDropViewCount = firstView.getOnDropViewCount()
     const initialPrepareForRecycleCount = firstView.getPrepareForRecycleCount()
 
@@ -753,6 +756,9 @@ describe('RecyclableTestView', () => {
       initialPrepareForRecycleCount + (SUPPORTS_NATIVE_VIEW_RECYCLING ? 1 : 0)
     )
     expect(firstView.getInvalidLifecycleOrderCount()).toBe(0)
+    const firstNativeDefaultSetterCountAfterRecycle =
+      firstView.getNativeDefaultValueSetterCallCount()
+    expect(firstNativeDefaultSetterCountAfterRecycle).toBe(0)
 
     const secondRef = deferred<RecyclableTestViewRef>()
     const secondLayout = deferred<LayoutRectangle>()
@@ -762,6 +768,7 @@ describe('RecyclableTestView', () => {
         style={RESIZED_SIZE}
         hybridRef={callback((view) => secondRef.resolve(view))}
         isBlue={false}
+        nativeDefaultValue={0}
         onLayout={({ nativeEvent }) => secondLayout.resolve(nativeEvent.layout)}
       />
     )
@@ -777,6 +784,8 @@ describe('RecyclableTestView', () => {
     )
     expect(secondView.getInvalidLifecycleOrderCount()).toBe(0)
     expect(secondView.isBlue).toBe(false)
+    expect(secondView.nativeDefaultValue).toBe(0)
+    expect(secondView.getNativeDefaultValueSetterCallCount()).toBe(1)
     expect(reportedSecondLayout.width).toBeCloseTo(RESIZED_SIZE.width, 0)
     expect(reportedSecondLayout.height).toBeCloseTo(RESIZED_SIZE.height, 0)
 
@@ -794,6 +803,11 @@ describe('RecyclableTestView', () => {
         (SUPPORTS_NATIVE_VIEW_RECYCLING ? 1 : 0)
     )
     expect(secondView.getInvalidLifecycleOrderCount()).toBe(0)
+    const secondNativeDefaultSetterCountAfterRecycle =
+      secondView.getNativeDefaultValueSetterCallCount()
+    expect(secondNativeDefaultSetterCountAfterRecycle).toBe(
+      SUPPORTS_NATIVE_VIEW_RECYCLING ? 0 : 1
+    )
 
     const thirdRef = deferred<RecyclableTestViewRef>()
     const thirdLayout = deferred<LayoutRectangle>()
@@ -819,6 +833,8 @@ describe('RecyclableTestView', () => {
     )
     expect(thirdView.getInvalidLifecycleOrderCount()).toBe(0)
     expect(thirdView.isBlue).toBe(true)
+    expect(thirdView.nativeDefaultValue).toBe(42)
+    expect(thirdView.getNativeDefaultValueSetterCallCount()).toBe(0)
     expect(reportedThirdLayout.width).toBeCloseTo(INITIAL_SIZE.width, 0)
     expect(reportedThirdLayout.height).toBeCloseTo(INITIAL_SIZE.height, 0)
 

--- a/packages/nitrogen/src/views/CppHybridViewComponent.ts
+++ b/packages/nitrogen/src/views/CppHybridViewComponent.ts
@@ -82,6 +82,10 @@ export function createViewComponentShadowNodeFiles(
     const name = escapeCppName(prop.name)
     return `${name}.hasSameValue(other.${name})`
   })
+  const providedChecks = props.map((prop) => {
+    const name = escapeCppName(prop.name)
+    return `${name}.isProvided()`
+  })
   const includes = props
     .flatMap((p) =>
       p.getRequiredImports('c++').map((i) => includeHeader(i, true))
@@ -132,6 +136,11 @@ namespace ${namespace} {
     [[nodiscard]]
     bool hasSameProps(const ${propsClassName}& other) const noexcept {
       return ${comparisons.join(' &&\n             ')};
+    }
+
+    [[nodiscard]]
+    bool hasAnyProvidedProps() const noexcept {
+      return ${providedChecks.join(' ||\n             ')};
     }
 
   private:

--- a/packages/nitrogen/src/views/kotlin/KotlinHybridViewManager.ts
+++ b/packages/nitrogen/src/views/kotlin/KotlinHybridViewManager.ts
@@ -214,7 +214,9 @@ public:
     const name = escapeCppName(p.name)
     const setter = p.getSetterName('other')
     return `
-if (oldProps == nullptr || !newProps->${name}.hasSameValue(oldProps->${name})) {
+if (oldProps == nullptr
+      ? newProps->${name}.isProvided()
+      : !newProps->${name}.hasSameValue(oldProps->${name})) {
   hybridView->${setter}(newProps->${name}.get());
 }
     `.trim()
@@ -273,7 +275,9 @@ void J${stateUpdaterName}::updateViewProps(jni::alias_ref<jni::JClass> /* class 
   ${indent(propsUpdaterCalls.join('\n'), '  ')}
 
   // Update hybridRef if it changed
-  if (oldProps == nullptr || !newProps->hybridRef.hasSameValue(oldProps->hybridRef)) {
+  if (oldProps == nullptr
+        ? newProps->hybridRef.isProvided()
+        : !newProps->hybridRef.hasSameValue(oldProps->hybridRef)) {
     // hybridRef changed - call it with new this
     const auto& maybeFunc = newProps->hybridRef.get();
     if (maybeFunc.has_value()) {

--- a/packages/nitrogen/src/views/swift/SwiftHybridViewManager.ts
+++ b/packages/nitrogen/src/views/swift/SwiftHybridViewManager.ts
@@ -49,7 +49,9 @@ export function createSwiftHybridViewManager(
     )
     return `
 // ${p.jsSignature}
-if (oldViewProps == nullptr || !newViewProps.${name}.hasSameValue(oldViewProps->${name})) {
+if (oldViewProps == nullptr
+      ? newViewProps.${name}.isProvided()
+      : !newViewProps.${name}.hasSameValue(oldViewProps->${name})) {
   swiftPart.${setter}(${indent(parse, '  ')});
 }
 `.trim()
@@ -144,14 +146,18 @@ using namespace ${namespace}::views;
   ${swiftNamespace}::${HybridTSpecCxx}& swiftPart = _hybridView->getSwiftPart();
 
   // 2. Update only props that differ from the previous Props snapshot.
-  const bool hasTransactionPropChanges = oldViewProps == nullptr || !newViewProps.hasSameProps(*oldViewProps);
+  const bool hasTransactionPropChanges = oldViewProps == nullptr
+      ? newViewProps.hasAnyProvidedProps()
+      : !newViewProps.hasSameProps(*oldViewProps);
   if (hasTransactionPropChanges) {
     swiftPart.beforeUpdate();
 
     ${indent(propAssignments.join('\n'), '    ')}
 
     // Update hybridRef if it changed
-    if (oldViewProps == nullptr || !newViewProps.hybridRef.hasSameValue(oldViewProps->hybridRef)) {
+    if (oldViewProps == nullptr
+          ? newViewProps.hybridRef.isProvided()
+          : !newViewProps.hybridRef.hasSameValue(oldViewProps->hybridRef)) {
       // hybridRef changed - call it with new this
       const auto& maybeFunc = newViewProps.hybridRef.get();
       if (maybeFunc.has_value()) {

--- a/packages/react-native-nitro-modules/cpp/views/CachedProp.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/CachedProp.hpp
@@ -35,9 +35,11 @@ private:
   struct Entry final {
     T value{};
     BorrowingReference<jsi::Value> jsiValue;
+    bool isProvided{false};
 
     Entry() = default;
-    Entry(T&& value, BorrowingReference<jsi::Value>&& jsiValue) : value(std::move(value)), jsiValue(std::move(jsiValue)) {}
+    Entry(T&& value, BorrowingReference<jsi::Value>&& jsiValue)
+        : value(std::move(value)), jsiValue(std::move(jsiValue)), isProvided(true) {}
   };
 
   std::shared_ptr<const Entry> _entry;
@@ -64,6 +66,16 @@ public:
   [[nodiscard]]
   bool hasSameValue(const CachedProp<T>& other) const noexcept {
     return _entry == other._entry;
+  }
+
+  /**
+   * Returns whether this prop has an explicit value in the current Fabric
+   * Props snapshot. Omitted props inherit this immutable state from the
+   * previous snapshot.
+   */
+  [[nodiscard]]
+  bool isProvided() const noexcept {
+    return _entry->isProvided;
   }
 
 private:

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridRecyclableTestView.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridRecyclableTestView.kt
@@ -20,6 +20,8 @@ class HybridRecyclableTestView(
   private var invalidLifecycleOrderCount = 0.0
   private var onDropViewCount = 0.0
   private var prepareForRecycleCount = 0.0
+  private var nativeDefaultValueSetterCallCount = 0.0
+  private var nativeDefaultValueStorage: Double? = 42.0
 
   // Props
   override var isBlue: Boolean = false
@@ -29,6 +31,12 @@ class HybridRecyclableTestView(
         val color = if (value) Color.BLUE else Color.RED
         view.setBackgroundColor(color)
       }
+    }
+  override var nativeDefaultValue: Double?
+    get() = nativeDefaultValueStorage
+    set(value) {
+      nativeDefaultValueStorage = value
+      nativeDefaultValueSetterCallCount += 1
     }
 
   override fun onDropView() {
@@ -42,6 +50,8 @@ class HybridRecyclableTestView(
 
   override fun getPrepareForRecycleCount(): Double = prepareForRecycleCount
 
+  override fun getNativeDefaultValueSetterCallCount(): Double = nativeDefaultValueSetterCallCount
+
   override fun beforeUpdate() {
     isRecycled = false
   }
@@ -52,6 +62,8 @@ class HybridRecyclableTestView(
       invalidLifecycleOrderCount += 1
     }
     prepareForRecycleCount += 1
+    nativeDefaultValueStorage = 42.0
+    nativeDefaultValueSetterCallCount = 0.0
     view.setBackgroundColor(Color.YELLOW)
     isRecycled = true
   }

--- a/packages/react-native-nitro-test/ios/HybridRecyclableTestView.swift
+++ b/packages/react-native-nitro-test/ios/HybridRecyclableTestView.swift
@@ -15,6 +15,8 @@ class HybridRecyclableTestView: HybridRecyclableTestViewSpec, RecyclableView {
   private var invalidLifecycleOrderCount: Double = 0
   private var onDropViewCount: Double = 0
   private var prepareForRecycleCount: Double = 0
+  private var nativeDefaultValueSetterCallCount: Double = 0
+  private var nativeDefaultValueStorage: Double? = 42
 
   // Props
   var isBlue: Bool = false {
@@ -22,6 +24,15 @@ class HybridRecyclableTestView: HybridRecyclableTestViewSpec, RecyclableView {
       if !isRecycled {
         view.backgroundColor = isBlue ? .systemBlue : .systemRed
       }
+    }
+  }
+  var nativeDefaultValue: Double? {
+    get {
+      return nativeDefaultValueStorage
+    }
+    set {
+      nativeDefaultValueStorage = newValue
+      nativeDefaultValueSetterCallCount += 1
     }
   }
 
@@ -42,6 +53,10 @@ class HybridRecyclableTestView: HybridRecyclableTestViewSpec, RecyclableView {
     return prepareForRecycleCount
   }
 
+  func getNativeDefaultValueSetterCallCount() throws -> Double {
+    return nativeDefaultValueSetterCallCount
+  }
+
   func beforeUpdate() {
     isRecycled = false
   }
@@ -52,6 +67,8 @@ class HybridRecyclableTestView: HybridRecyclableTestViewSpec, RecyclableView {
       invalidLifecycleOrderCount += 1
     }
     prepareForRecycleCount += 1
+    nativeDefaultValueStorage = 42
+    nativeDefaultValueSetterCallCount = 0
     view.backgroundColor = .yellow
     isRecycled = true
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridRecyclableTestViewSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridRecyclableTestViewSpec.cpp
@@ -9,7 +9,7 @@
 
 
 
-
+#include <optional>
 
 namespace margelo::nitro::test {
 
@@ -50,6 +50,15 @@ namespace margelo::nitro::test {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void(jboolean /* isBlue */)>("setBlue");
     method(_javaPart, isBlue);
   }
+  std::optional<double> JHybridRecyclableTestViewSpec::getNativeDefaultValue() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JDouble>()>("getNativeDefaultValue");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(__result->value()) : std::nullopt;
+  }
+  void JHybridRecyclableTestViewSpec::setNativeDefaultValue(std::optional<double> nativeDefaultValue) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JDouble> /* nativeDefaultValue */)>("setNativeDefaultValue");
+    method(_javaPart, nativeDefaultValue.has_value() ? jni::JDouble::valueOf(nativeDefaultValue.value()) : nullptr);
+  }
 
   // Methods
   double JHybridRecyclableTestViewSpec::getInvalidLifecycleOrderCount() {
@@ -64,6 +73,11 @@ namespace margelo::nitro::test {
   }
   double JHybridRecyclableTestViewSpec::getPrepareForRecycleCount() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getPrepareForRecycleCount");
+    auto __result = method(_javaPart);
+    return __result;
+  }
+  double JHybridRecyclableTestViewSpec::getNativeDefaultValueSetterCallCount() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getNativeDefaultValueSetterCallCount");
     auto __result = method(_javaPart);
     return __result;
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridRecyclableTestViewSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridRecyclableTestViewSpec.hpp
@@ -52,12 +52,15 @@ namespace margelo::nitro::test {
     // Properties
     bool getIsBlue() override;
     void setIsBlue(bool isBlue) override;
+    std::optional<double> getNativeDefaultValue() override;
+    void setNativeDefaultValue(std::optional<double> nativeDefaultValue) override;
 
   public:
     // Methods
     double getInvalidLifecycleOrderCount() override;
     double getOnDropViewCount() override;
     double getPrepareForRecycleCount() override;
+    double getNativeDefaultValueSetterCallCount() override;
 
   private:
     jni::global_ref<JHybridRecyclableTestViewSpec::JavaPart> _javaPart;

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridRecyclableTestViewStateUpdater.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridRecyclableTestViewStateUpdater.cpp
@@ -53,12 +53,21 @@ void JHybridRecyclableTestViewStateUpdater::updateViewProps(jni::alias_ref<jni::
   }
 
   // Update only props that differ from the previous State snapshot.
-  if (oldProps == nullptr || !newProps->isBlue.hasSameValue(oldProps->isBlue)) {
+  if (oldProps == nullptr
+        ? newProps->isBlue.isProvided()
+        : !newProps->isBlue.hasSameValue(oldProps->isBlue)) {
     hybridView->setIsBlue(newProps->isBlue.get());
+  }
+  if (oldProps == nullptr
+        ? newProps->nativeDefaultValue.isProvided()
+        : !newProps->nativeDefaultValue.hasSameValue(oldProps->nativeDefaultValue)) {
+    hybridView->setNativeDefaultValue(newProps->nativeDefaultValue.get());
   }
 
   // Update hybridRef if it changed
-  if (oldProps == nullptr || !newProps->hybridRef.hasSameValue(oldProps->hybridRef)) {
+  if (oldProps == nullptr
+        ? newProps->hybridRef.isProvided()
+        : !newProps->hybridRef.hasSameValue(oldProps->hybridRef)) {
     // hybridRef changed - call it with new this
     const auto& maybeFunc = newProps->hybridRef.get();
     if (maybeFunc.has_value()) {

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.cpp
@@ -53,24 +53,36 @@ void JHybridTestViewStateUpdater::updateViewProps(jni::alias_ref<jni::JClass> /*
   }
 
   // Update only props that differ from the previous State snapshot.
-  if (oldProps == nullptr || !newProps->isBlue.hasSameValue(oldProps->isBlue)) {
+  if (oldProps == nullptr
+        ? newProps->isBlue.isProvided()
+        : !newProps->isBlue.hasSameValue(oldProps->isBlue)) {
     hybridView->setIsBlue(newProps->isBlue.get());
   }
-  if (oldProps == nullptr || !newProps->hasBeenCalled.hasSameValue(oldProps->hasBeenCalled)) {
+  if (oldProps == nullptr
+        ? newProps->hasBeenCalled.isProvided()
+        : !newProps->hasBeenCalled.hasSameValue(oldProps->hasBeenCalled)) {
     hybridView->setHasBeenCalled(newProps->hasBeenCalled.get());
   }
-  if (oldProps == nullptr || !newProps->colorScheme.hasSameValue(oldProps->colorScheme)) {
+  if (oldProps == nullptr
+        ? newProps->colorScheme.isProvided()
+        : !newProps->colorScheme.hasSameValue(oldProps->colorScheme)) {
     hybridView->setColorScheme(newProps->colorScheme.get());
   }
-  if (oldProps == nullptr || !newProps->someCallback.hasSameValue(oldProps->someCallback)) {
+  if (oldProps == nullptr
+        ? newProps->someCallback.isProvided()
+        : !newProps->someCallback.hasSameValue(oldProps->someCallback)) {
     hybridView->setSomeCallback(newProps->someCallback.get());
   }
-  if (oldProps == nullptr || !newProps->nativeDefaultValue.hasSameValue(oldProps->nativeDefaultValue)) {
+  if (oldProps == nullptr
+        ? newProps->nativeDefaultValue.isProvided()
+        : !newProps->nativeDefaultValue.hasSameValue(oldProps->nativeDefaultValue)) {
     hybridView->setNativeDefaultValue(newProps->nativeDefaultValue.get());
   }
 
   // Update hybridRef if it changed
-  if (oldProps == nullptr || !newProps->hybridRef.hasSameValue(oldProps->hybridRef)) {
+  if (oldProps == nullptr
+        ? newProps->hybridRef.isProvided()
+        : !newProps->hybridRef.hasSameValue(oldProps->hybridRef)) {
     // hybridRef changed - call it with new this
     const auto& maybeFunc = newProps->hybridRef.get();
     if (maybeFunc.has_value()) {

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridRecyclableTestViewSpec.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridRecyclableTestViewSpec.kt
@@ -32,6 +32,12 @@ abstract class HybridRecyclableTestViewSpec: HybridView() {
   @set:DoNotStrip
   @set:Keep
   abstract var isBlue: Boolean
+  
+  @get:DoNotStrip
+  @get:Keep
+  @set:DoNotStrip
+  @set:Keep
+  abstract var nativeDefaultValue: Double?
 
   // Methods
   @DoNotStrip
@@ -45,6 +51,10 @@ abstract class HybridRecyclableTestViewSpec: HybridView() {
   @DoNotStrip
   @Keep
   abstract fun getPrepareForRecycleCount(): Double
+  
+  @DoNotStrip
+  @Keep
+  abstract fun getNativeDefaultValueSetterCallCount(): Double
 
   // Default implementation of `HybridObject.toString()`
   override fun toString(): String {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
@@ -308,6 +308,21 @@ namespace margelo::nitro::test::bridge::swift {
     return Result<std::string>::withError(error);
   }
   
+  // pragma MARK: std::optional<double>
+  /**
+   * Specialized version of `std::optional<double>`.
+   */
+  using std__optional_double_ = std::optional<double>;
+  inline std::optional<double> create_std__optional_double_(const double& value) noexcept {
+    return std::optional<double>(value);
+  }
+  inline bool has_value_std__optional_double_(const std::optional<double>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline double get_std__optional_double_(const std::optional<double>& optional) noexcept {
+    return optional.value();
+  }
+  
   // pragma MARK: std::shared_ptr<HybridRecyclableTestViewSpec>
   /**
    * Specialized version of `std::shared_ptr<HybridRecyclableTestViewSpec>`.
@@ -587,21 +602,6 @@ namespace margelo::nitro::test::bridge::swift {
     std::vector<std::vector<Person>> vector;
     vector.reserve(size);
     return vector;
-  }
-  
-  // pragma MARK: std::optional<double>
-  /**
-   * Specialized version of `std::optional<double>`.
-   */
-  using std__optional_double_ = std::optional<double>;
-  inline std::optional<double> create_std__optional_double_(const double& value) noexcept {
-    return std::optional<double>(value);
-  }
-  inline bool has_value_std__optional_double_(const std::optional<double>& optional) noexcept {
-    return optional.has_value();
-  }
-  inline double get_std__optional_double_(const std::optional<double>& optional) noexcept {
-    return optional.value();
   }
   
   // pragma MARK: std::vector<Car>

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridRecyclableTestViewSpecSwift.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridRecyclableTestViewSpecSwift.hpp
@@ -14,7 +14,7 @@ namespace NitroTest { class HybridRecyclableTestViewSpec_cxx; }
 
 
 
-
+#include <optional>
 
 #include "NitroTest-Swift-Cxx-Umbrella.hpp"
 
@@ -68,6 +68,13 @@ namespace margelo::nitro::test {
     inline void setIsBlue(bool isBlue) noexcept override {
       _swiftPart.setIsBlue(std::forward<decltype(isBlue)>(isBlue));
     }
+    inline std::optional<double> getNativeDefaultValue() noexcept override {
+      auto __result = _swiftPart.getNativeDefaultValue();
+      return __result;
+    }
+    inline void setNativeDefaultValue(std::optional<double> nativeDefaultValue) noexcept override {
+      _swiftPart.setNativeDefaultValue(nativeDefaultValue);
+    }
 
   public:
     // Methods
@@ -89,6 +96,14 @@ namespace margelo::nitro::test {
     }
     inline double getPrepareForRecycleCount() override {
       auto __result = _swiftPart.getPrepareForRecycleCount();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline double getNativeDefaultValueSetterCallCount() override {
+      auto __result = _swiftPart.getNativeDefaultValueSetterCallCount();
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridRecyclableTestViewComponent.mm
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridRecyclableTestViewComponent.mm
@@ -92,17 +92,29 @@ using namespace margelo::nitro::test::views;
   NitroTest::HybridRecyclableTestViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
 
   // 2. Update only props that differ from the previous Props snapshot.
-  const bool hasTransactionPropChanges = oldViewProps == nullptr || !newViewProps.hasSameProps(*oldViewProps);
+  const bool hasTransactionPropChanges = oldViewProps == nullptr
+      ? newViewProps.hasAnyProvidedProps()
+      : !newViewProps.hasSameProps(*oldViewProps);
   if (hasTransactionPropChanges) {
     swiftPart.beforeUpdate();
 
     // isBlue: boolean
-    if (oldViewProps == nullptr || !newViewProps.isBlue.hasSameValue(oldViewProps->isBlue)) {
+    if (oldViewProps == nullptr
+          ? newViewProps.isBlue.isProvided()
+          : !newViewProps.isBlue.hasSameValue(oldViewProps->isBlue)) {
       swiftPart.setIsBlue(newViewProps.isBlue.get());
+    }
+    // nativeDefaultValue: optional
+    if (oldViewProps == nullptr
+          ? newViewProps.nativeDefaultValue.isProvided()
+          : !newViewProps.nativeDefaultValue.hasSameValue(oldViewProps->nativeDefaultValue)) {
+      swiftPart.setNativeDefaultValue(newViewProps.nativeDefaultValue.get());
     }
 
     // Update hybridRef if it changed
-    if (oldViewProps == nullptr || !newViewProps.hybridRef.hasSameValue(oldViewProps->hybridRef)) {
+    if (oldViewProps == nullptr
+          ? newViewProps.hybridRef.isProvided()
+          : !newViewProps.hybridRef.hasSameValue(oldViewProps->hybridRef)) {
       // hybridRef changed - call it with new this
       const auto& maybeFunc = newViewProps.hybridRef.get();
       if (maybeFunc.has_value()) {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
@@ -92,33 +92,47 @@ using namespace margelo::nitro::test::views;
   NitroTest::HybridTestViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
 
   // 2. Update only props that differ from the previous Props snapshot.
-  const bool hasTransactionPropChanges = oldViewProps == nullptr || !newViewProps.hasSameProps(*oldViewProps);
+  const bool hasTransactionPropChanges = oldViewProps == nullptr
+      ? newViewProps.hasAnyProvidedProps()
+      : !newViewProps.hasSameProps(*oldViewProps);
   if (hasTransactionPropChanges) {
     swiftPart.beforeUpdate();
 
     // isBlue: boolean
-    if (oldViewProps == nullptr || !newViewProps.isBlue.hasSameValue(oldViewProps->isBlue)) {
+    if (oldViewProps == nullptr
+          ? newViewProps.isBlue.isProvided()
+          : !newViewProps.isBlue.hasSameValue(oldViewProps->isBlue)) {
       swiftPart.setIsBlue(newViewProps.isBlue.get());
     }
     // hasBeenCalled: boolean
-    if (oldViewProps == nullptr || !newViewProps.hasBeenCalled.hasSameValue(oldViewProps->hasBeenCalled)) {
+    if (oldViewProps == nullptr
+          ? newViewProps.hasBeenCalled.isProvided()
+          : !newViewProps.hasBeenCalled.hasSameValue(oldViewProps->hasBeenCalled)) {
       swiftPart.setHasBeenCalled(newViewProps.hasBeenCalled.get());
     }
     // colorScheme: enum
-    if (oldViewProps == nullptr || !newViewProps.colorScheme.hasSameValue(oldViewProps->colorScheme)) {
+    if (oldViewProps == nullptr
+          ? newViewProps.colorScheme.isProvided()
+          : !newViewProps.colorScheme.hasSameValue(oldViewProps->colorScheme)) {
       swiftPart.setColorScheme(static_cast<int>(newViewProps.colorScheme.get()));
     }
     // someCallback: function
-    if (oldViewProps == nullptr || !newViewProps.someCallback.hasSameValue(oldViewProps->someCallback)) {
+    if (oldViewProps == nullptr
+          ? newViewProps.someCallback.isProvided()
+          : !newViewProps.someCallback.hasSameValue(oldViewProps->someCallback)) {
       swiftPart.setSomeCallback(newViewProps.someCallback.get());
     }
     // nativeDefaultValue: optional
-    if (oldViewProps == nullptr || !newViewProps.nativeDefaultValue.hasSameValue(oldViewProps->nativeDefaultValue)) {
+    if (oldViewProps == nullptr
+          ? newViewProps.nativeDefaultValue.isProvided()
+          : !newViewProps.nativeDefaultValue.hasSameValue(oldViewProps->nativeDefaultValue)) {
       swiftPart.setNativeDefaultValue(newViewProps.nativeDefaultValue.get());
     }
 
     // Update hybridRef if it changed
-    if (oldViewProps == nullptr || !newViewProps.hybridRef.hasSameValue(oldViewProps->hybridRef)) {
+    if (oldViewProps == nullptr
+          ? newViewProps.hybridRef.isProvided()
+          : !newViewProps.hybridRef.hasSameValue(oldViewProps->hybridRef)) {
       // hybridRef changed - call it with new this
       const auto& maybeFunc = newViewProps.hybridRef.get();
       if (maybeFunc.has_value()) {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridRecyclableTestViewSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridRecyclableTestViewSpec.swift
@@ -11,11 +11,13 @@ import NitroModules
 public protocol HybridRecyclableTestViewSpec_protocol: HybridObject, HybridView {
   // Properties
   var isBlue: Bool { get set }
+  var nativeDefaultValue: Double? { get set }
 
   // Methods
   func getInvalidLifecycleOrderCount() throws -> Double
   func getOnDropViewCount() throws -> Double
   func getPrepareForRecycleCount() throws -> Double
+  func getNativeDefaultValueSetterCallCount() throws -> Double
 }
 
 public extension HybridRecyclableTestViewSpec_protocol {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridRecyclableTestViewSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridRecyclableTestViewSpec_cxx.swift
@@ -131,6 +131,30 @@ open class HybridRecyclableTestViewSpec_cxx {
       self.__implementation.isBlue = newValue
     }
   }
+  
+  public final var nativeDefaultValue: bridge.std__optional_double_ {
+    @inline(__always)
+    get {
+      return { () -> bridge.std__optional_double_ in
+        if let __unwrappedValue = self.__implementation.nativeDefaultValue {
+          return bridge.create_std__optional_double_(__unwrappedValue)
+        } else {
+          return .init()
+        }
+      }()
+    }
+    @inline(__always)
+    set {
+      self.__implementation.nativeDefaultValue = { () -> Double? in
+        if bridge.has_value_std__optional_double_(newValue) {
+          let __unwrapped = bridge.get_std__optional_double_(newValue)
+          return __unwrapped
+        } else {
+          return nil
+        }
+      }()
+    }
+  }
 
   // Methods
   @inline(__always)
@@ -161,6 +185,18 @@ open class HybridRecyclableTestViewSpec_cxx {
   public final func getPrepareForRecycleCount() -> bridge.Result_double_ {
     do {
       let __result = try self.__implementation.getPrepareForRecycleCount()
+      let __resultCpp = __result
+      return bridge.create_Result_double_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_double_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func getNativeDefaultValueSetterCallCount() -> bridge.Result_double_ {
+    do {
+      let __result = try self.__implementation.getNativeDefaultValueSetterCallCount()
       let __resultCpp = __result
       return bridge.create_Result_double_(__resultCpp)
     } catch (let __error) {

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridRecyclableTestViewSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridRecyclableTestViewSpec.cpp
@@ -16,9 +16,12 @@ namespace margelo::nitro::test {
     registerHybrids(this, [](Prototype& prototype) {
       prototype.registerHybridGetter("isBlue", &HybridRecyclableTestViewSpec::getIsBlue);
       prototype.registerHybridSetter("isBlue", &HybridRecyclableTestViewSpec::setIsBlue);
+      prototype.registerHybridGetter("nativeDefaultValue", &HybridRecyclableTestViewSpec::getNativeDefaultValue);
+      prototype.registerHybridSetter("nativeDefaultValue", &HybridRecyclableTestViewSpec::setNativeDefaultValue);
       prototype.registerHybridMethod("getInvalidLifecycleOrderCount", &HybridRecyclableTestViewSpec::getInvalidLifecycleOrderCount);
       prototype.registerHybridMethod("getOnDropViewCount", &HybridRecyclableTestViewSpec::getOnDropViewCount);
       prototype.registerHybridMethod("getPrepareForRecycleCount", &HybridRecyclableTestViewSpec::getPrepareForRecycleCount);
+      prototype.registerHybridMethod("getNativeDefaultValueSetterCallCount", &HybridRecyclableTestViewSpec::getNativeDefaultValueSetterCallCount);
     });
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridRecyclableTestViewSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridRecyclableTestViewSpec.hpp
@@ -15,7 +15,7 @@
 
 
 
-
+#include <optional>
 
 namespace margelo::nitro::test {
 
@@ -46,12 +46,15 @@ namespace margelo::nitro::test {
       // Properties
       virtual bool getIsBlue() = 0;
       virtual void setIsBlue(bool isBlue) = 0;
+      virtual std::optional<double> getNativeDefaultValue() = 0;
+      virtual void setNativeDefaultValue(std::optional<double> nativeDefaultValue) = 0;
 
     public:
       // Methods
       virtual double getInvalidLifecycleOrderCount() = 0;
       virtual double getOnDropViewCount() = 0;
       virtual double getPrepareForRecycleCount() = 0;
+      virtual double getNativeDefaultValueSetterCallCount() = 0;
 
     protected:
       // Hybrid Setup

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridRecyclableTestViewComponent.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridRecyclableTestViewComponent.cpp
@@ -21,11 +21,13 @@ namespace margelo::nitro::test::views {
                                                                const react::RawProps& rawProps):
     react::ViewProps(context, sourceProps, rawProps, filterObjectKeys),
     isBlue(nitro::CachedProp<bool>::fromRawValue("RecyclableTestView", "isBlue", rawProps, sourceProps.isBlue)),
+    nativeDefaultValue(nitro::CachedProp<std::optional<double>>::fromRawValue("RecyclableTestView", "nativeDefaultValue", rawProps, sourceProps.nativeDefaultValue)),
     hybridRef(nitro::CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridRecyclableTestViewSpec>& /* ref */)>>>::fromRawValue("RecyclableTestView", "hybridRef", rawProps, sourceProps.hybridRef)) { }
 
   bool HybridRecyclableTestViewProps::filterObjectKeys(const std::string& propName) {
     switch (hashString(propName)) {
       case hashString("isBlue"): return true;
+      case hashString("nativeDefaultValue"): return true;
       case hashString("hybridRef"): return true;
       default: return false;
     }

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridRecyclableTestViewComponent.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridRecyclableTestViewComponent.hpp
@@ -17,10 +17,10 @@
 
 #include <string>
 
+#include <optional>
 #include <memory>
 #include "HybridRecyclableTestViewSpec.hpp"
 #include <functional>
-#include <optional>
 
 namespace margelo::nitro::test::views {
 
@@ -43,12 +43,21 @@ namespace margelo::nitro::test::views {
 
   public:
     nitro::CachedProp<bool> isBlue;
+    nitro::CachedProp<std::optional<double>> nativeDefaultValue;
     nitro::CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridRecyclableTestViewSpec>& /* ref */)>>> hybridRef;
 
     [[nodiscard]]
     bool hasSameProps(const HybridRecyclableTestViewProps& other) const noexcept {
       return isBlue.hasSameValue(other.isBlue) &&
+             nativeDefaultValue.hasSameValue(other.nativeDefaultValue) &&
              hybridRef.hasSameValue(other.hybridRef);
+    }
+
+    [[nodiscard]]
+    bool hasAnyProvidedProps() const noexcept {
+      return isBlue.isProvided() ||
+             nativeDefaultValue.isProvided() ||
+             hybridRef.isProvided();
     }
 
   private:

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.hpp
@@ -60,6 +60,16 @@ namespace margelo::nitro::test::views {
              hybridRef.hasSameValue(other.hybridRef);
     }
 
+    [[nodiscard]]
+    bool hasAnyProvidedProps() const noexcept {
+      return isBlue.isProvided() ||
+             hasBeenCalled.isProvided() ||
+             colorScheme.isProvided() ||
+             someCallback.isProvided() ||
+             nativeDefaultValue.isProvided() ||
+             hybridRef.isProvided();
+    }
+
   private:
     static bool filterObjectKeys(const std::string& propName);
   };

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/json/RecyclableTestViewConfig.json
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/json/RecyclableTestViewConfig.json
@@ -5,6 +5,7 @@
   "directEventTypes": {},
   "validAttributes": {
     "isBlue": true,
+    "nativeDefaultValue": true,
     "hybridRef": true
   }
 }

--- a/packages/react-native-nitro-test/src/specs/RecyclableTestView.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/RecyclableTestView.nitro.ts
@@ -6,11 +6,13 @@ import type {
 
 export interface RecyclableTestViewProps extends HybridViewProps {
   isBlue: boolean
+  nativeDefaultValue?: number
 }
 export interface RecyclableTestViewMethods extends HybridViewMethods {
   getInvalidLifecycleOrderCount(): number
   getOnDropViewCount(): number
   getPrepareForRecycleCount(): number
+  getNativeDefaultValueSetterCallCount(): number
 }
 
 export type RecyclableTestView = HybridView<


### PR DESCRIPTION
## Summary

- record whether each `CachedProp` has an explicit value in its immutable shared entry
- on initial and recycled mounts, deliver only explicitly provided props and `hybridRef`
- on normal updates, continue diffing immutable entry identity against the previous native snapshot
- keep Swift and Kotlin property initialization as the source of truth for omitted native defaults, without comparing against C++ `defaultSharedProps()`
- keep `isBlue` required and cover fresh omission, explicit `0`, and recycled omission with a separate optional native-default fixture

## Validation

- workspace typecheck and lint
- deterministic Nitrogen generation
- React Native 0.85 Android arm64-v8a example build
- complete Android View Harness suite: 8 passed
- React Native 0.85 iOS simulator example build
- focused iOS View Harness test: 1 passed