### PR TITLE
test: Add Harness coverage for View prop updates

### DIFF
--- a/example/__tests__/nitro.views.harness.tsx
+++ b/example/__tests__/nitro.views.harness.tsx
@@ -296,6 +296,133 @@ describe('TestView', () => {
     expectRed(resizedCapture.pixelCoverage)
   })
 
+  it('preserves an omitted native default while applying another prop', async () => {
+    const viewRef = deferred<TestViewRef>()
+    const stableHybridRef = callback((view: TestViewRef) =>
+      viewRef.resolve(view)
+    )
+    const stableSomeCallback = callback(fn())
+    const renderResult = await render(
+      <TestView
+        testID="test-view-native-default"
+        style={INITIAL_SIZE}
+        hybridRef={stableHybridRef}
+        isBlue={false}
+        hasBeenCalled={false}
+        colorScheme="dark"
+        someCallback={stableSomeCallback}
+      />,
+      { timeout: RENDER_TIMEOUT }
+    )
+
+    const view = await viewRef.promise
+    expect(view.isBlue).toBe(false)
+    expect(view.getIsBlueSetterCallCount()).toBe(1)
+    expect(view.nativeDefaultValue).toBe(42)
+    expect(view.getNativeDefaultValueSetterCallCount()).toBe(0)
+
+    await renderResult.rerender(
+      <TestView
+        testID="test-view-native-default"
+        style={INITIAL_SIZE}
+        hybridRef={stableHybridRef}
+        isBlue={true}
+        hasBeenCalled={false}
+        colorScheme="dark"
+        someCallback={stableSomeCallback}
+      />
+    )
+
+    expect(view.isBlue).toBe(true)
+    expect(view.getIsBlueSetterCallCount()).toBe(2)
+    expect(view.nativeDefaultValue).toBe(42)
+    expect(view.getNativeDefaultValueSetterCallCount()).toBe(0)
+  })
+
+  it('only calls native setters for changed Nitro props', async () => {
+    const viewRef = deferred<TestViewRef>()
+    const stableHybridRef = callback((view: TestViewRef) =>
+      viewRef.resolve(view)
+    )
+    const stableSomeCallback = callback(fn())
+    const renderResult = await render(
+      <TestView
+        testID="test-view-setter-counts"
+        style={INITIAL_SIZE}
+        hybridRef={stableHybridRef}
+        isBlue={false}
+        hasBeenCalled={false}
+        colorScheme="dark"
+        someCallback={stableSomeCallback}
+        nativeDefaultValue={1}
+      />,
+      { timeout: RENDER_TIMEOUT }
+    )
+
+    const view = await viewRef.promise
+    expect(view.getIsBlueSetterCallCount()).toBe(1)
+    expect(view.getNativeDefaultValueSetterCallCount()).toBe(1)
+
+    await renderResult.rerender(
+      <TestView
+        testID="test-view-setter-counts"
+        style={INITIAL_SIZE}
+        hybridRef={stableHybridRef}
+        isBlue={false}
+        hasBeenCalled={false}
+        colorScheme="dark"
+        someCallback={stableSomeCallback}
+        nativeDefaultValue={2}
+      />
+    )
+
+    expect(view.isBlue).toBe(false)
+    expect(view.nativeDefaultValue).toBe(2)
+    expect(view.getIsBlueSetterCallCount()).toBe(1)
+    expect(view.getNativeDefaultValueSetterCallCount()).toBe(2)
+
+    await renderResult.rerender(
+      <TestView
+        testID="test-view-setter-counts"
+        style={INITIAL_SIZE}
+        hybridRef={stableHybridRef}
+        isBlue={true}
+        hasBeenCalled={false}
+        colorScheme="dark"
+        someCallback={stableSomeCallback}
+        nativeDefaultValue={2}
+      />
+    )
+
+    expect(view.isBlue).toBe(true)
+    expect(view.nativeDefaultValue).toBe(2)
+    expect(view.getIsBlueSetterCallCount()).toBe(2)
+    expect(view.getNativeDefaultValueSetterCallCount()).toBe(2)
+
+    const resizedLayout = deferred<LayoutRectangle>()
+    await renderResult.rerender(
+      <TestView
+        testID="test-view-setter-counts"
+        style={RESIZED_SIZE}
+        hybridRef={stableHybridRef}
+        isBlue={true}
+        hasBeenCalled={false}
+        colorScheme="dark"
+        someCallback={stableSomeCallback}
+        nativeDefaultValue={2}
+        onLayout={({ nativeEvent }) =>
+          resizedLayout.resolve(nativeEvent.layout)
+        }
+      />
+    )
+
+    const reportedResizedLayout = await resizedLayout.promise
+    expect(reportedResizedLayout.width).toBeCloseTo(RESIZED_SIZE.width, 0)
+    expect(reportedResizedLayout.height).toBeCloseTo(RESIZED_SIZE.height, 0)
+    expect(view.getIsBlueSetterCallCount()).toBe(2)
+    expect(view.getNativeDefaultValueSetterCallCount()).toBe(2)
+  })
+
   it('unmounts and creates a fresh native view when remounted', async () => {
     const firstRef = deferred<TestViewRef>()
     const renderResult = await render(

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestView.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestView.kt
@@ -14,20 +14,32 @@ class HybridTestView(
   // View
   override val view: View = View(context)
   private var onDropViewCount = 0.0
+  private var isBlueSetterCallCount = 0.0
+  private var nativeDefaultValueSetterCallCount = 0.0
 
   // Props
   override var isBlue: Boolean = false
     set(value) {
       field = value
+      isBlueSetterCallCount += 1
       val color = if (value) Color.BLUE else Color.RED
       view.setBackgroundColor(color)
     }
   override var hasBeenCalled: Boolean = false
   override var colorScheme: ColorScheme = ColorScheme.LIGHT
   override var someCallback: () -> Unit = {}
+  override var nativeDefaultValue: Double? = 42.0
+    set(value) {
+      field = value
+      nativeDefaultValueSetterCallCount += 1
+    }
 
   // Methods
   override fun getOnDropViewCount(): Double = onDropViewCount
+
+  override fun getIsBlueSetterCallCount(): Double = isBlueSetterCallCount
+
+  override fun getNativeDefaultValueSetterCallCount(): Double = nativeDefaultValueSetterCallCount
 
   override fun someMethod() {
     hasBeenCalled = true

--- a/packages/react-native-nitro-test/ios/HybridTestView.swift
+++ b/packages/react-native-nitro-test/ios/HybridTestView.swift
@@ -12,20 +12,36 @@ class HybridTestView: HybridTestViewSpec {
   // UIView
   var view: UIView = UIView()
   private var onDropViewCount: Double = 0
+  private var isBlueSetterCallCount: Double = 0
+  private var nativeDefaultValueSetterCallCount: Double = 0
 
   // Props
   var isBlue: Bool = false {
     didSet {
+      isBlueSetterCallCount += 1
       view.backgroundColor = isBlue ? .systemBlue : .systemRed
     }
   }
   var hasBeenCalled: Bool = false
   var colorScheme: ColorScheme = .light
   var someCallback: () -> Void = {}
+  var nativeDefaultValue: Double? = 42 {
+    didSet {
+      nativeDefaultValueSetterCallCount += 1
+    }
+  }
 
   // Methods
   func getOnDropViewCount() throws -> Double {
     return onDropViewCount
+  }
+
+  func getIsBlueSetterCallCount() throws -> Double {
+    return isBlueSetterCallCount
+  }
+
+  func getNativeDefaultValueSetterCallCount() throws -> Double {
+    return nativeDefaultValueSetterCallCount
   }
 
   func someMethod() throws {

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.cpp
@@ -15,6 +15,7 @@ namespace margelo::nitro::test { enum class ColorScheme; }
 #include <functional>
 #include "JFunc_void.hpp"
 #include <NitroModules/JNICallable.hpp>
+#include <optional>
 
 namespace margelo::nitro::test {
 
@@ -90,10 +91,29 @@ namespace margelo::nitro::test {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JFunc_void::javaobject> /* someCallback */)>("setSomeCallback_cxx");
     method(_javaPart, JFunc_void_cxx::fromCpp(someCallback));
   }
+  std::optional<double> JHybridTestViewSpec::getNativeDefaultValue() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JDouble>()>("getNativeDefaultValue");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(__result->value()) : std::nullopt;
+  }
+  void JHybridTestViewSpec::setNativeDefaultValue(std::optional<double> nativeDefaultValue) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JDouble> /* nativeDefaultValue */)>("setNativeDefaultValue");
+    method(_javaPart, nativeDefaultValue.has_value() ? jni::JDouble::valueOf(nativeDefaultValue.value()) : nullptr);
+  }
 
   // Methods
   double JHybridTestViewSpec::getOnDropViewCount() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getOnDropViewCount");
+    auto __result = method(_javaPart);
+    return __result;
+  }
+  double JHybridTestViewSpec::getIsBlueSetterCallCount() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getIsBlueSetterCallCount");
+    auto __result = method(_javaPart);
+    return __result;
+  }
+  double JHybridTestViewSpec::getNativeDefaultValueSetterCallCount() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getNativeDefaultValueSetterCallCount");
     auto __result = method(_javaPart);
     return __result;
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.hpp
@@ -58,10 +58,14 @@ namespace margelo::nitro::test {
     void setColorScheme(ColorScheme colorScheme) override;
     std::function<void()> getSomeCallback() override;
     void setSomeCallback(const std::function<void()>& someCallback) override;
+    std::optional<double> getNativeDefaultValue() override;
+    void setNativeDefaultValue(std::optional<double> nativeDefaultValue) override;
 
   public:
     // Methods
     double getOnDropViewCount() override;
+    double getIsBlueSetterCallCount() override;
+    double getNativeDefaultValueSetterCallCount() override;
     void someMethod() override;
 
   private:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/views/JHybridTestViewStateUpdater.cpp
@@ -65,6 +65,9 @@ void JHybridTestViewStateUpdater::updateViewProps(jni::alias_ref<jni::JClass> /*
   if (oldProps == nullptr || !newProps->someCallback.hasSameValue(oldProps->someCallback)) {
     hybridView->setSomeCallback(newProps->someCallback.get());
   }
+  if (oldProps == nullptr || !newProps->nativeDefaultValue.hasSameValue(oldProps->nativeDefaultValue)) {
+    hybridView->setNativeDefaultValue(newProps->nativeDefaultValue.get());
+  }
 
   // Update hybridRef if it changed
   if (oldProps == nullptr || !newProps->hybridRef.hasSameValue(oldProps->hybridRef)) {

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestViewSpec.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestViewSpec.kt
@@ -58,11 +58,25 @@ abstract class HybridTestViewSpec: HybridView() {
     set(value) {
       someCallback = value
     }
+  
+  @get:DoNotStrip
+  @get:Keep
+  @set:DoNotStrip
+  @set:Keep
+  abstract var nativeDefaultValue: Double?
 
   // Methods
   @DoNotStrip
   @Keep
   abstract fun getOnDropViewCount(): Double
+  
+  @DoNotStrip
+  @Keep
+  abstract fun getIsBlueSetterCallCount(): Double
+  
+  @DoNotStrip
+  @Keep
+  abstract fun getNativeDefaultValueSetterCallCount(): Double
   
   @DoNotStrip
   @Keep

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestViewSpecSwift.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestViewSpecSwift.hpp
@@ -17,6 +17,7 @@ namespace margelo::nitro::test { enum class ColorScheme; }
 
 #include "ColorScheme.hpp"
 #include <functional>
+#include <optional>
 
 #include "NitroTest-Swift-Cxx-Umbrella.hpp"
 
@@ -90,11 +91,34 @@ namespace margelo::nitro::test {
     inline void setSomeCallback(const std::function<void()>& someCallback) noexcept override {
       _swiftPart.setSomeCallback(someCallback);
     }
+    inline std::optional<double> getNativeDefaultValue() noexcept override {
+      auto __result = _swiftPart.getNativeDefaultValue();
+      return __result;
+    }
+    inline void setNativeDefaultValue(std::optional<double> nativeDefaultValue) noexcept override {
+      _swiftPart.setNativeDefaultValue(nativeDefaultValue);
+    }
 
   public:
     // Methods
     inline double getOnDropViewCount() override {
       auto __result = _swiftPart.getOnDropViewCount();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline double getIsBlueSetterCallCount() override {
+      auto __result = _swiftPart.getIsBlueSetterCallCount();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline double getNativeDefaultValueSetterCallCount() override {
+      auto __result = _swiftPart.getNativeDefaultValueSetterCallCount();
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/views/HybridTestViewComponent.mm
@@ -112,6 +112,10 @@ using namespace margelo::nitro::test::views;
     if (oldViewProps == nullptr || !newViewProps.someCallback.hasSameValue(oldViewProps->someCallback)) {
       swiftPart.setSomeCallback(newViewProps.someCallback.get());
     }
+    // nativeDefaultValue: optional
+    if (oldViewProps == nullptr || !newViewProps.nativeDefaultValue.hasSameValue(oldViewProps->nativeDefaultValue)) {
+      swiftPart.setNativeDefaultValue(newViewProps.nativeDefaultValue.get());
+    }
 
     // Update hybridRef if it changed
     if (oldViewProps == nullptr || !newViewProps.hybridRef.hasSameValue(oldViewProps->hybridRef)) {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec.swift
@@ -14,9 +14,12 @@ public protocol HybridTestViewSpec_protocol: HybridObject, HybridView {
   var hasBeenCalled: Bool { get set }
   var colorScheme: ColorScheme { get set }
   var someCallback: () -> Void { get set }
+  var nativeDefaultValue: Double? { get set }
 
   // Methods
   func getOnDropViewCount() throws -> Double
+  func getIsBlueSetterCallCount() throws -> Double
+  func getNativeDefaultValueSetterCallCount() throws -> Double
   func someMethod() throws -> Void
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec_cxx.swift
@@ -172,12 +172,60 @@ open class HybridTestViewSpec_cxx {
       }()
     }
   }
+  
+  public final var nativeDefaultValue: bridge.std__optional_double_ {
+    @inline(__always)
+    get {
+      return { () -> bridge.std__optional_double_ in
+        if let __unwrappedValue = self.__implementation.nativeDefaultValue {
+          return bridge.create_std__optional_double_(__unwrappedValue)
+        } else {
+          return .init()
+        }
+      }()
+    }
+    @inline(__always)
+    set {
+      self.__implementation.nativeDefaultValue = { () -> Double? in
+        if bridge.has_value_std__optional_double_(newValue) {
+          let __unwrapped = bridge.get_std__optional_double_(newValue)
+          return __unwrapped
+        } else {
+          return nil
+        }
+      }()
+    }
+  }
 
   // Methods
   @inline(__always)
   public final func getOnDropViewCount() -> bridge.Result_double_ {
     do {
       let __result = try self.__implementation.getOnDropViewCount()
+      let __resultCpp = __result
+      return bridge.create_Result_double_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_double_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func getIsBlueSetterCallCount() -> bridge.Result_double_ {
+    do {
+      let __result = try self.__implementation.getIsBlueSetterCallCount()
+      let __resultCpp = __result
+      return bridge.create_Result_double_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_double_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func getNativeDefaultValueSetterCallCount() -> bridge.Result_double_ {
+    do {
+      let __result = try self.__implementation.getNativeDefaultValueSetterCallCount()
       let __resultCpp = __result
       return bridge.create_Result_double_(__resultCpp)
     } catch (let __error) {

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestViewSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestViewSpec.cpp
@@ -22,7 +22,11 @@ namespace margelo::nitro::test {
       prototype.registerHybridSetter("colorScheme", &HybridTestViewSpec::setColorScheme);
       prototype.registerHybridGetter("someCallback", &HybridTestViewSpec::getSomeCallback);
       prototype.registerHybridSetter("someCallback", &HybridTestViewSpec::setSomeCallback);
+      prototype.registerHybridGetter("nativeDefaultValue", &HybridTestViewSpec::getNativeDefaultValue);
+      prototype.registerHybridSetter("nativeDefaultValue", &HybridTestViewSpec::setNativeDefaultValue);
       prototype.registerHybridMethod("getOnDropViewCount", &HybridTestViewSpec::getOnDropViewCount);
+      prototype.registerHybridMethod("getIsBlueSetterCallCount", &HybridTestViewSpec::getIsBlueSetterCallCount);
+      prototype.registerHybridMethod("getNativeDefaultValueSetterCallCount", &HybridTestViewSpec::getNativeDefaultValueSetterCallCount);
       prototype.registerHybridMethod("someMethod", &HybridTestViewSpec::someMethod);
     });
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestViewSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestViewSpec.hpp
@@ -18,6 +18,7 @@ namespace margelo::nitro::test { enum class ColorScheme; }
 
 #include "ColorScheme.hpp"
 #include <functional>
+#include <optional>
 
 namespace margelo::nitro::test {
 
@@ -54,10 +55,14 @@ namespace margelo::nitro::test {
       virtual void setColorScheme(ColorScheme colorScheme) = 0;
       virtual std::function<void()> getSomeCallback() = 0;
       virtual void setSomeCallback(const std::function<void()>& someCallback) = 0;
+      virtual std::optional<double> getNativeDefaultValue() = 0;
+      virtual void setNativeDefaultValue(std::optional<double> nativeDefaultValue) = 0;
 
     public:
       // Methods
       virtual double getOnDropViewCount() = 0;
+      virtual double getIsBlueSetterCallCount() = 0;
+      virtual double getNativeDefaultValueSetterCallCount() = 0;
       virtual void someMethod() = 0;
 
     protected:

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.cpp
@@ -24,6 +24,7 @@ namespace margelo::nitro::test::views {
     hasBeenCalled(nitro::CachedProp<bool>::fromRawValue("TestView", "hasBeenCalled", rawProps, sourceProps.hasBeenCalled)),
     colorScheme(nitro::CachedProp<ColorScheme>::fromRawValue("TestView", "colorScheme", rawProps, sourceProps.colorScheme)),
     someCallback(nitro::CachedProp<std::function<void()>>::fromRawValue("TestView", "someCallback", rawProps, sourceProps.someCallback)),
+    nativeDefaultValue(nitro::CachedProp<std::optional<double>>::fromRawValue("TestView", "nativeDefaultValue", rawProps, sourceProps.nativeDefaultValue)),
     hybridRef(nitro::CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridTestViewSpec>& /* ref */)>>>::fromRawValue("TestView", "hybridRef", rawProps, sourceProps.hybridRef)) { }
 
   bool HybridTestViewProps::filterObjectKeys(const std::string& propName) {
@@ -32,6 +33,7 @@ namespace margelo::nitro::test::views {
       case hashString("hasBeenCalled"): return true;
       case hashString("colorScheme"): return true;
       case hashString("someCallback"): return true;
+      case hashString("nativeDefaultValue"): return true;
       case hashString("hybridRef"): return true;
       default: return false;
     }

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/views/HybridTestViewComponent.hpp
@@ -19,9 +19,9 @@
 
 #include "ColorScheme.hpp"
 #include <functional>
+#include <optional>
 #include <memory>
 #include "HybridTestViewSpec.hpp"
-#include <optional>
 
 namespace margelo::nitro::test::views {
 
@@ -47,6 +47,7 @@ namespace margelo::nitro::test::views {
     nitro::CachedProp<bool> hasBeenCalled;
     nitro::CachedProp<ColorScheme> colorScheme;
     nitro::CachedProp<std::function<void()>> someCallback;
+    nitro::CachedProp<std::optional<double>> nativeDefaultValue;
     nitro::CachedProp<std::optional<std::function<void(const std::shared_ptr<HybridTestViewSpec>& /* ref */)>>> hybridRef;
 
     [[nodiscard]]
@@ -55,6 +56,7 @@ namespace margelo::nitro::test::views {
              hasBeenCalled.hasSameValue(other.hasBeenCalled) &&
              colorScheme.hasSameValue(other.colorScheme) &&
              someCallback.hasSameValue(other.someCallback) &&
+             nativeDefaultValue.hasSameValue(other.nativeDefaultValue) &&
              hybridRef.hasSameValue(other.hybridRef);
     }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/json/TestViewConfig.json
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/json/TestViewConfig.json
@@ -8,6 +8,7 @@
     "hasBeenCalled": true,
     "colorScheme": true,
     "someCallback": true,
+    "nativeDefaultValue": true,
     "hybridRef": true
   }
 }

--- a/packages/react-native-nitro-test/src/specs/TestView.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestView.nitro.ts
@@ -11,9 +11,12 @@ export interface TestViewProps extends HybridViewProps {
   hasBeenCalled: boolean
   colorScheme: ColorScheme
   someCallback: () => void
+  nativeDefaultValue?: number
 }
 export interface TestViewMethods extends HybridViewMethods {
   getOnDropViewCount(): number
+  getIsBlueSetterCallCount(): number
+  getNativeDefaultValueSetterCallCount(): number
   someMethod(): void
 }
 


### PR DESCRIPTION
## Summary

- add native setter-call counters and an optional prop whose Swift/Kotlin default is 42
- verify a fresh render preserves an omitted native default while applying another explicit prop
- verify sparse Nitro prop updates only call the setter whose prop changed
- verify a style-only rerender calls neither tested Nitro setter
- regenerate the affected Nitrogen fixtures

## Why

The existing View Harness tests validate final values and rendering, but they do not prove that omitted or unchanged props avoid the C++ to Swift/Kotlin bridge. This PR adds that behavioral coverage directly on main and is independent of the prop-update implementation stack.

This intentionally tests continued omission. Clearing a prop that was previously supplied is a different behavior and should still invoke its setter.

## Validation

- bun typecheck
- bun --cwd packages/react-native-nitro-test lint-ci
- bun --cwd example lint-ci
- bun nitro-test specs, rerun with an identical generated diff
- Android arm64-v8a example build
- Android Pixel API 35 Harness: 2 selected tests passed
- iOS Simulator example build on iPhone 16 Pro, iOS 18.4
- iOS Harness: 2 selected tests passed