### PR TITLE
test: Cover View beforeUpdate/afterUpdate transaction semantics

### DIFF
--- a/example/__tests__/nitro.views.harness.tsx
+++ b/example/__tests__/nitro.views.harness.tsx
@@ -423,6 +423,77 @@ describe('TestView', () => {
     expect(view.getNativeDefaultValueSetterCallCount()).toBe(2)
   })
 
+  it('only brackets transactions that deliver Nitro props with beforeUpdate/afterUpdate', async () => {
+    const viewRef = deferred<TestViewRef>()
+    const stableHybridRef = callback((view: TestViewRef) =>
+      viewRef.resolve(view)
+    )
+    const stableSomeCallback = callback(fn())
+    const renderResult = await render(
+      // @ts-expect-error TypeScript requires TestView's props, but plain-JS
+      // consumers can omit them all at runtime - no Nitro props are delivered.
+      <TestView testID="test-view-update-brackets" style={INITIAL_SIZE} />,
+      { timeout: RENDER_TIMEOUT }
+    )
+
+    await renderResult.rerender(
+      <TestView
+        testID="test-view-update-brackets"
+        style={INITIAL_SIZE}
+        hybridRef={stableHybridRef}
+        isBlue={false}
+        hasBeenCalled={false}
+        colorScheme="dark"
+        someCallback={stableSomeCallback}
+      />
+    )
+
+    const view = await viewRef.promise
+    // The empty mount delivered no Nitro props, so only the second render
+    // was a props transaction.
+    expect(view.getBeforeUpdateCount()).toBe(1)
+    expect(view.getAfterUpdateCount()).toBe(1)
+
+    const resizedLayout = deferred<LayoutRectangle>()
+    await renderResult.rerender(
+      <TestView
+        testID="test-view-update-brackets"
+        style={RESIZED_SIZE}
+        hybridRef={stableHybridRef}
+        isBlue={false}
+        hasBeenCalled={false}
+        colorScheme="dark"
+        someCallback={stableSomeCallback}
+        onLayout={({ nativeEvent }) =>
+          resizedLayout.resolve(nativeEvent.layout)
+        }
+      />
+    )
+
+    const reportedResizedLayout = await resizedLayout.promise
+    expect(reportedResizedLayout.width).toBeCloseTo(RESIZED_SIZE.width, 0)
+    expect(reportedResizedLayout.height).toBeCloseTo(RESIZED_SIZE.height, 0)
+    // A style-only resize changes no Nitro props - not a props transaction.
+    expect(view.getBeforeUpdateCount()).toBe(1)
+    expect(view.getAfterUpdateCount()).toBe(1)
+
+    await renderResult.rerender(
+      <TestView
+        testID="test-view-update-brackets"
+        style={RESIZED_SIZE}
+        hybridRef={stableHybridRef}
+        isBlue={true}
+        hasBeenCalled={false}
+        colorScheme="dark"
+        someCallback={stableSomeCallback}
+      />
+    )
+
+    expect(view.isBlue).toBe(true)
+    expect(view.getBeforeUpdateCount()).toBe(2)
+    expect(view.getAfterUpdateCount()).toBe(2)
+  })
+
   it('unmounts and creates a fresh native view when remounted', async () => {
     const firstRef = deferred<TestViewRef>()
     const renderResult = await render(

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestView.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestView.kt
@@ -16,6 +16,8 @@ class HybridTestView(
   private var onDropViewCount = 0.0
   private var isBlueSetterCallCount = 0.0
   private var nativeDefaultValueSetterCallCount = 0.0
+  private var beforeUpdateCount = 0.0
+  private var afterUpdateCount = 0.0
 
   // Props
   override var isBlue: Boolean = false
@@ -40,6 +42,18 @@ class HybridTestView(
   override fun getIsBlueSetterCallCount(): Double = isBlueSetterCallCount
 
   override fun getNativeDefaultValueSetterCallCount(): Double = nativeDefaultValueSetterCallCount
+
+  override fun getBeforeUpdateCount(): Double = beforeUpdateCount
+
+  override fun getAfterUpdateCount(): Double = afterUpdateCount
+
+  override fun beforeUpdate() {
+    beforeUpdateCount += 1
+  }
+
+  override fun afterUpdate() {
+    afterUpdateCount += 1
+  }
 
   override fun someMethod() {
     hasBeenCalled = true

--- a/packages/react-native-nitro-test/ios/HybridTestView.swift
+++ b/packages/react-native-nitro-test/ios/HybridTestView.swift
@@ -14,6 +14,8 @@ class HybridTestView: HybridTestViewSpec {
   private var onDropViewCount: Double = 0
   private var isBlueSetterCallCount: Double = 0
   private var nativeDefaultValueSetterCallCount: Double = 0
+  private var beforeUpdateCount: Double = 0
+  private var afterUpdateCount: Double = 0
 
   // Props
   var isBlue: Bool = false {
@@ -42,6 +44,22 @@ class HybridTestView: HybridTestViewSpec {
 
   func getNativeDefaultValueSetterCallCount() throws -> Double {
     return nativeDefaultValueSetterCallCount
+  }
+
+  func getBeforeUpdateCount() throws -> Double {
+    return beforeUpdateCount
+  }
+
+  func getAfterUpdateCount() throws -> Double {
+    return afterUpdateCount
+  }
+
+  func beforeUpdate() {
+    beforeUpdateCount += 1
+  }
+
+  func afterUpdate() {
+    afterUpdateCount += 1
   }
 
   func someMethod() throws {

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.cpp
@@ -117,6 +117,16 @@ namespace margelo::nitro::test {
     auto __result = method(_javaPart);
     return __result;
   }
+  double JHybridTestViewSpec::getBeforeUpdateCount() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getBeforeUpdateCount");
+    auto __result = method(_javaPart);
+    return __result;
+  }
+  double JHybridTestViewSpec::getAfterUpdateCount() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getAfterUpdateCount");
+    auto __result = method(_javaPart);
+    return __result;
+  }
   void JHybridTestViewSpec::someMethod() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void()>("someMethod");
     method(_javaPart);

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestViewSpec.hpp
@@ -66,6 +66,8 @@ namespace margelo::nitro::test {
     double getOnDropViewCount() override;
     double getIsBlueSetterCallCount() override;
     double getNativeDefaultValueSetterCallCount() override;
+    double getBeforeUpdateCount() override;
+    double getAfterUpdateCount() override;
     void someMethod() override;
 
   private:

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestViewSpec.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestViewSpec.kt
@@ -80,6 +80,14 @@ abstract class HybridTestViewSpec: HybridView() {
   
   @DoNotStrip
   @Keep
+  abstract fun getBeforeUpdateCount(): Double
+  
+  @DoNotStrip
+  @Keep
+  abstract fun getAfterUpdateCount(): Double
+  
+  @DoNotStrip
+  @Keep
   abstract fun someMethod(): Unit
 
   // Default implementation of `HybridObject.toString()`

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestViewSpecSwift.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestViewSpecSwift.hpp
@@ -125,6 +125,22 @@ namespace margelo::nitro::test {
       auto __value = std::move(__result.value());
       return __value;
     }
+    inline double getBeforeUpdateCount() override {
+      auto __result = _swiftPart.getBeforeUpdateCount();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline double getAfterUpdateCount() override {
+      auto __result = _swiftPart.getAfterUpdateCount();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
     inline void someMethod() override {
       auto __result = _swiftPart.someMethod();
       if (__result.hasError()) [[unlikely]] {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec.swift
@@ -20,6 +20,8 @@ public protocol HybridTestViewSpec_protocol: HybridObject, HybridView {
   func getOnDropViewCount() throws -> Double
   func getIsBlueSetterCallCount() throws -> Double
   func getNativeDefaultValueSetterCallCount() throws -> Double
+  func getBeforeUpdateCount() throws -> Double
+  func getAfterUpdateCount() throws -> Double
   func someMethod() throws -> Void
 }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec_cxx.swift
@@ -235,6 +235,30 @@ open class HybridTestViewSpec_cxx {
   }
   
   @inline(__always)
+  public final func getBeforeUpdateCount() -> bridge.Result_double_ {
+    do {
+      let __result = try self.__implementation.getBeforeUpdateCount()
+      let __resultCpp = __result
+      return bridge.create_Result_double_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_double_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func getAfterUpdateCount() -> bridge.Result_double_ {
+    do {
+      let __result = try self.__implementation.getAfterUpdateCount()
+      let __resultCpp = __result
+      return bridge.create_Result_double_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_double_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public final func someMethod() -> bridge.Result_void_ {
     do {
       try self.__implementation.someMethod()

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestViewSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestViewSpec.cpp
@@ -27,6 +27,8 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("getOnDropViewCount", &HybridTestViewSpec::getOnDropViewCount);
       prototype.registerHybridMethod("getIsBlueSetterCallCount", &HybridTestViewSpec::getIsBlueSetterCallCount);
       prototype.registerHybridMethod("getNativeDefaultValueSetterCallCount", &HybridTestViewSpec::getNativeDefaultValueSetterCallCount);
+      prototype.registerHybridMethod("getBeforeUpdateCount", &HybridTestViewSpec::getBeforeUpdateCount);
+      prototype.registerHybridMethod("getAfterUpdateCount", &HybridTestViewSpec::getAfterUpdateCount);
       prototype.registerHybridMethod("someMethod", &HybridTestViewSpec::someMethod);
     });
   }

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestViewSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestViewSpec.hpp
@@ -63,6 +63,8 @@ namespace margelo::nitro::test {
       virtual double getOnDropViewCount() = 0;
       virtual double getIsBlueSetterCallCount() = 0;
       virtual double getNativeDefaultValueSetterCallCount() = 0;
+      virtual double getBeforeUpdateCount() = 0;
+      virtual double getAfterUpdateCount() = 0;
       virtual void someMethod() = 0;
 
     protected:

--- a/packages/react-native-nitro-test/src/specs/TestView.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestView.nitro.ts
@@ -17,6 +17,8 @@ export interface TestViewMethods extends HybridViewMethods {
   getOnDropViewCount(): number
   getIsBlueSetterCallCount(): number
   getNativeDefaultValueSetterCallCount(): number
+  getBeforeUpdateCount(): number
+  getAfterUpdateCount(): number
   someMethod(): void
 }
 


### PR DESCRIPTION
## Summary

- `TestView` now counts `beforeUpdate()`/`afterUpdate()` invocations (`getBeforeUpdateCount()`/`getAfterUpdateCount()`), keeping all existing required props required
- a new Harness test asserts the pair brackets **exactly the transactions that deliver at least one Nitro prop**:
  - a mount with zero provided Nitro props (TS-suppressed, runtime-legal for plain-JS consumers) is not a props transaction
  - a style-only resize with identical Nitro props is not a props transaction
  - a changed Nitro prop is exactly one transaction

## Why

#1510 gates iOS prop delivery on `hasAnyProvidedProps()` / `hasSameProps()`, so `beforeUpdate()`/`afterUpdate()` only fire when a transaction actually delivers Nitro props - matching their doc contract ("Called right before updating props. React props are updated in a single batch/transaction.").

Android's generated `ViewManager.updateState()` still calls `beforeUpdate()`/`afterUpdate()` unconditionally on **every** state update, including zero-prop mounts and style-only rerenders. That platform asymmetry was previously invisible because no fixture counted these calls.

## Expected CI status

🔴 **This test is intentionally red on Harness Android** until the Kotlin/JNI updater gates the calls the same way iOS does (e.g. by moving the `beforeUpdate`/`afterUpdate` calls into C++ behind the same provided/changed checks). iOS behavior already matches the asserted contract.

## Validation

- workspace typecheck (all packages)
- eslint (example + react-native-nitro-test, CI settings)
- swift-format + kotlin-format (no changes)
- deterministic Nitrogen generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)