### PR TITLE
test: Pin `null` vs `undefined` shapes in array & Record elements

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -605,13 +605,26 @@ export function getTests(
       it(() =>
         testObject.bounceOptionals(
           ['hello', undefined, 'world'],
-          [new ArrayBuffer(16), undefined],
-          { a: 'b', c: undefined }
+          [new ArrayBuffer(16), undefined]
         )
       )
         .didNotThrow()
         .didReturn('object')
         .equals(['hello', undefined, 'world'])
+    ),
+    createTest('bounceNulls(...) keeps null elements', () =>
+      it(() => testObject.bounceNulls(['hello', null, 'world']))
+        .didNotThrow()
+        .didReturn('object')
+        .equals(['hello', null, 'world'])
+    ),
+    createTest(
+      'bounceOptionalNulls(...) keeps null and undefined elements',
+      () =>
+        it(() => testObject.bounceOptionalNulls(['hello', null, undefined]))
+          .didNotThrow()
+          .didReturn('object')
+          .equals(['hello', null, undefined])
     ),
     createTest('bounceEnums(...) equals', () =>
       it(() => testObject.bounceEnums(['gas', 'hybrid']))
@@ -1423,6 +1436,28 @@ export function getTests(
         .didNotThrow()
         .didReturn('object')
         .equals(TEST_MAP_3)
+    ),
+    createTest('bounceOptionalMap(map) keeps undefined values', () =>
+      it(() => testObject.bounceOptionalMap({ a: 'b', c: undefined }))
+        .didNotThrow()
+        .didReturn('object')
+        .equals({ a: 'b', c: undefined })
+    ),
+    createTest('bounceNullMap(map) keeps null values', () =>
+      it(() => testObject.bounceNullMap({ a: 'b', c: null }))
+        .didNotThrow()
+        .didReturn('object')
+        .equals({ a: 'b', c: null })
+    ),
+    createTest(
+      'bounceOptionalNullMap(map) keeps null and undefined values',
+      () =>
+        it(() =>
+          testObject.bounceOptionalNullMap({ a: 'b', b: null, c: undefined })
+        )
+          .didNotThrow()
+          .didReturn('object')
+          .equals({ a: 'b', b: null, c: undefined })
     ),
     createTest('extractMap(mapWrapper) === mapWrapper.map', () =>
       it(() =>

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
@@ -137,8 +137,15 @@ class HybridTestObjectKotlin : HybridTestObjectSwiftKotlinSpec() {
   override fun bounceOptionals(
     strings: Array<String?>,
     arrayBuffers: Array<ArrayBuffer?>,
-    map: Map<String, String?>,
   ): Array<String?> {
+    return strings
+  }
+
+  override fun bounceNulls(strings: Array<Variant_NullType_String>): Array<Variant_NullType_String> {
+    return strings
+  }
+
+  override fun bounceOptionalNulls(strings: Array<Variant_NullType_String?>): Array<Variant_NullType_String?> {
     return strings
   }
 
@@ -249,6 +256,18 @@ class HybridTestObjectKotlin : HybridTestObjectSwiftKotlinSpec() {
   }
 
   override fun bounceSimpleMap(map: Map<String, Double>): Map<String, Double> {
+    return map
+  }
+
+  override fun bounceOptionalMap(map: Map<String, String?>): Map<String, String?> {
+    return map
+  }
+
+  override fun bounceNullMap(map: Map<String, Variant_NullType_String>): Map<String, Variant_NullType_String> {
+    return map
+  }
+
+  override fun bounceOptionalNullMap(map: Map<String, Variant_NullType_String?>): Map<String, Variant_NullType_String?> {
     return map
   }
 

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
@@ -284,9 +284,33 @@ HybridTestObjectCpp::bounceArrayBuffers(const std::vector<std::shared_ptr<ArrayB
 
 std::vector<std::optional<std::string>>
 HybridTestObjectCpp::bounceOptionals(const std::vector<std::optional<std::string>>& strings,
-                                     const std::vector<std::optional<std::shared_ptr<ArrayBuffer>>>& /* arrayBuffers */,
-                                     const std::unordered_map<std::string, std::optional<std::string>>& /* map */) {
+                                     const std::vector<std::optional<std::shared_ptr<ArrayBuffer>>>& /* arrayBuffers */) {
   return strings;
+}
+
+std::vector<std::variant<nitro::NullType, std::string>>
+HybridTestObjectCpp::bounceNulls(const std::vector<std::variant<nitro::NullType, std::string>>& strings) {
+  return strings;
+}
+
+std::vector<std::optional<std::variant<nitro::NullType, std::string>>>
+HybridTestObjectCpp::bounceOptionalNulls(const std::vector<std::optional<std::variant<nitro::NullType, std::string>>>& strings) {
+  return strings;
+}
+
+std::unordered_map<std::string, std::optional<std::string>>
+HybridTestObjectCpp::bounceOptionalMap(const std::unordered_map<std::string, std::optional<std::string>>& map) {
+  return map;
+}
+
+std::unordered_map<std::string, std::variant<nitro::NullType, std::string>>
+HybridTestObjectCpp::bounceNullMap(const std::unordered_map<std::string, std::variant<nitro::NullType, std::string>>& map) {
+  return map;
+}
+
+std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>> HybridTestObjectCpp::bounceOptionalNullMap(
+    const std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>>& map) {
+  return map;
 }
 
 std::shared_ptr<AnyMap> HybridTestObjectCpp::createMap() {

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
@@ -140,11 +140,21 @@ public:
   std::vector<std::function<void()>> bounceFunctions(const std::vector<std::function<void()>>& functions) override;
   std::vector<std::shared_ptr<AnyMap>> bounceMaps(const std::vector<std::shared_ptr<AnyMap>>& maps) override;
   std::unordered_map<std::string, double> bounceSimpleMap(const std::unordered_map<std::string, double>& map) override;
+  std::unordered_map<std::string, std::optional<std::string>>
+  bounceOptionalMap(const std::unordered_map<std::string, std::optional<std::string>>& map) override;
+  std::unordered_map<std::string, std::variant<nitro::NullType, std::string>>
+  bounceNullMap(const std::unordered_map<std::string, std::variant<nitro::NullType, std::string>>& map) override;
+  std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>>
+  bounceOptionalNullMap(const std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>>& map) override;
   std::vector<std::shared_ptr<Promise<double>>> bouncePromises(const std::vector<std::shared_ptr<Promise<double>>>& promises) override;
   std::vector<std::shared_ptr<ArrayBuffer>> bounceArrayBuffers(const std::vector<std::shared_ptr<ArrayBuffer>>& arrayBuffers) override;
-  std::vector<std::optional<std::string>> bounceOptionals(const std::vector<std::optional<std::string>>& strings,
-                                                          const std::vector<std::optional<std::shared_ptr<ArrayBuffer>>>& arrayBuffers,
-                                                          const std::unordered_map<std::string, std::optional<std::string>>& map) override;
+  std::vector<std::optional<std::string>>
+  bounceOptionals(const std::vector<std::optional<std::string>>& strings,
+                  const std::vector<std::optional<std::shared_ptr<ArrayBuffer>>>& arrayBuffers) override;
+  std::vector<std::variant<nitro::NullType, std::string>>
+  bounceNulls(const std::vector<std::variant<nitro::NullType, std::string>>& strings) override;
+  std::vector<std::optional<std::variant<nitro::NullType, std::string>>>
+  bounceOptionalNulls(const std::vector<std::optional<std::variant<nitro::NullType, std::string>>>& strings) override;
 
   std::variant<OldEnum, bool> getVariantEnum(const std::variant<OldEnum, bool>& variant) override;
   std::variant<Powertrain, Car> bounceVariantUnionEnum(const std::variant<Powertrain, Car>& variant) override;

--- a/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
@@ -227,8 +227,16 @@ class HybridTestObjectSwift: HybridTestObjectSwiftKotlinSpec {
     return arrayBuffers
   }
 
-  func bounceOptionals(strings: [String?], arrayBuffers: [ArrayBuffer?], map: [String: String?])
-    throws -> [String?]
+  func bounceOptionals(strings: [String?], arrayBuffers: [ArrayBuffer?]) throws -> [String?] {
+    return strings
+  }
+
+  func bounceNulls(strings: [Variant_NullType_String]) throws -> [Variant_NullType_String] {
+    return strings
+  }
+
+  func bounceOptionalNulls(strings: [Variant_NullType_String?]) throws
+    -> [Variant_NullType_String?]
   {
     return strings
   }
@@ -333,6 +341,22 @@ class HybridTestObjectSwift: HybridTestObjectSwiftKotlinSpec {
   }
 
   func bounceSimpleMap(map: [String: Double]) throws -> [String: Double] {
+    return map
+  }
+
+  func bounceOptionalMap(map: [String: String?]) throws -> [String: String?] {
+    return map
+  }
+
+  func bounceNullMap(map: [String: Variant_NullType_String]) throws -> [String:
+    Variant_NullType_String]
+  {
+    return map
+  }
+
+  func bounceOptionalNullMap(map: [String: Variant_NullType_String?]) throws -> [String:
+    Variant_NullType_String?]
+  {
     return map
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -726,8 +726,8 @@ namespace margelo::nitro::test {
       return __vector;
     }(__result);
   }
-  std::vector<std::optional<std::string>> JHybridTestObjectSwiftKotlinSpec::bounceOptionals(const std::vector<std::optional<std::string>>& strings, const std::vector<std::optional<std::shared_ptr<ArrayBuffer>>>& arrayBuffers, const std::unordered_map<std::string, std::optional<std::string>>& map) {
-    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<jni::JString>>(jni::alias_ref<jni::JArrayClass<jni::JString>> /* strings */, jni::alias_ref<jni::JArrayClass<JArrayBuffer::javaobject>> /* arrayBuffers */, jni::alias_ref<jni::JMap<jni::JString, jni::JString>> /* map */)>("bounceOptionals");
+  std::vector<std::optional<std::string>> JHybridTestObjectSwiftKotlinSpec::bounceOptionals(const std::vector<std::optional<std::string>>& strings, const std::vector<std::optional<std::shared_ptr<ArrayBuffer>>>& arrayBuffers) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<jni::JString>>(jni::alias_ref<jni::JArrayClass<jni::JString>> /* strings */, jni::alias_ref<jni::JArrayClass<JArrayBuffer::javaobject>> /* arrayBuffers */)>("bounceOptionals");
     auto __result = method(_javaPart, [&](auto&& __input) {
       size_t __size = __input.size();
       jni::local_ref<jni::JArrayClass<jni::JString>> __array = jni::JArrayClass<jni::JString>::newArray(__size);
@@ -746,13 +746,7 @@ namespace margelo::nitro::test {
         __array->setElement(__i, __elementJni.get());
       }
       return __array;
-    }(arrayBuffers), [&]() -> jni::local_ref<jni::JMap<jni::JString, jni::JString>> {
-      auto __map = jni::JHashMap<jni::JString, jni::JString>::create(map.size());
-      for (const auto& __entry : map) {
-        __map->put(jni::make_jstring(__entry.first), __entry.second.has_value() ? jni::make_jstring(__entry.second.value()) : nullptr);
-      }
-      return __map;
-    }());
+    }(arrayBuffers));
     return [&](auto&& __input) {
       size_t __size = __input->size();
       std::vector<std::optional<std::string>> __vector;
@@ -760,6 +754,52 @@ namespace margelo::nitro::test {
       for (size_t __i = 0; __i < __size; __i++) {
         auto __element = __input->getElement(__i);
         __vector.push_back(__element != nullptr ? std::make_optional(__element->toStdString()) : std::nullopt);
+      }
+      return __vector;
+    }(__result);
+  }
+  std::vector<std::variant<nitro::NullType, std::string>> JHybridTestObjectSwiftKotlinSpec::bounceNulls(const std::vector<std::variant<nitro::NullType, std::string>>& strings) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<JVariant_NullType_String>>(jni::alias_ref<jni::JArrayClass<JVariant_NullType_String>> /* strings */)>("bounceNulls");
+    auto __result = method(_javaPart, [&](auto&& __input) {
+      size_t __size = __input.size();
+      jni::local_ref<jni::JArrayClass<JVariant_NullType_String>> __array = jni::JArrayClass<JVariant_NullType_String>::newArray(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        const auto& __element = __input[__i];
+        auto __elementJni = JVariant_NullType_String::fromCpp(__element);
+        __array->setElement(__i, *__elementJni);
+      }
+      return __array;
+    }(strings));
+    return [&](auto&& __input) {
+      size_t __size = __input->size();
+      std::vector<std::variant<nitro::NullType, std::string>> __vector;
+      __vector.reserve(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        auto __element = __input->getElement(__i);
+        __vector.push_back(__element->toCpp());
+      }
+      return __vector;
+    }(__result);
+  }
+  std::vector<std::optional<std::variant<nitro::NullType, std::string>>> JHybridTestObjectSwiftKotlinSpec::bounceOptionalNulls(const std::vector<std::optional<std::variant<nitro::NullType, std::string>>>& strings) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<JVariant_NullType_String>>(jni::alias_ref<jni::JArrayClass<JVariant_NullType_String>> /* strings */)>("bounceOptionalNulls");
+    auto __result = method(_javaPart, [&](auto&& __input) {
+      size_t __size = __input.size();
+      jni::local_ref<jni::JArrayClass<JVariant_NullType_String>> __array = jni::JArrayClass<JVariant_NullType_String>::newArray(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        const auto& __element = __input[__i];
+        auto __elementJni = __element.has_value() ? JVariant_NullType_String::fromCpp(__element.value()) : nullptr;
+        __array->setElement(__i, *__elementJni);
+      }
+      return __array;
+    }(strings));
+    return [&](auto&& __input) {
+      size_t __size = __input->size();
+      std::vector<std::optional<std::variant<nitro::NullType, std::string>>> __vector;
+      __vector.reserve(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        auto __element = __input->getElement(__i);
+        __vector.push_back(__element != nullptr ? std::make_optional(__element->toCpp()) : std::nullopt);
       }
       return __vector;
     }(__result);
@@ -830,6 +870,60 @@ namespace margelo::nitro::test {
       __map.reserve(__result->size());
       for (const auto& __entry : *__result) {
         __map.emplace(__entry.first->toStdString(), __entry.second->value());
+      }
+      return __map;
+    }();
+  }
+  std::unordered_map<std::string, std::optional<std::string>> JHybridTestObjectSwiftKotlinSpec::bounceOptionalMap(const std::unordered_map<std::string, std::optional<std::string>>& map) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JMap<jni::JString, jni::JString>>(jni::alias_ref<jni::JMap<jni::JString, jni::JString>> /* map */)>("bounceOptionalMap");
+    auto __result = method(_javaPart, [&]() -> jni::local_ref<jni::JMap<jni::JString, jni::JString>> {
+      auto __map = jni::JHashMap<jni::JString, jni::JString>::create(map.size());
+      for (const auto& __entry : map) {
+        __map->put(jni::make_jstring(__entry.first), __entry.second.has_value() ? jni::make_jstring(__entry.second.value()) : nullptr);
+      }
+      return __map;
+    }());
+    return [&]() {
+      std::unordered_map<std::string, std::optional<std::string>> __map;
+      __map.reserve(__result->size());
+      for (const auto& __entry : *__result) {
+        __map.emplace(__entry.first->toStdString(), __entry.second != nullptr ? std::make_optional(__entry.second->toStdString()) : std::nullopt);
+      }
+      return __map;
+    }();
+  }
+  std::unordered_map<std::string, std::variant<nitro::NullType, std::string>> JHybridTestObjectSwiftKotlinSpec::bounceNullMap(const std::unordered_map<std::string, std::variant<nitro::NullType, std::string>>& map) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JMap<jni::JString, JVariant_NullType_String>>(jni::alias_ref<jni::JMap<jni::JString, JVariant_NullType_String>> /* map */)>("bounceNullMap");
+    auto __result = method(_javaPart, [&]() -> jni::local_ref<jni::JMap<jni::JString, JVariant_NullType_String>> {
+      auto __map = jni::JHashMap<jni::JString, JVariant_NullType_String>::create(map.size());
+      for (const auto& __entry : map) {
+        __map->put(jni::make_jstring(__entry.first), JVariant_NullType_String::fromCpp(__entry.second));
+      }
+      return __map;
+    }());
+    return [&]() {
+      std::unordered_map<std::string, std::variant<nitro::NullType, std::string>> __map;
+      __map.reserve(__result->size());
+      for (const auto& __entry : *__result) {
+        __map.emplace(__entry.first->toStdString(), __entry.second->toCpp());
+      }
+      return __map;
+    }();
+  }
+  std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>> JHybridTestObjectSwiftKotlinSpec::bounceOptionalNullMap(const std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>>& map) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JMap<jni::JString, JVariant_NullType_String>>(jni::alias_ref<jni::JMap<jni::JString, JVariant_NullType_String>> /* map */)>("bounceOptionalNullMap");
+    auto __result = method(_javaPart, [&]() -> jni::local_ref<jni::JMap<jni::JString, JVariant_NullType_String>> {
+      auto __map = jni::JHashMap<jni::JString, JVariant_NullType_String>::create(map.size());
+      for (const auto& __entry : map) {
+        __map->put(jni::make_jstring(__entry.first), __entry.second.has_value() ? JVariant_NullType_String::fromCpp(__entry.second.value()) : nullptr);
+      }
+      return __map;
+    }());
+    return [&]() {
+      std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>> __map;
+      __map.reserve(__result->size());
+      for (const auto& __entry : *__result) {
+        __map.emplace(__entry.first->toStdString(), __entry.second != nullptr ? std::make_optional(__entry.second->toCpp()) : std::nullopt);
       }
       return __map;
     }();

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -113,7 +113,9 @@ namespace margelo::nitro::test {
     std::vector<std::shared_ptr<AnyMap>> bounceMaps(const std::vector<std::shared_ptr<AnyMap>>& maps) override;
     std::vector<std::shared_ptr<Promise<double>>> bouncePromises(const std::vector<std::shared_ptr<Promise<double>>>& promises) override;
     std::vector<std::shared_ptr<ArrayBuffer>> bounceArrayBuffers(const std::vector<std::shared_ptr<ArrayBuffer>>& arrayBuffers) override;
-    std::vector<std::optional<std::string>> bounceOptionals(const std::vector<std::optional<std::string>>& strings, const std::vector<std::optional<std::shared_ptr<ArrayBuffer>>>& arrayBuffers, const std::unordered_map<std::string, std::optional<std::string>>& map) override;
+    std::vector<std::optional<std::string>> bounceOptionals(const std::vector<std::optional<std::string>>& strings, const std::vector<std::optional<std::shared_ptr<ArrayBuffer>>>& arrayBuffers) override;
+    std::vector<std::variant<nitro::NullType, std::string>> bounceNulls(const std::vector<std::variant<nitro::NullType, std::string>>& strings) override;
+    std::vector<std::optional<std::variant<nitro::NullType, std::string>>> bounceOptionalNulls(const std::vector<std::optional<std::variant<nitro::NullType, std::string>>>& strings) override;
     std::shared_ptr<AnyMap> createMap() override;
     std::shared_ptr<AnyMap> mapRoundtrip(const std::shared_ptr<AnyMap>& map) override;
     std::vector<std::string> getMapKeys(const std::shared_ptr<AnyMap>& map) override;
@@ -121,6 +123,9 @@ namespace margelo::nitro::test {
     std::shared_ptr<AnyMap> copyAnyMap(const std::shared_ptr<AnyMap>& map) override;
     std::unordered_map<std::string, std::variant<bool, double>> bounceMap(const std::unordered_map<std::string, std::variant<bool, double>>& map) override;
     std::unordered_map<std::string, double> bounceSimpleMap(const std::unordered_map<std::string, double>& map) override;
+    std::unordered_map<std::string, std::optional<std::string>> bounceOptionalMap(const std::unordered_map<std::string, std::optional<std::string>>& map) override;
+    std::unordered_map<std::string, std::variant<nitro::NullType, std::string>> bounceNullMap(const std::unordered_map<std::string, std::variant<nitro::NullType, std::string>>& map) override;
+    std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>> bounceOptionalNullMap(const std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>>& map) override;
     std::unordered_map<std::string, std::string> extractMap(const MapWrapper& mapWrapper) override;
     double funcThatThrows() override;
     std::shared_ptr<Promise<void>> funcThatThrowsBeforePromise() override;

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec.kt
@@ -264,7 +264,15 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  abstract fun bounceOptionals(strings: Array<String?>, arrayBuffers: Array<ArrayBuffer?>, map: Map<String, String?>): Array<String?>
+  abstract fun bounceOptionals(strings: Array<String?>, arrayBuffers: Array<ArrayBuffer?>): Array<String?>
+  
+  @DoNotStrip
+  @Keep
+  abstract fun bounceNulls(strings: Array<Variant_NullType_String>): Array<Variant_NullType_String>
+  
+  @DoNotStrip
+  @Keep
+  abstract fun bounceOptionalNulls(strings: Array<Variant_NullType_String?>): Array<Variant_NullType_String?>
   
   @DoNotStrip
   @Keep
@@ -293,6 +301,18 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   abstract fun bounceSimpleMap(map: Map<String, Double>): Map<String, Double>
+  
+  @DoNotStrip
+  @Keep
+  abstract fun bounceOptionalMap(map: Map<String, String?>): Map<String, String?>
+  
+  @DoNotStrip
+  @Keep
+  abstract fun bounceNullMap(map: Map<String, Variant_NullType_String>): Map<String, Variant_NullType_String>
+  
+  @DoNotStrip
+  @Keep
+  abstract fun bounceOptionalNullMap(map: Map<String, Variant_NullType_String?>): Map<String, Variant_NullType_String?>
   
   @DoNotStrip
   @Keep

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/NitroTest-Swift-Cxx-Bridge.hpp
@@ -774,29 +774,41 @@ namespace margelo::nitro::test::bridge::swift {
     return vector;
   }
   
-  // pragma MARK: std::unordered_map<std::string, std::optional<std::string>>
+  // pragma MARK: std::vector<std::variant<nitro::NullType, std::string>>
   /**
-   * Specialized version of `std::unordered_map<std::string, std::optional<std::string>>`.
+   * Specialized version of `std::vector<std::variant<nitro::NullType, std::string>>`.
    */
-  using std__unordered_map_std__string__std__optional_std__string__ = std::unordered_map<std::string, std::optional<std::string>>;
-  inline std::unordered_map<std::string, std::optional<std::string>> create_std__unordered_map_std__string__std__optional_std__string__(size_t size) noexcept {
-    std::unordered_map<std::string, std::optional<std::string>> map;
-    map.reserve(size);
-    return map;
+  using std__vector_std__variant_nitro__NullType__std__string__ = std::vector<std::variant<nitro::NullType, std::string>>;
+  inline std::vector<std::variant<nitro::NullType, std::string>> create_std__vector_std__variant_nitro__NullType__std__string__(size_t size) noexcept {
+    std::vector<std::variant<nitro::NullType, std::string>> vector;
+    vector.reserve(size);
+    return vector;
   }
-  inline std::vector<std::string> get_std__unordered_map_std__string__std__optional_std__string___keys(const std__unordered_map_std__string__std__optional_std__string__& map) noexcept {
-    std::vector<std::string> keys;
-    keys.reserve(map.size());
-    for (const auto& entry : map) {
-      keys.push_back(entry.first);
-    }
-    return keys;
+  
+  // pragma MARK: std::optional<std::variant<nitro::NullType, std::string>>
+  /**
+   * Specialized version of `std::optional<std::variant<nitro::NullType, std::string>>`.
+   */
+  using std__optional_std__variant_nitro__NullType__std__string__ = std::optional<std::variant<nitro::NullType, std::string>>;
+  inline std::optional<std::variant<nitro::NullType, std::string>> create_std__optional_std__variant_nitro__NullType__std__string__(const std::variant<nitro::NullType, std::string>& value) noexcept {
+    return std::optional<std::variant<nitro::NullType, std::string>>(value);
   }
-  inline std::optional<std::string> get_std__unordered_map_std__string__std__optional_std__string___value(const std__unordered_map_std__string__std__optional_std__string__& map, const std::string& key) noexcept {
-    return map.find(key)->second;
+  inline bool has_value_std__optional_std__variant_nitro__NullType__std__string__(const std::optional<std::variant<nitro::NullType, std::string>>& optional) noexcept {
+    return optional.has_value();
   }
-  inline void emplace_std__unordered_map_std__string__std__optional_std__string__(std__unordered_map_std__string__std__optional_std__string__& map, const std::string& key, const std::optional<std::string>& value) noexcept {
-    map.emplace(key, value);
+  inline std::variant<nitro::NullType, std::string> get_std__optional_std__variant_nitro__NullType__std__string__(const std::optional<std::variant<nitro::NullType, std::string>>& optional) noexcept {
+    return optional.value();
+  }
+  
+  // pragma MARK: std::vector<std::optional<std::variant<nitro::NullType, std::string>>>
+  /**
+   * Specialized version of `std::vector<std::optional<std::variant<nitro::NullType, std::string>>>`.
+   */
+  using std__vector_std__optional_std__variant_nitro__NullType__std__string___ = std::vector<std::optional<std::variant<nitro::NullType, std::string>>>;
+  inline std::vector<std::optional<std::variant<nitro::NullType, std::string>>> create_std__vector_std__optional_std__variant_nitro__NullType__std__string___(size_t size) noexcept {
+    std::vector<std::optional<std::variant<nitro::NullType, std::string>>> vector;
+    vector.reserve(size);
+    return vector;
   }
   
   // pragma MARK: std::variant<bool, double>
@@ -875,6 +887,81 @@ namespace margelo::nitro::test::bridge::swift {
     return map.find(key)->second;
   }
   inline void emplace_std__unordered_map_std__string__double_(std__unordered_map_std__string__double_& map, const std::string& key, const double& value) noexcept {
+    map.emplace(key, value);
+  }
+  
+  // pragma MARK: std::unordered_map<std::string, std::optional<std::string>>
+  /**
+   * Specialized version of `std::unordered_map<std::string, std::optional<std::string>>`.
+   */
+  using std__unordered_map_std__string__std__optional_std__string__ = std::unordered_map<std::string, std::optional<std::string>>;
+  inline std::unordered_map<std::string, std::optional<std::string>> create_std__unordered_map_std__string__std__optional_std__string__(size_t size) noexcept {
+    std::unordered_map<std::string, std::optional<std::string>> map;
+    map.reserve(size);
+    return map;
+  }
+  inline std::vector<std::string> get_std__unordered_map_std__string__std__optional_std__string___keys(const std__unordered_map_std__string__std__optional_std__string__& map) noexcept {
+    std::vector<std::string> keys;
+    keys.reserve(map.size());
+    for (const auto& entry : map) {
+      keys.push_back(entry.first);
+    }
+    return keys;
+  }
+  inline std::optional<std::string> get_std__unordered_map_std__string__std__optional_std__string___value(const std__unordered_map_std__string__std__optional_std__string__& map, const std::string& key) noexcept {
+    return map.find(key)->second;
+  }
+  inline void emplace_std__unordered_map_std__string__std__optional_std__string__(std__unordered_map_std__string__std__optional_std__string__& map, const std::string& key, const std::optional<std::string>& value) noexcept {
+    map.emplace(key, value);
+  }
+  
+  // pragma MARK: std::unordered_map<std::string, std::variant<nitro::NullType, std::string>>
+  /**
+   * Specialized version of `std::unordered_map<std::string, std::variant<nitro::NullType, std::string>>`.
+   */
+  using std__unordered_map_std__string__std__variant_nitro__NullType__std__string__ = std::unordered_map<std::string, std::variant<nitro::NullType, std::string>>;
+  inline std::unordered_map<std::string, std::variant<nitro::NullType, std::string>> create_std__unordered_map_std__string__std__variant_nitro__NullType__std__string__(size_t size) noexcept {
+    std::unordered_map<std::string, std::variant<nitro::NullType, std::string>> map;
+    map.reserve(size);
+    return map;
+  }
+  inline std::vector<std::string> get_std__unordered_map_std__string__std__variant_nitro__NullType__std__string___keys(const std__unordered_map_std__string__std__variant_nitro__NullType__std__string__& map) noexcept {
+    std::vector<std::string> keys;
+    keys.reserve(map.size());
+    for (const auto& entry : map) {
+      keys.push_back(entry.first);
+    }
+    return keys;
+  }
+  inline std::variant<nitro::NullType, std::string> get_std__unordered_map_std__string__std__variant_nitro__NullType__std__string___value(const std__unordered_map_std__string__std__variant_nitro__NullType__std__string__& map, const std::string& key) noexcept {
+    return map.find(key)->second;
+  }
+  inline void emplace_std__unordered_map_std__string__std__variant_nitro__NullType__std__string__(std__unordered_map_std__string__std__variant_nitro__NullType__std__string__& map, const std::string& key, const std::variant<nitro::NullType, std::string>& value) noexcept {
+    map.emplace(key, value);
+  }
+  
+  // pragma MARK: std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>>
+  /**
+   * Specialized version of `std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>>`.
+   */
+  using std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string___ = std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>>;
+  inline std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>> create_std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string___(size_t size) noexcept {
+    std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>> map;
+    map.reserve(size);
+    return map;
+  }
+  inline std::vector<std::string> get_std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string____keys(const std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string___& map) noexcept {
+    std::vector<std::string> keys;
+    keys.reserve(map.size());
+    for (const auto& entry : map) {
+      keys.push_back(entry.first);
+    }
+    return keys;
+  }
+  inline std::optional<std::variant<nitro::NullType, std::string>> get_std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string____value(const std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string___& map, const std::string& key) noexcept {
+    return map.find(key)->second;
+  }
+  inline void emplace_std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string___(std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string___& map, const std::string& key, const std::optional<std::variant<nitro::NullType, std::string>>& value) noexcept {
     map.emplace(key, value);
   }
   
@@ -1884,6 +1971,24 @@ namespace margelo::nitro::test::bridge::swift {
     return Result<std::vector<std::optional<std::string>>>::withError(error);
   }
   
+  // pragma MARK: Result<std::vector<std::variant<nitro::NullType, std::string>>>
+  using Result_std__vector_std__variant_nitro__NullType__std__string___ = Result<std::vector<std::variant<nitro::NullType, std::string>>>;
+  inline Result_std__vector_std__variant_nitro__NullType__std__string___ create_Result_std__vector_std__variant_nitro__NullType__std__string___(const std::vector<std::variant<nitro::NullType, std::string>>& value) noexcept {
+    return Result<std::vector<std::variant<nitro::NullType, std::string>>>::withValue(value);
+  }
+  inline Result_std__vector_std__variant_nitro__NullType__std__string___ create_Result_std__vector_std__variant_nitro__NullType__std__string___(const std::exception_ptr& error) noexcept {
+    return Result<std::vector<std::variant<nitro::NullType, std::string>>>::withError(error);
+  }
+  
+  // pragma MARK: Result<std::vector<std::optional<std::variant<nitro::NullType, std::string>>>>
+  using Result_std__vector_std__optional_std__variant_nitro__NullType__std__string____ = Result<std::vector<std::optional<std::variant<nitro::NullType, std::string>>>>;
+  inline Result_std__vector_std__optional_std__variant_nitro__NullType__std__string____ create_Result_std__vector_std__optional_std__variant_nitro__NullType__std__string____(const std::vector<std::optional<std::variant<nitro::NullType, std::string>>>& value) noexcept {
+    return Result<std::vector<std::optional<std::variant<nitro::NullType, std::string>>>>::withValue(value);
+  }
+  inline Result_std__vector_std__optional_std__variant_nitro__NullType__std__string____ create_Result_std__vector_std__optional_std__variant_nitro__NullType__std__string____(const std::exception_ptr& error) noexcept {
+    return Result<std::vector<std::optional<std::variant<nitro::NullType, std::string>>>>::withError(error);
+  }
+  
   // pragma MARK: Result<std::shared_ptr<AnyMap>>
   using Result_std__shared_ptr_AnyMap__ = Result<std::shared_ptr<AnyMap>>;
   inline Result_std__shared_ptr_AnyMap__ create_Result_std__shared_ptr_AnyMap__(const std::shared_ptr<AnyMap>& value) noexcept {
@@ -1909,6 +2014,33 @@ namespace margelo::nitro::test::bridge::swift {
   }
   inline Result_std__unordered_map_std__string__double__ create_Result_std__unordered_map_std__string__double__(const std::exception_ptr& error) noexcept {
     return Result<std::unordered_map<std::string, double>>::withError(error);
+  }
+  
+  // pragma MARK: Result<std::unordered_map<std::string, std::optional<std::string>>>
+  using Result_std__unordered_map_std__string__std__optional_std__string___ = Result<std::unordered_map<std::string, std::optional<std::string>>>;
+  inline Result_std__unordered_map_std__string__std__optional_std__string___ create_Result_std__unordered_map_std__string__std__optional_std__string___(const std::unordered_map<std::string, std::optional<std::string>>& value) noexcept {
+    return Result<std::unordered_map<std::string, std::optional<std::string>>>::withValue(value);
+  }
+  inline Result_std__unordered_map_std__string__std__optional_std__string___ create_Result_std__unordered_map_std__string__std__optional_std__string___(const std::exception_ptr& error) noexcept {
+    return Result<std::unordered_map<std::string, std::optional<std::string>>>::withError(error);
+  }
+  
+  // pragma MARK: Result<std::unordered_map<std::string, std::variant<nitro::NullType, std::string>>>
+  using Result_std__unordered_map_std__string__std__variant_nitro__NullType__std__string___ = Result<std::unordered_map<std::string, std::variant<nitro::NullType, std::string>>>;
+  inline Result_std__unordered_map_std__string__std__variant_nitro__NullType__std__string___ create_Result_std__unordered_map_std__string__std__variant_nitro__NullType__std__string___(const std::unordered_map<std::string, std::variant<nitro::NullType, std::string>>& value) noexcept {
+    return Result<std::unordered_map<std::string, std::variant<nitro::NullType, std::string>>>::withValue(value);
+  }
+  inline Result_std__unordered_map_std__string__std__variant_nitro__NullType__std__string___ create_Result_std__unordered_map_std__string__std__variant_nitro__NullType__std__string___(const std::exception_ptr& error) noexcept {
+    return Result<std::unordered_map<std::string, std::variant<nitro::NullType, std::string>>>::withError(error);
+  }
+  
+  // pragma MARK: Result<std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>>>
+  using Result_std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string____ = Result<std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>>>;
+  inline Result_std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string____ create_Result_std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string____(const std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>>& value) noexcept {
+    return Result<std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>>>::withValue(value);
+  }
+  inline Result_std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string____ create_Result_std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string____(const std::exception_ptr& error) noexcept {
+    return Result<std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>>>::withError(error);
   }
   
   // pragma MARK: Result<std::unordered_map<std::string, std::string>>

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -434,8 +434,24 @@ namespace margelo::nitro::test {
       auto __value = std::move(__result.value());
       return __value;
     }
-    inline std::vector<std::optional<std::string>> bounceOptionals(const std::vector<std::optional<std::string>>& strings, const std::vector<std::optional<std::shared_ptr<ArrayBuffer>>>& arrayBuffers, const std::unordered_map<std::string, std::optional<std::string>>& map) override {
-      auto __result = _swiftPart.bounceOptionals(strings, arrayBuffers, map);
+    inline std::vector<std::optional<std::string>> bounceOptionals(const std::vector<std::optional<std::string>>& strings, const std::vector<std::optional<std::shared_ptr<ArrayBuffer>>>& arrayBuffers) override {
+      auto __result = _swiftPart.bounceOptionals(strings, arrayBuffers);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline std::vector<std::variant<nitro::NullType, std::string>> bounceNulls(const std::vector<std::variant<nitro::NullType, std::string>>& strings) override {
+      auto __result = _swiftPart.bounceNulls(strings);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline std::vector<std::optional<std::variant<nitro::NullType, std::string>>> bounceOptionalNulls(const std::vector<std::optional<std::variant<nitro::NullType, std::string>>>& strings) override {
+      auto __result = _swiftPart.bounceOptionalNulls(strings);
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }
@@ -492,6 +508,30 @@ namespace margelo::nitro::test {
     }
     inline std::unordered_map<std::string, double> bounceSimpleMap(const std::unordered_map<std::string, double>& map) override {
       auto __result = _swiftPart.bounceSimpleMap(map);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline std::unordered_map<std::string, std::optional<std::string>> bounceOptionalMap(const std::unordered_map<std::string, std::optional<std::string>>& map) override {
+      auto __result = _swiftPart.bounceOptionalMap(map);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline std::unordered_map<std::string, std::variant<nitro::NullType, std::string>> bounceNullMap(const std::unordered_map<std::string, std::variant<nitro::NullType, std::string>>& map) override {
+      auto __result = _swiftPart.bounceNullMap(map);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>> bounceOptionalNullMap(const std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>>& map) override {
+      auto __result = _swiftPart.bounceOptionalNullMap(map);
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -55,7 +55,9 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: HybridObject {
   func bounceMaps(maps: [AnyMap]) throws -> [AnyMap]
   func bouncePromises(promises: [Promise<Double>]) throws -> [Promise<Double>]
   func bounceArrayBuffers(arrayBuffers: [ArrayBuffer]) throws -> [ArrayBuffer]
-  func bounceOptionals(strings: [String?], arrayBuffers: [ArrayBuffer?], map: Dictionary<String, String?>) throws -> [String?]
+  func bounceOptionals(strings: [String?], arrayBuffers: [ArrayBuffer?]) throws -> [String?]
+  func bounceNulls(strings: [Variant_NullType_String]) throws -> [Variant_NullType_String]
+  func bounceOptionalNulls(strings: [Variant_NullType_String?]) throws -> [Variant_NullType_String?]
   func createMap() throws -> AnyMap
   func mapRoundtrip(map: AnyMap) throws -> AnyMap
   func getMapKeys(map: AnyMap) throws -> [String]
@@ -63,6 +65,9 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: HybridObject {
   func copyAnyMap(map: AnyMap) throws -> AnyMap
   func bounceMap(map: Dictionary<String, Variant_Bool_Double>) throws -> Dictionary<String, Variant_Bool_Double>
   func bounceSimpleMap(map: Dictionary<String, Double>) throws -> Dictionary<String, Double>
+  func bounceOptionalMap(map: Dictionary<String, String?>) throws -> Dictionary<String, String?>
+  func bounceNullMap(map: Dictionary<String, Variant_NullType_String>) throws -> Dictionary<String, Variant_NullType_String>
+  func bounceOptionalNullMap(map: Dictionary<String, Variant_NullType_String?>) throws -> Dictionary<String, Variant_NullType_String?>
   func extractMap(mapWrapper: MapWrapper) throws -> Dictionary<String, String>
   func funcThatThrows() throws -> Double
   func funcThatThrowsBeforePromise() throws -> Promise<Void>

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -895,7 +895,7 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
   }
   
   @inline(__always)
-  public final func bounceOptionals(strings: bridge.std__vector_std__optional_std__string__, arrayBuffers: bridge.std__vector_std__optional_std__shared_ptr_ArrayBuffer___, map: bridge.std__unordered_map_std__string__std__optional_std__string__) -> bridge.Result_std__vector_std__optional_std__string___ {
+  public final func bounceOptionals(strings: bridge.std__vector_std__optional_std__string__, arrayBuffers: bridge.std__vector_std__optional_std__shared_ptr_ArrayBuffer___) -> bridge.Result_std__vector_std__optional_std__string___ {
     do {
       let __result = try self.__implementation.bounceOptionals(strings: strings.map({ __item in { () -> String? in
         if bridge.has_value_std__optional_std__string_(__item) {
@@ -911,22 +911,7 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
         } else {
           return nil
         }
-      }() }), map: { () -> Dictionary<String, String?> in
-        var __dictionary = Dictionary<String, String?>(minimumCapacity: map.size())
-        let __keys = bridge.get_std__unordered_map_std__string__std__optional_std__string___keys(map)
-        for __key in __keys {
-          let __value = bridge.get_std__unordered_map_std__string__std__optional_std__string___value(map, __key)
-          __dictionary[String(__key)] = { () -> String? in
-            if bridge.has_value_std__optional_std__string_(__value) {
-              let __unwrapped = bridge.get_std__optional_std__string_(__value)
-              return String(__unwrapped)
-            } else {
-              return nil
-            }
-          }()
-        }
-        return __dictionary
-      }())
+      }() }))
       let __resultCpp = { () -> bridge.std__vector_std__optional_std__string__ in
         var __vector = bridge.create_std__vector_std__optional_std__string__(__result.count)
         for __item in __result {
@@ -944,6 +929,93 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
     } catch (let __error) {
       let __exceptionPtr = __error.toCpp()
       return bridge.create_Result_std__vector_std__optional_std__string___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func bounceNulls(strings: bridge.std__vector_std__variant_nitro__NullType__std__string__) -> bridge.Result_std__vector_std__variant_nitro__NullType__std__string___ {
+    do {
+      let __result = try self.__implementation.bounceNulls(strings: strings.map({ __item in { () -> Variant_NullType_String in
+        let __variant = bridge.std__variant_nitro__NullType__std__string_(__item)
+        switch __variant.index() {
+          case 0:
+            let __actual = __variant.get_0()
+            return .first(NullType.null)
+          case 1:
+            let __actual = __variant.get_1()
+            return .second(String(__actual))
+          default:
+            fatalError("Variant can never have index \(__variant.index())!")
+        }
+      }() }))
+      let __resultCpp = { () -> bridge.std__vector_std__variant_nitro__NullType__std__string__ in
+        var __vector = bridge.create_std__vector_std__variant_nitro__NullType__std__string__(__result.count)
+        for __item in __result {
+          __vector.push_back({ () -> bridge.std__variant_nitro__NullType__std__string_ in
+            switch __item {
+              case .first(let __value):
+                return bridge.create_std__variant_nitro__NullType__std__string_(margelo.nitro.NullType.null)
+              case .second(let __value):
+                return bridge.create_std__variant_nitro__NullType__std__string_(std.string(__value))
+            }
+          }().variant)
+        }
+        return __vector
+      }()
+      return bridge.create_Result_std__vector_std__variant_nitro__NullType__std__string___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__vector_std__variant_nitro__NullType__std__string___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func bounceOptionalNulls(strings: bridge.std__vector_std__optional_std__variant_nitro__NullType__std__string___) -> bridge.Result_std__vector_std__optional_std__variant_nitro__NullType__std__string____ {
+    do {
+      let __result = try self.__implementation.bounceOptionalNulls(strings: strings.map({ __item in { () -> Variant_NullType_String? in
+        if bridge.has_value_std__optional_std__variant_nitro__NullType__std__string__(__item) {
+          let __unwrapped = bridge.get_std__optional_std__variant_nitro__NullType__std__string__(__item)
+          return { () -> Variant_NullType_String in
+            let __variant = bridge.std__variant_nitro__NullType__std__string_(__unwrapped)
+            switch __variant.index() {
+              case 0:
+                let __actual = __variant.get_0()
+                return .first(NullType.null)
+              case 1:
+                let __actual = __variant.get_1()
+                return .second(String(__actual))
+              default:
+                fatalError("Variant can never have index \(__variant.index())!")
+            }
+          }()
+        } else {
+          return nil
+        }
+      }() }))
+      let __resultCpp = { () -> bridge.std__vector_std__optional_std__variant_nitro__NullType__std__string___ in
+        var __vector = bridge.create_std__vector_std__optional_std__variant_nitro__NullType__std__string___(__result.count)
+        for __item in __result {
+          __vector.push_back({ () -> bridge.std__optional_std__variant_nitro__NullType__std__string__ in
+            if let __unwrappedValue = __item {
+              return bridge.create_std__optional_std__variant_nitro__NullType__std__string__({ () -> bridge.std__variant_nitro__NullType__std__string_ in
+                switch __unwrappedValue {
+                  case .first(let __value):
+                    return bridge.create_std__variant_nitro__NullType__std__string_(margelo.nitro.NullType.null)
+                  case .second(let __value):
+                    return bridge.create_std__variant_nitro__NullType__std__string_(std.string(__value))
+                }
+              }().variant)
+            } else {
+              return .init()
+            }
+          }())
+        }
+        return __vector
+      }()
+      return bridge.create_Result_std__vector_std__optional_std__variant_nitro__NullType__std__string____(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__vector_std__optional_std__variant_nitro__NullType__std__string____(__exceptionPtr)
     }
   }
   
@@ -1081,6 +1153,148 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
     } catch (let __error) {
       let __exceptionPtr = __error.toCpp()
       return bridge.create_Result_std__unordered_map_std__string__double__(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func bounceOptionalMap(map: bridge.std__unordered_map_std__string__std__optional_std__string__) -> bridge.Result_std__unordered_map_std__string__std__optional_std__string___ {
+    do {
+      let __result = try self.__implementation.bounceOptionalMap(map: { () -> Dictionary<String, String?> in
+        var __dictionary = Dictionary<String, String?>(minimumCapacity: map.size())
+        let __keys = bridge.get_std__unordered_map_std__string__std__optional_std__string___keys(map)
+        for __key in __keys {
+          let __value = bridge.get_std__unordered_map_std__string__std__optional_std__string___value(map, __key)
+          __dictionary[String(__key)] = { () -> String? in
+            if bridge.has_value_std__optional_std__string_(__value) {
+              let __unwrapped = bridge.get_std__optional_std__string_(__value)
+              return String(__unwrapped)
+            } else {
+              return nil
+            }
+          }()
+        }
+        return __dictionary
+      }())
+      let __resultCpp = { () -> bridge.std__unordered_map_std__string__std__optional_std__string__ in
+        var __map = bridge.create_std__unordered_map_std__string__std__optional_std__string__(__result.count)
+        for (__k, __v) in __result {
+          bridge.emplace_std__unordered_map_std__string__std__optional_std__string__(&__map, std.string(__k), { () -> bridge.std__optional_std__string_ in
+            if let __unwrappedValue = __v {
+              return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
+            } else {
+              return .init()
+            }
+          }())
+        }
+        return __map
+      }()
+      return bridge.create_Result_std__unordered_map_std__string__std__optional_std__string___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__unordered_map_std__string__std__optional_std__string___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func bounceNullMap(map: bridge.std__unordered_map_std__string__std__variant_nitro__NullType__std__string__) -> bridge.Result_std__unordered_map_std__string__std__variant_nitro__NullType__std__string___ {
+    do {
+      let __result = try self.__implementation.bounceNullMap(map: { () -> Dictionary<String, Variant_NullType_String> in
+        var __dictionary = Dictionary<String, Variant_NullType_String>(minimumCapacity: map.size())
+        let __keys = bridge.get_std__unordered_map_std__string__std__variant_nitro__NullType__std__string___keys(map)
+        for __key in __keys {
+          let __value = bridge.get_std__unordered_map_std__string__std__variant_nitro__NullType__std__string___value(map, __key)
+          __dictionary[String(__key)] = { () -> Variant_NullType_String in
+            let __variant = bridge.std__variant_nitro__NullType__std__string_(__value)
+            switch __variant.index() {
+              case 0:
+                let __actual = __variant.get_0()
+                return .first(NullType.null)
+              case 1:
+                let __actual = __variant.get_1()
+                return .second(String(__actual))
+              default:
+                fatalError("Variant can never have index \(__variant.index())!")
+            }
+          }()
+        }
+        return __dictionary
+      }())
+      let __resultCpp = { () -> bridge.std__unordered_map_std__string__std__variant_nitro__NullType__std__string__ in
+        var __map = bridge.create_std__unordered_map_std__string__std__variant_nitro__NullType__std__string__(__result.count)
+        for (__k, __v) in __result {
+          bridge.emplace_std__unordered_map_std__string__std__variant_nitro__NullType__std__string__(&__map, std.string(__k), { () -> bridge.std__variant_nitro__NullType__std__string_ in
+            switch __v {
+              case .first(let __value):
+                return bridge.create_std__variant_nitro__NullType__std__string_(margelo.nitro.NullType.null)
+              case .second(let __value):
+                return bridge.create_std__variant_nitro__NullType__std__string_(std.string(__value))
+            }
+          }().variant)
+        }
+        return __map
+      }()
+      return bridge.create_Result_std__unordered_map_std__string__std__variant_nitro__NullType__std__string___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__unordered_map_std__string__std__variant_nitro__NullType__std__string___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func bounceOptionalNullMap(map: bridge.std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string___) -> bridge.Result_std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string____ {
+    do {
+      let __result = try self.__implementation.bounceOptionalNullMap(map: { () -> Dictionary<String, Variant_NullType_String?> in
+        var __dictionary = Dictionary<String, Variant_NullType_String?>(minimumCapacity: map.size())
+        let __keys = bridge.get_std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string____keys(map)
+        for __key in __keys {
+          let __value = bridge.get_std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string____value(map, __key)
+          __dictionary[String(__key)] = { () -> Variant_NullType_String? in
+            if bridge.has_value_std__optional_std__variant_nitro__NullType__std__string__(__value) {
+              let __unwrapped = bridge.get_std__optional_std__variant_nitro__NullType__std__string__(__value)
+              return { () -> Variant_NullType_String in
+                let __variant = bridge.std__variant_nitro__NullType__std__string_(__unwrapped)
+                switch __variant.index() {
+                  case 0:
+                    let __actual = __variant.get_0()
+                    return .first(NullType.null)
+                  case 1:
+                    let __actual = __variant.get_1()
+                    return .second(String(__actual))
+                  default:
+                    fatalError("Variant can never have index \(__variant.index())!")
+                }
+              }()
+            } else {
+              return nil
+            }
+          }()
+        }
+        return __dictionary
+      }())
+      let __resultCpp = { () -> bridge.std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string___ in
+        var __map = bridge.create_std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string___(__result.count)
+        for (__k, __v) in __result {
+          bridge.emplace_std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string___(&__map, std.string(__k), { () -> bridge.std__optional_std__variant_nitro__NullType__std__string__ in
+            if let __unwrappedValue = __v {
+              return bridge.create_std__optional_std__variant_nitro__NullType__std__string__({ () -> bridge.std__variant_nitro__NullType__std__string_ in
+                switch __unwrappedValue {
+                  case .first(let __value):
+                    return bridge.create_std__variant_nitro__NullType__std__string_(margelo.nitro.NullType.null)
+                  case .second(let __value):
+                    return bridge.create_std__variant_nitro__NullType__std__string_(std.string(__value))
+                }
+              }().variant)
+            } else {
+              return .init()
+            }
+          }())
+        }
+        return __map
+      }()
+      return bridge.create_Result_std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string____(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__unordered_map_std__string__std__optional_std__variant_nitro__NullType__std__string____(__exceptionPtr)
     }
   }
   

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -83,6 +83,8 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("bouncePromises", &HybridTestObjectCppSpec::bouncePromises);
       prototype.registerHybridMethod("bounceArrayBuffers", &HybridTestObjectCppSpec::bounceArrayBuffers);
       prototype.registerHybridMethod("bounceOptionals", &HybridTestObjectCppSpec::bounceOptionals);
+      prototype.registerHybridMethod("bounceNulls", &HybridTestObjectCppSpec::bounceNulls);
+      prototype.registerHybridMethod("bounceOptionalNulls", &HybridTestObjectCppSpec::bounceOptionalNulls);
       prototype.registerHybridMethod("createMap", &HybridTestObjectCppSpec::createMap);
       prototype.registerHybridMethod("mapRoundtrip", &HybridTestObjectCppSpec::mapRoundtrip);
       prototype.registerHybridMethod("getMapKeys", &HybridTestObjectCppSpec::getMapKeys);
@@ -90,6 +92,9 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("copyAnyMap", &HybridTestObjectCppSpec::copyAnyMap);
       prototype.registerHybridMethod("bounceMap", &HybridTestObjectCppSpec::bounceMap);
       prototype.registerHybridMethod("bounceSimpleMap", &HybridTestObjectCppSpec::bounceSimpleMap);
+      prototype.registerHybridMethod("bounceOptionalMap", &HybridTestObjectCppSpec::bounceOptionalMap);
+      prototype.registerHybridMethod("bounceNullMap", &HybridTestObjectCppSpec::bounceNullMap);
+      prototype.registerHybridMethod("bounceOptionalNullMap", &HybridTestObjectCppSpec::bounceOptionalNullMap);
       prototype.registerHybridMethod("extractMap", &HybridTestObjectCppSpec::extractMap);
       prototype.registerHybridMethod("funcThatThrows", &HybridTestObjectCppSpec::funcThatThrows);
       prototype.registerHybridMethod("funcThatThrowsBeforePromise", &HybridTestObjectCppSpec::funcThatThrowsBeforePromise);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -191,7 +191,9 @@ namespace margelo::nitro::test {
       virtual std::vector<std::shared_ptr<AnyMap>> bounceMaps(const std::vector<std::shared_ptr<AnyMap>>& maps) = 0;
       virtual std::vector<std::shared_ptr<Promise<double>>> bouncePromises(const std::vector<std::shared_ptr<Promise<double>>>& promises) = 0;
       virtual std::vector<std::shared_ptr<ArrayBuffer>> bounceArrayBuffers(const std::vector<std::shared_ptr<ArrayBuffer>>& arrayBuffers) = 0;
-      virtual std::vector<std::optional<std::string>> bounceOptionals(const std::vector<std::optional<std::string>>& strings, const std::vector<std::optional<std::shared_ptr<ArrayBuffer>>>& arrayBuffers, const std::unordered_map<std::string, std::optional<std::string>>& map) = 0;
+      virtual std::vector<std::optional<std::string>> bounceOptionals(const std::vector<std::optional<std::string>>& strings, const std::vector<std::optional<std::shared_ptr<ArrayBuffer>>>& arrayBuffers) = 0;
+      virtual std::vector<std::variant<nitro::NullType, std::string>> bounceNulls(const std::vector<std::variant<nitro::NullType, std::string>>& strings) = 0;
+      virtual std::vector<std::optional<std::variant<nitro::NullType, std::string>>> bounceOptionalNulls(const std::vector<std::optional<std::variant<nitro::NullType, std::string>>>& strings) = 0;
       virtual std::shared_ptr<AnyMap> createMap() = 0;
       virtual std::shared_ptr<AnyMap> mapRoundtrip(const std::shared_ptr<AnyMap>& map) = 0;
       virtual std::vector<std::string> getMapKeys(const std::shared_ptr<AnyMap>& map) = 0;
@@ -199,6 +201,9 @@ namespace margelo::nitro::test {
       virtual std::shared_ptr<AnyMap> copyAnyMap(const std::shared_ptr<AnyMap>& map) = 0;
       virtual std::unordered_map<std::string, std::variant<bool, double>> bounceMap(const std::unordered_map<std::string, std::variant<bool, double>>& map) = 0;
       virtual std::unordered_map<std::string, double> bounceSimpleMap(const std::unordered_map<std::string, double>& map) = 0;
+      virtual std::unordered_map<std::string, std::optional<std::string>> bounceOptionalMap(const std::unordered_map<std::string, std::optional<std::string>>& map) = 0;
+      virtual std::unordered_map<std::string, std::variant<nitro::NullType, std::string>> bounceNullMap(const std::unordered_map<std::string, std::variant<nitro::NullType, std::string>>& map) = 0;
+      virtual std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>> bounceOptionalNullMap(const std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>>& map) = 0;
       virtual std::unordered_map<std::string, std::string> extractMap(const MapWrapper& mapWrapper) = 0;
       virtual double funcThatThrows() = 0;
       virtual std::shared_ptr<Promise<void>> funcThatThrowsBeforePromise() = 0;

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
@@ -75,6 +75,8 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("bouncePromises", &HybridTestObjectSwiftKotlinSpec::bouncePromises);
       prototype.registerHybridMethod("bounceArrayBuffers", &HybridTestObjectSwiftKotlinSpec::bounceArrayBuffers);
       prototype.registerHybridMethod("bounceOptionals", &HybridTestObjectSwiftKotlinSpec::bounceOptionals);
+      prototype.registerHybridMethod("bounceNulls", &HybridTestObjectSwiftKotlinSpec::bounceNulls);
+      prototype.registerHybridMethod("bounceOptionalNulls", &HybridTestObjectSwiftKotlinSpec::bounceOptionalNulls);
       prototype.registerHybridMethod("createMap", &HybridTestObjectSwiftKotlinSpec::createMap);
       prototype.registerHybridMethod("mapRoundtrip", &HybridTestObjectSwiftKotlinSpec::mapRoundtrip);
       prototype.registerHybridMethod("getMapKeys", &HybridTestObjectSwiftKotlinSpec::getMapKeys);
@@ -82,6 +84,9 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("copyAnyMap", &HybridTestObjectSwiftKotlinSpec::copyAnyMap);
       prototype.registerHybridMethod("bounceMap", &HybridTestObjectSwiftKotlinSpec::bounceMap);
       prototype.registerHybridMethod("bounceSimpleMap", &HybridTestObjectSwiftKotlinSpec::bounceSimpleMap);
+      prototype.registerHybridMethod("bounceOptionalMap", &HybridTestObjectSwiftKotlinSpec::bounceOptionalMap);
+      prototype.registerHybridMethod("bounceNullMap", &HybridTestObjectSwiftKotlinSpec::bounceNullMap);
+      prototype.registerHybridMethod("bounceOptionalNullMap", &HybridTestObjectSwiftKotlinSpec::bounceOptionalNullMap);
       prototype.registerHybridMethod("extractMap", &HybridTestObjectSwiftKotlinSpec::extractMap);
       prototype.registerHybridMethod("funcThatThrows", &HybridTestObjectSwiftKotlinSpec::funcThatThrows);
       prototype.registerHybridMethod("funcThatThrowsBeforePromise", &HybridTestObjectSwiftKotlinSpec::funcThatThrowsBeforePromise);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
@@ -178,7 +178,9 @@ namespace margelo::nitro::test {
       virtual std::vector<std::shared_ptr<AnyMap>> bounceMaps(const std::vector<std::shared_ptr<AnyMap>>& maps) = 0;
       virtual std::vector<std::shared_ptr<Promise<double>>> bouncePromises(const std::vector<std::shared_ptr<Promise<double>>>& promises) = 0;
       virtual std::vector<std::shared_ptr<ArrayBuffer>> bounceArrayBuffers(const std::vector<std::shared_ptr<ArrayBuffer>>& arrayBuffers) = 0;
-      virtual std::vector<std::optional<std::string>> bounceOptionals(const std::vector<std::optional<std::string>>& strings, const std::vector<std::optional<std::shared_ptr<ArrayBuffer>>>& arrayBuffers, const std::unordered_map<std::string, std::optional<std::string>>& map) = 0;
+      virtual std::vector<std::optional<std::string>> bounceOptionals(const std::vector<std::optional<std::string>>& strings, const std::vector<std::optional<std::shared_ptr<ArrayBuffer>>>& arrayBuffers) = 0;
+      virtual std::vector<std::variant<nitro::NullType, std::string>> bounceNulls(const std::vector<std::variant<nitro::NullType, std::string>>& strings) = 0;
+      virtual std::vector<std::optional<std::variant<nitro::NullType, std::string>>> bounceOptionalNulls(const std::vector<std::optional<std::variant<nitro::NullType, std::string>>>& strings) = 0;
       virtual std::shared_ptr<AnyMap> createMap() = 0;
       virtual std::shared_ptr<AnyMap> mapRoundtrip(const std::shared_ptr<AnyMap>& map) = 0;
       virtual std::vector<std::string> getMapKeys(const std::shared_ptr<AnyMap>& map) = 0;
@@ -186,6 +188,9 @@ namespace margelo::nitro::test {
       virtual std::shared_ptr<AnyMap> copyAnyMap(const std::shared_ptr<AnyMap>& map) = 0;
       virtual std::unordered_map<std::string, std::variant<bool, double>> bounceMap(const std::unordered_map<std::string, std::variant<bool, double>>& map) = 0;
       virtual std::unordered_map<std::string, double> bounceSimpleMap(const std::unordered_map<std::string, double>& map) = 0;
+      virtual std::unordered_map<std::string, std::optional<std::string>> bounceOptionalMap(const std::unordered_map<std::string, std::optional<std::string>>& map) = 0;
+      virtual std::unordered_map<std::string, std::variant<nitro::NullType, std::string>> bounceNullMap(const std::unordered_map<std::string, std::variant<nitro::NullType, std::string>>& map) = 0;
+      virtual std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>> bounceOptionalNullMap(const std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>>& map) = 0;
       virtual std::unordered_map<std::string, std::string> extractMap(const MapWrapper& mapWrapper) = 0;
       virtual double funcThatThrows() = 0;
       virtual std::shared_ptr<Promise<void>> funcThatThrowsBeforePromise() = 0;

--- a/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
@@ -191,9 +191,12 @@ interface SharedTestObjectProps {
   bounceArrayBuffers(arrayBuffers: ArrayBuffer[]): ArrayBuffer[]
   bounceOptionals(
     strings: (string | undefined)[],
-    arrayBuffers: (ArrayBuffer | undefined)[],
-    map: Record<string, string | undefined>
+    arrayBuffers: (ArrayBuffer | undefined)[]
   ): (string | undefined)[]
+  bounceNulls(strings: (string | null)[]): (string | null)[]
+  bounceOptionalNulls(
+    strings: (string | null | undefined)[]
+  ): (string | null | undefined)[]
 
   // Maps
   createMap(): AnyMap
@@ -207,6 +210,15 @@ interface SharedTestObjectProps {
     map: Record<string, number | boolean>
   ): Record<string, number | boolean>
   bounceSimpleMap(map: Record<string, number>): Record<string, number>
+  bounceOptionalMap(
+    map: Record<string, string | undefined>
+  ): Record<string, string | undefined>
+  bounceNullMap(
+    map: Record<string, string | null>
+  ): Record<string, string | null>
+  bounceOptionalNullMap(
+    map: Record<string, string | null | undefined>
+  ): Record<string, string | null | undefined>
   extractMap(mapWrapper: MapWrapper): MapWrapper['map']
 
   // Errors


### PR DESCRIPTION
Follow-up to #1478, which fixed `| undefined` being dropped on array elements and `Record` values. That PR covers the `undefined` half of the semantic; this one pins the other half, so the distinction is asserted by codegen instead of only being implied:

- **`undefined` means optional** -> `std::optional<T>`
- **`null` is a type of its own** (`NullType`) -> stays a `variant<NullType, T>`, never gains an `optional<..>` wrapper

## What's added

Five methods on the existing `SharedTestObjectProps`, reusing existing types - no new structs, enums or spec files. Arrays and `Record`s are separate methods so that each one is actually *returned* and asserted, rather than converted into native and dropped:

```ts
// Arrays
bounceNulls(strings: (string | null)[]): (string | null)[]
bounceOptionalNulls(
  strings: (string | null | undefined)[]
): (string | null | undefined)[]

// Records
bounceOptionalMap(
  map: Record<string, string | undefined>
): Record<string, string | undefined>
bounceNullMap(map: Record<string, string | null>): Record<string, string | null>
bounceOptionalNullMap(
  map: Record<string, string | null | undefined>
): Record<string, string | null | undefined>
```

`bounceOptionals(...)` loses its `map` parameter - it returned `strings`, so the map was only ever converted *into* native and never asserted coming back. `bounceOptionalMap(...)` now covers it in both directions.

Generated shapes, which are the actual assertion:

| spec type | C++ |
| --- | --- |
| `(string \| null)[]` | `std::vector<std::variant<nitro::NullType, std::string>>` |
| `(string \| null \| undefined)[]` | `std::vector<std::optional<std::variant<nitro::NullType, std::string>>>` |
| `Record<string, string \| undefined>` | `std::unordered_map<std::string, std::optional<std::string>>` |
| `Record<string, string \| null>` | `std::unordered_map<std::string, std::variant<nitro::NullType, std::string>>` |
| `Record<string, string \| null \| undefined>` | `std::unordered_map<std::string, std::optional<std::variant<nitro::NullType, std::string>>>` |

Swift gets `[Variant_NullType_String]` / `[Variant_NullType_String?]` and the `[String: ...]` equivalents, Kotlin `Array<Variant_NullType_String>` / `Array<Variant_NullType_String?>` and `Map<String, ...>`.

Every method is also exercised at runtime in `getTests.ts`, so `null` and `undefined` are round-tripped through C++, Swift and Kotlin rather than only compiled:

```ts
testObject.bounceNulls(['hello', null, 'world'])
testObject.bounceOptionalNulls(['hello', null, undefined])
testObject.bounceOptionalMap({ a: 'b', c: undefined })
testObject.bounceNullMap({ a: 'b', c: null })
testObject.bounceOptionalNullMap({ a: 'b', b: null, c: undefined })
```

## Why it's worth pinning

Four call sites still use ts-morph's `isNullable()`, which is `getUnionTypes().some(t => t.isNull() || t.isUndefined())` - it conflates the two: `Parameter.ts:28`, tuple elements and function parameters in `createType.ts`, and struct properties in `getInterfaceProperties.ts:35`. So a *parameter* `x: string | null` still becomes `std::optional<std::variant<NullType, std::string>>` today. Narrowing those is a user-visible codegen change that deserves its own PR; these tests are the guard rail for it - if that change accidentally reaches array or `Record` positions, `bounceNulls(...)` stops compiling.

## Verification

Run locally on this branch (macOS, Xcode 26.6, Pixel API 35 emulator):

- **Regeneration** - `bun run build` + `bun specs` in both test packages, generated tree matches what's committed
- **iOS build** - `xcodebuild -workspace NitroExample.xcworkspace -scheme NitroExample -sdk iphonesimulator` -> `** BUILD SUCCEEDED **`
- **Android build** - `./gradlew :app:assembleDebug -PreactNativeArchitectures=arm64-v8a` -> `BUILD SUCCESSFUL`
- **Harness iOS** - 542/542 pass (iPhone 17 Pro, iOS 26.5)
- **Harness Android** - 542/542 pass (Pixel API 35, `minSdkVersion` set to 26 as CI does)
- `bun typecheck`, `bun lint`, `bun lint-cpp`, `bun lint-swift`, `bun lint-kotlin` all pass
