### PR TITLE
fix: Treat `null` as `undefined` for removed optional View props

### DIFF
--- a/example/__tests__/nitro.views.harness.tsx
+++ b/example/__tests__/nitro.views.harness.tsx
@@ -339,6 +339,46 @@ describe('TestView', () => {
     expect(view.getNativeDefaultValueSetterCallCount()).toBe(0)
   })
 
+  it('delivers undefined when an optional prop is removed', async () => {
+    const viewRef = deferred<TestViewRef>()
+    const stableSomeCallback = callback(fn())
+    const renderResult = await render(
+      <TestView
+        testID="test-view-prop-removal"
+        style={INITIAL_SIZE}
+        hybridRef={callback((view) => viewRef.resolve(view))}
+        isBlue={false}
+        hasBeenCalled={false}
+        colorScheme="dark"
+        someCallback={stableSomeCallback}
+        nativeDefaultValue={1}
+      />,
+      { timeout: RENDER_TIMEOUT }
+    )
+
+    const view = await viewRef.promise
+    expect(view.nativeDefaultValue).toBe(1)
+    expect(view.getNativeDefaultValueSetterCallCount()).toBe(1)
+    expect(view.getIsBlueSetterCallCount()).toBe(1)
+
+    // Removing the optional `nativeDefaultValue` and `hybridRef` props sends
+    // an explicit `null` to native - Nitro must deliver `undefined` for them.
+    await renderResult.rerender(
+      <TestView
+        testID="test-view-prop-removal"
+        style={INITIAL_SIZE}
+        isBlue={false}
+        hasBeenCalled={false}
+        colorScheme="dark"
+        someCallback={stableSomeCallback}
+      />
+    )
+
+    expect(view.nativeDefaultValue).toBe(undefined)
+    expect(view.getNativeDefaultValueSetterCallCount()).toBe(2)
+    expect(view.getIsBlueSetterCallCount()).toBe(1)
+  })
+
   it('only calls native setters for changed Nitro props', async () => {
     const viewRef = deferred<TestViewRef>()
     const stableHybridRef = callback((view: TestViewRef) =>

--- a/packages/react-native-nitro-modules/cpp/views/ReactProp.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/ReactProp.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "BorrowingReference.hpp"
+#include "CountTrailingOptionals.hpp"
 #include "IsFunctionProp.hpp"
 #include "JSIConverter.hpp"
 #include "NitroDefines.hpp"
@@ -97,6 +98,15 @@ public:
       }
 
       auto [runtime, value] = static_cast<std::pair<jsi::Runtime*, jsi::Value>>(*rawValue);
+
+      if constexpr (is_optional<T>::value) {
+        // React turns a removed prop into `null`.
+        // If our type is nullable, we set it to `undefined` (unless `null` is a valid value for it).
+        // Otherwise this will throw, since we don't know a desired default value.
+        if (value.isNull() && !JSIConverter<T>::canConvert(*runtime, value)) [[unlikely]] {
+          value = jsi::Value::undefined();
+        }
+      }
 
       if constexpr (IsFunctionProp<std::remove_cv_t<T>>::value) {
         // React Native cannot transport functions as regular props. Nitrogen


### PR DESCRIPTION
- Fixes https://github.com/mrousavy/nitro/issues/1184

---

## Summary

- React's Fabric diff sends an explicit `null` sentinel for a removed prop ([ReactNativeAttributePayload](https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload.js): "Flag the leaf property for removal by sending a sentinel") - and `prop={undefined}` takes the same path, so the two are indistinguishable on the wire
- `CachedProp` previously passed that `null` straight into conversion, which **throws mid-commit** for every optional prop type that rejects null (`optional<double>` via `asNumber()`, and `hybridRef` even earlier, in the `{ f }` function-prop unwrap)
- now: if the prop type is optional **and** `null` is not a valid value for it (`JSIConverter<T>::canConvert`), the value is normalized to `undefined` → the native setter is called once with `nullopt`

## Semantics

- **optional prop removed / set to `undefined`** → setter receives `nullopt` (the JS-visible value becomes `undefined`). The native initializer default still only covers never-provided props - a richer "reset on clear" belongs in the implementation (`storage ?? default`)
- **props that can legitimately hold `null`** (`NullType`, variants containing null): untouched - `null` stays data, so removal collapses to "explicit null" for those (inherent to React's sentinel protocol)
- **required props**: unchanged, removal still throws loudly with the `ViewName.propName:` prefix

Because normalization only applies where conversion was guaranteed to throw, no currently-working behavior can change.

## Overhead

- non-optional props: none - the `if constexpr (is_optional<T>)` branch compiles out
- optional props: one `value.isNull()` tag check during Props parsing; the `canConvert` walk only runs when the value actually is `null` (i.e. an actual removal)

## Testing

New Harness test `delivers undefined when an optional prop is removed": mounts TestView with `nativeDefaultValue={1}` + `hybridRef`, then removes both - asserts the value reads `undefined`, the setter fired exactly once more, unrelated setters (`isBlue`) did not fire, and the previously-crashing `hybridRef` removal path survives. Red without the fix (commit-time throw), green with it.

Validated: workspace typecheck, eslint (CI settings), clang-format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)