### PR TITLE
fix: Mark react-native-nitro-modules peer dependency as optional

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -147,6 +147,9 @@
         "react-native-nitro-modules": "*",
         "react-native-nitro-test-external": "*",
       },
+      "optionalPeers": [
+        "react-native-nitro-modules",
+      ],
     },
     "packages/react-native-nitro-test-external": {
       "name": "react-native-nitro-test-external",
@@ -170,6 +173,9 @@
         "react-native": "*",
         "react-native-nitro-modules": "*",
       },
+      "optionalPeers": [
+        "react-native-nitro-modules",
+      ],
     },
   },
   "packages": {

--- a/docs/docs/getting-started/how-to-build-a-nitro-module.md
+++ b/docs/docs/getting-started/how-to-build-a-nitro-module.md
@@ -44,6 +44,25 @@ First, you need to create a [Nitro Module](../concepts/nitro-modules) - either b
     npm install nitrogen --save-dev
     ```
 
+    Also declare `react-native-nitro-modules` as an **optional peer dependency**, so the app using your library is the one that decides which Nitro version gets installed:
+
+    ```json title="package.json"
+    {
+      "peerDependencies": {
+        "react-native-nitro-modules": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-nitro-modules": {
+          "optional": true
+        }
+      }
+    }
+    ```
+
+    :::warning
+    The `optional` flag matters. Without it, package managers try to satisfy the peer range themselves - and since semver ranges never match pre-releases, `"*"` does **not** match a version like `0.37.0-beta.0`. A user testing a Nitro beta would then get a second, stable copy of `react-native-nitro-modules` installed next to yours, and Nitro throws [`Nitro was installed twice`](../guides/troubleshooting#nitro-was-installed-twice) at runtime. Marking the peer optional stops the package manager from installing Nitro on your behalf.
+    :::
+
     Then, you need to decide if you want to use Nitro's C++ library directly, or use [nitrogen](../concepts/nitrogen) to generate specs:
 
     <Tabs>

--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -66,6 +66,36 @@ If your app fails to build after installing Nitro or a library powered by Nitro,
   </TabItem>
 </Tabs>
 
+## Nitro was installed twice
+
+If your app crashes at startup with:
+
+```
+Nitro was installed twice: once with native version X and once with JS version Y.
+```
+
+...then two different copies of `react-native-nitro-modules` ended up in your project - the native build linked one, and Metro bundled the other.
+
+The most common cause is **installing a Nitro pre-release** (e.g. `0.37.0-beta.0`). Semver ranges never match pre-release versions, so a library declaring `"react-native-nitro-modules": "*"` as a required peer dependency does not consider the beta a match - and your package manager silently installs a second, stable copy inside that library's `node_modules` to satisfy the peer.
+
+To fix it:
+
+1. Check how many copies you have:
+   ```sh
+   npm ls react-native-nitro-modules
+   ```
+2. If a library nests its own copy, ask the library author to mark the peer dependency as [optional](../getting-started/how-to-build-a-nitro-module#11-install-nitro-and-nitrogen).
+3. As a workaround until then, force a single version from your app's `package.json`:
+   ```json title="package.json"
+   {
+     "overrides": {
+       "react-native-nitro-modules": "0.37.0-beta.0"
+     }
+   }
+   ```
+   (use `resolutions` instead of `overrides` for Yarn)
+4. Delete `node_modules` and reinstall - package managers often leave the stale nested copy on disk even after the lockfile is fixed.
+
 ## Runtime error
 
 If your app crashes at runtime, make sure to inspect the native logs.

--- a/packages/react-native-nitro-test-external/package.json
+++ b/packages/react-native-nitro-test-external/package.json
@@ -71,6 +71,11 @@
     "react-native": "*",
     "react-native-nitro-modules": "*"
   },
+  "peerDependenciesMeta": {
+    "react-native-nitro-modules": {
+      "optional": true
+    }
+  },
   "eslintConfig": {
     "root": true,
     "extends": [

--- a/packages/react-native-nitro-test/package.json
+++ b/packages/react-native-nitro-test/package.json
@@ -72,6 +72,11 @@
     "react-native-nitro-modules": "*",
     "react-native-nitro-test-external": "*"
   },
+  "peerDependenciesMeta": {
+    "react-native-nitro-modules": {
+      "optional": true
+    }
+  },
   "jest": {
     "preset": "@react-native/jest-preset",
     "modulePathIgnorePatterns": [

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -71,6 +71,11 @@
     "react-native": "*",
     "react-native-nitro-modules": "*"
   },
+  "peerDependenciesMeta": {
+    "react-native-nitro-modules": {
+      "optional": true
+    }
+  },
   "eslintConfig": {
     "root": true,
     "extends": [


### PR DESCRIPTION
## Problem

Semver ranges **never match pre-release versions** unless a comparator shares the same `major.minor.patch` tuple *and* carries a pre-release tag. So the `"react-native-nitro-modules": "*"` peer range that every Nitro Module declares does not match `0.37.0-beta.0`:

| range | 0.36.5 | 0.37.0-beta.0 | 0.37.0 | 0.38.0-beta.0 |
|---|---|---|---|---|
| `*` | yes | **no** | yes | **no** |
| `>=0.0.0-0` | yes | **no** | yes | **no** |
| `>=0.37.0-0` | no | yes | yes | **no** |

Because the peer is *required*, bun tries to satisfy it itself and installs a second, **stable** copy of `react-native-nitro-modules` nested inside the library. The native build then links the pre-release while Metro bundles the stable JS, and Nitro's own version guard throws at startup:

```
Nitro was installed twice: once with native version 0.37.0-beta.0 and once with JS version 0.36.5.
```

This is exactly what happened when upgrading react-native-nitro-image to the 0.37 beta (mrousavy/react-native-nitro-image#166) - builds stayed green, only the runtime harness tests caught it.

## Fix

Mark the peer as optional. No range can express "anything, including future pre-releases" (see the table - `>=0.37.0-0` just moves the breakage to 0.38.0-beta.0), so the fix has to be resolution behaviour rather than a cleverer range.

```json
"peerDependenciesMeta": {
  "react-native-nitro-modules": { "optional": true }
}
```

Verified with a minimal repro: bumping an existing lockfile to a pre-release keeps a stale stable copy with a required peer, and resolves to a single copy with an optional one.

Applied to `packages/template` (so `create-nitro-module` and the docs' manual setup produce it), plus the two test libraries.

## Trade-off

`optional: true` also suppresses the *missing* peer warning. That's an acceptable loss here: a Nitro Module without `react-native-nitro-modules` fails loudly at build time (autolinking can't find the pod / Gradle project), and version mismatches are already caught by Nitro's runtime guard - which is strictly stronger than an install-time range check.

## Docs

- **how-to-build-a-nitro-module**: documents the optional peer as part of library setup, with a warning explaining why.
- **troubleshooting**: new `Nitro was installed twice` section covering diagnosis (`npm ls`), the real fix, the `overrides`/`resolutions` workaround for app authors stuck on a library that hasn't updated, and the reminder that package managers leave the stale copy on disk after the lockfile is fixed.

Note npm is unaffected - it special-cases `*` and accepts the pre-release. This is bun-specific behaviour.