### PR TITLE
fix: Don't include cxxreact/ReactNativeVersion.h in public view headers

### DIFF
--- a/packages/react-native-nitro-modules/cpp/views/RawPropsCompat.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/RawPropsCompat.hpp
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#if __has_include(<cxxreact/ReactNativeVersion.h>)
-#include <cxxreact/ReactNativeVersion.h>
-#endif
 #include <react/renderer/core/RawProps.h>
 
 namespace margelo::nitro::RawPropsCompat {
@@ -14,14 +11,24 @@ namespace margelo::nitro::RawPropsCompat {
 /**
  * Same as `props.at(name)`, with compatibility for React Native 0.79 through
  * 0.86, where `RawProps::at(...)` requires prefix and suffix arguments.
+ *
+ * The available overload is detected at compile-time instead of reading
+ * `<cxxreact/ReactNativeVersion.h>`: this header is part of the NitroModules
+ * modulemap, and a `cxxreact` import inside a modular header breaks iOS
+ * builds using `use_frameworks!` - clang then has to build the `cxxreact`
+ * module from the consumer's context, which fails because cxxreact's own
+ * headers need search paths (e.g. jsinspector-modern) that are not exposed
+ * to third-party pods.
  */
-inline const facebook::react::RawValue* at(const facebook::react::RawProps& props, const char* name) {
-#if defined(REACT_NATIVE_VERSION_MAJOR) && (REACT_NATIVE_VERSION_MAJOR > 0 || REACT_NATIVE_VERSION_MINOR > 86)
-  // React Native 0.87 introduced the canonical single-argument overload.
-  return props.at(name);
-#else
-  return props.at(name, nullptr, nullptr);
-#endif
+template <typename TRawProps = facebook::react::RawProps>
+const facebook::react::RawValue* at(const TRawProps& props, const char* name) {
+  if constexpr (requires { props.at(name); }) {
+    // React Native 0.87+: canonical single-argument overload.
+    return props.at(name);
+  } else {
+    // React Native 0.79 - 0.86: prefix and suffix arguments are required.
+    return props.at(name, nullptr, nullptr);
+  }
 }
 
 } // namespace margelo::nitro::RawPropsCompat

--- a/packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp
@@ -5,20 +5,41 @@
 #pragma once
 
 #include <concepts>
-#include <cxxreact/ReactNativeVersion.h>
 #include <memory>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include <utility>
 
-#if REACT_NATIVE_VERSION_MAJOR != 0 || REACT_NATIVE_VERSION_MINOR >= 85
-// Since React Native 0.85, the RawPropsParser has JSI Parsing always enabled
-// by default, and the boolean argument has been removed.
-#define RAW_PROPS_PARSER_USES_JSI_BY_DEFAULT
-#endif
-
 namespace margelo::nitro {
 
 using namespace facebook;
+
+/**
+ * Creates a `react::RawPropsParser` with JSI parsing enabled.
+ *
+ * On React Native < 0.85, JSI parsing had to be explicitly enabled through a
+ * boolean constructor argument. Since React Native 0.85, JSI parsing is always
+ * enabled - the boolean constructor was first deprecated (its argument is
+ * ignored) and will eventually be removed.
+ *
+ * The available constructor is detected at compile-time instead of reading
+ * `<cxxreact/ReactNativeVersion.h>` - see `RawPropsCompat.hpp` for why that
+ * header must not be imported here.
+ */
+template <typename TRawPropsParser = react::RawPropsParser>
+TRawPropsParser makeJsiRawPropsParser() {
+  if constexpr (std::constructible_from<TRawPropsParser, bool>) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    // React Native < 0.87: enable JSI parsing. On 0.85 and 0.86 the argument
+    // is an ignored no-op because JSI parsing is already always enabled.
+    return TRawPropsParser(true);
+#pragma clang diagnostic pop
+  } else {
+    // React Native 0.87+: the boolean constructor is gone, JSI parsing is
+    // always enabled.
+    return TRawPropsParser();
+  }
+}
 
 /**
  * A `react::ConcreteComponentDescriptor` implementation for a Nitro View.
@@ -40,12 +61,7 @@ class ViewComponentDescriptor final : public react::ConcreteComponentDescriptor<
 #endif
 
 public:
-#ifdef RAW_PROPS_PARSER_USES_JSI_BY_DEFAULT
-  explicit ViewComponentDescriptor(const react::ComponentDescriptorParameters& parameters) : Base(parameters, react::RawPropsParser()) {}
-#else
-  explicit ViewComponentDescriptor(const react::ComponentDescriptorParameters& parameters)
-      : Base(parameters, react::RawPropsParser(true)) {}
-#endif
+  explicit ViewComponentDescriptor(const react::ComponentDescriptorParameters& parameters) : Base(parameters, makeJsiRawPropsParser()) {}
 
 public:
   /**


### PR DESCRIPTION
Fixes #1520

## What's happening?

Since 0.37.0 (#1517), iOS builds using `use_frameworks!` fail while building the `NitroModules` clang module:

```
node_modules/react-native/ReactCommon/cxxreact/JSExecutor.h:15:10:
  'jsinspector-modern/InspectorInterfaces.h' file not found

node_modules/react-native-nitro-modules/cpp/views/RawPropsCompat.hpp:8:10:
  could not build module 'cxxreact'
```

## Why

0.37.0 added `RawPropsCompat.hpp` and `ViewComponentDescriptor.hpp` to `public_header_files`, so they are now part of the `NitroModules` modulemap (`DEFINES_MODULE => YES`). Both include `<cxxreact/ReactNativeVersion.h>` to read the `REACT_NATIVE_VERSION_*` macros.

Inside a modular header, that include forces clang to build the `cxxreact` module from the consumer's context. That fails because cxxreact's own headers (e.g. `JSExecutor.h`) need search paths — `jsinspector-modern`, `react/timing` — that are not exposed to third-party pods. The `__has_include` guard in `RawPropsCompat.hpp` doesn't help: the header *is* resolvable, it's building the module that fails. `ViewComponentDescriptor.hpp` had no guard at all.

(`CommonGlobals.cpp` also includes `cxxreact/ReactNativeVersion.h`, but it's a `.cpp` outside the modulemap, so it's untouched and unaffected.)

## The fix

Detect the available React Native APIs at compile-time (C++20) instead of reading version macros, and drop the `cxxreact` include entirely:

- **`RawPropsCompat::at()`** probes for the single-argument `RawProps::at(name)` overload with a `requires`-expression, and falls back to the 0.79–0.86 three-argument overload.
- **`ViewComponentDescriptor`** probes for the `RawPropsParser(bool)` constructor with `std::constructible_from`. While it exists, JSI parsing is enabled through it; once it's removed (0.87+), the default constructor is used.

Behavior is unchanged on every supported React Native version:

| React Native | Before | After |
|---|---|---|
| 0.79–0.84 | `RawPropsParser(true)`, `at(name, nullptr, nullptr)` | same (bool ctor detected, 3-arg `at` detected) |
| 0.85–0.86 | `RawPropsParser()`, `at(name, nullptr, nullptr)` | `RawPropsParser(true)` — a documented `[[deprecated]] /* ignored */` no-op forwarding to the default ctor (warning suppressed locally), `at` unchanged |
| 0.87+ | `RawPropsParser()`, `at(name)` | same (bool ctor gone, 1-arg `at` detected) |

## Validation

Reproduced and verified on a production app (React Native 0.86.2, Expo, New Architecture, `use_frameworks! :linkage => static`, consuming Nitro through `react-native-mmkv`): build fails with the errors above on stock 0.37.0, and succeeds with `0 error(s)` with this patch applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
