### PR TITLE
fix: Hide React Native version checks from public headers

### DIFF
--- a/packages/react-native-nitro-modules/cpp/views/RawPropsCompat.cpp
+++ b/packages/react-native-nitro-modules/cpp/views/RawPropsCompat.cpp
@@ -1,0 +1,35 @@
+//
+// Created by Marc Rousavy on 21.08.26.
+//
+
+#include "RawPropsCompat.hpp"
+
+#if defined(ANDROID) && !defined(FOLLY_NO_CONFIG)
+#define FOLLY_NO_CONFIG 1
+#endif
+
+#include <cxxreact/ReactNativeVersion.h>
+#include <react/renderer/core/RawProps.h>
+#include <react/renderer/core/RawPropsParser.h>
+
+namespace margelo::nitro::RawPropsCompat {
+
+const facebook::react::RawValue* at(const facebook::react::RawProps& props, const char* name) {
+#if REACT_NATIVE_VERSION_MAJOR > 0 || REACT_NATIVE_VERSION_MINOR > 86
+  // React Native 0.87 introduced the canonical single-argument overload.
+  return props.at(name);
+#else
+  return props.at(name, nullptr, nullptr);
+#endif
+}
+
+facebook::react::RawPropsParser makePropsParser() {
+#if REACT_NATIVE_VERSION_MAJOR > 0 || REACT_NATIVE_VERSION_MINOR >= 85
+  // Since React Native 0.85, the RawPropsParser has JSI parsing always enabled by default.
+  return facebook::react::RawPropsParser();
+#else
+  return facebook::react::RawPropsParser(true);
+#endif
+}
+
+} // namespace margelo::nitro::RawPropsCompat

--- a/packages/react-native-nitro-modules/cpp/views/RawPropsCompat.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/RawPropsCompat.hpp
@@ -4,24 +4,15 @@
 
 #pragma once
 
-#if __has_include(<cxxreact/ReactNativeVersion.h>)
-#include <cxxreact/ReactNativeVersion.h>
-#endif
-#include <react/renderer/core/RawProps.h>
+namespace facebook::react {
+class RawProps;
+class RawPropsParser;
+class RawValue;
+} // namespace facebook::react
 
 namespace margelo::nitro::RawPropsCompat {
 
-/**
- * Same as `props.at(name)`, with compatibility for React Native 0.79 through
- * 0.86, where `RawProps::at(...)` requires prefix and suffix arguments.
- */
-inline const facebook::react::RawValue* at(const facebook::react::RawProps& props, const char* name) {
-#if defined(REACT_NATIVE_VERSION_MAJOR) && (REACT_NATIVE_VERSION_MAJOR > 0 || REACT_NATIVE_VERSION_MINOR > 86)
-  // React Native 0.87 introduced the canonical single-argument overload.
-  return props.at(name);
-#else
-  return props.at(name, nullptr, nullptr);
-#endif
-}
+const facebook::react::RawValue* at(const facebook::react::RawProps& props, const char* name);
+facebook::react::RawPropsParser makePropsParser();
 
 } // namespace margelo::nitro::RawPropsCompat

--- a/packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp
@@ -4,17 +4,12 @@
 
 #pragma once
 
+#include "RawPropsCompat.hpp"
+
 #include <concepts>
-#include <cxxreact/ReactNativeVersion.h>
 #include <memory>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include <utility>
-
-#if REACT_NATIVE_VERSION_MAJOR != 0 || REACT_NATIVE_VERSION_MINOR >= 85
-// Since React Native 0.85, the RawPropsParser has JSI Parsing always enabled
-// by default, and the boolean argument has been removed.
-#define RAW_PROPS_PARSER_USES_JSI_BY_DEFAULT
-#endif
 
 namespace margelo::nitro {
 
@@ -40,12 +35,8 @@ class ViewComponentDescriptor final : public react::ConcreteComponentDescriptor<
 #endif
 
 public:
-#ifdef RAW_PROPS_PARSER_USES_JSI_BY_DEFAULT
-  explicit ViewComponentDescriptor(const react::ComponentDescriptorParameters& parameters) : Base(parameters, react::RawPropsParser()) {}
-#else
   explicit ViewComponentDescriptor(const react::ComponentDescriptorParameters& parameters)
-      : Base(parameters, react::RawPropsParser(true)) {}
-#endif
+      : Base(parameters, RawPropsCompat::makePropsParser()) {}
 
 public:
   /**


### PR DESCRIPTION
Fixes #1520.

This takes the compatibility goal from #1519 but keeps the version-dependent React Native APIs out of NitroModules public modular headers without compile-time API probing.

- RawPropsCompat.hpp now contains only forward declarations plus at() and makePropsParser() declarations.
- RawPropsCompat.cpp owns the ReactNativeVersion.h include and the RN-version-specific implementations.
- ViewComponentDescriptor delegates parser construction to RawPropsCompat::makePropsParser().
- Android keeps the React Native-required FOLLY_NO_CONFIG detail local to this translation unit, with no new CMake compile definitions.

Validation:
- Full iOS example build with USE_FRAMEWORKS=static and static framework linkage
- Full Android arm64-v8a assembleDebug build
- Verified the relevant RawProps and RawPropsParser signatures against upstream React Native 0.79.0 and 0.87.0 sources