### PR TITLE
fix: Report native ArrayBuffer memory pressure

### DIFF
--- a/example/__tests__/nitro.harness.ts
+++ b/example/__tests__/nitro.harness.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'react-native-harness'
+import { describe, expect, it } from 'react-native-harness'
 import { NitroModules } from 'react-native-nitro-modules'
 import type {
   TestObjectCpp,
@@ -32,3 +32,28 @@ const testObjectSwiftKotlin =
 
 describe('TestObject (C++)', createTestRunner(testObjectCpp))
 describe('TestObject (Swift/Kotlin)', createTestRunner(testObjectSwiftKotlin))
+
+describe('ArrayBuffer external memory', () => {
+  it('reports native buffer memory pressure to Hermes', () => {
+    type HermesInternal = {
+      getInstrumentedStats(): { js_externalBytes: number }
+    }
+    const hermesInternal = (
+      globalThis as typeof globalThis & { HermesInternal?: HermesInternal }
+    ).HermesInternal
+
+    if (hermesInternal == null) {
+      return
+    }
+
+    const size = 1024 * 1024
+    const externalBytesBefore =
+      hermesInternal.getInstrumentedStats().js_externalBytes
+    const buffer = NitroModules.createNativeArrayBuffer(size)
+    const externalBytesAfter =
+      hermesInternal.getInstrumentedStats().js_externalBytes
+
+    expect(buffer.byteLength).toBe(size)
+    expect(externalBytesAfter - externalBytesBefore).toBe(size)
+  })
+})

--- a/example/__tests__/nitro.harness.ts
+++ b/example/__tests__/nitro.harness.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'react-native-harness'
+import { describe, it } from 'react-native-harness'
 import { NitroModules } from 'react-native-nitro-modules'
 import type {
   TestObjectCpp,
@@ -32,28 +32,3 @@ const testObjectSwiftKotlin =
 
 describe('TestObject (C++)', createTestRunner(testObjectCpp))
 describe('TestObject (Swift/Kotlin)', createTestRunner(testObjectSwiftKotlin))
-
-describe('ArrayBuffer external memory', () => {
-  it('reports native buffer memory pressure to Hermes', () => {
-    type HermesInternal = {
-      getInstrumentedStats(): { js_externalBytes: number }
-    }
-    const hermesInternal = (
-      globalThis as typeof globalThis & { HermesInternal?: HermesInternal }
-    ).HermesInternal
-
-    if (hermesInternal == null) {
-      return
-    }
-
-    const size = 1024 * 1024
-    const externalBytesBefore =
-      hermesInternal.getInstrumentedStats().js_externalBytes
-    const buffer = NitroModules.createNativeArrayBuffer(size)
-    const externalBytesAfter =
-      hermesInternal.getInstrumentedStats().js_externalBytes
-
-    expect(buffer.byteLength).toBe(size)
-    expect(externalBytesAfter - externalBytesBefore).toBe(size)
-  })
-})

--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -2481,6 +2481,42 @@ export function getTests(
         .didReturn('number')
         .equals(13)
     ),
+    createTest(
+      'NitroModules.createNativeArrayBuffer(...) reports external memory pressure',
+      () =>
+        it(() => {
+          type HermesInternal = {
+            getInstrumentedStats?: () => { js_externalBytes: number }
+          }
+          const hermesInternal = (
+            globalThis as typeof globalThis & {
+              HermesInternal?: HermesInternal
+            }
+          ).HermesInternal
+
+          if (hermesInternal?.getInstrumentedStats == null) {
+            throw new Error('Hermes instrumentation is unavailable!')
+          }
+
+          const size = 1024 * 1024
+          const externalBytesBefore =
+            hermesInternal.getInstrumentedStats().js_externalBytes
+          const buffer = NitroModules.createNativeArrayBuffer(size)
+          const externalBytesAfter =
+            hermesInternal.getInstrumentedStats().js_externalBytes
+
+          if (buffer.byteLength !== size) {
+            throw new Error(
+              `Expected a ${size}-byte ArrayBuffer, but received ${buffer.byteLength} bytes!`
+            )
+          }
+
+          return externalBytesAfter - externalBytesBefore
+        })
+          .didNotThrow()
+          .didReturn('number')
+          .equals(1024 * 1024)
+    ),
     createTest('NitroModules.buildType holds a string', () =>
       it(() => {
         return NitroModules.buildType

--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/ByteBufferArrayBuffer.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/ByteBufferArrayBuffer.hpp
@@ -39,6 +39,9 @@ public:
   [[nodiscard]] bool isOwner() const noexcept override {
     return _byteBuffer != nullptr && _byteBuffer->isDirect();
   }
+  [[nodiscard]] size_t getExternalMemorySize() const override {
+    return isOwner() ? size() : 0;
+  }
 
 public:
   [[nodiscard]] const jni::global_ref<jni::JByteBuffer>& getBuffer() const {

--- a/packages/react-native-nitro-modules/android/src/main/cpp/core/HardwareBufferArrayBuffer.hpp
+++ b/packages/react-native-nitro-modules/android/src/main/cpp/core/HardwareBufferArrayBuffer.hpp
@@ -88,6 +88,9 @@ public:
   [[nodiscard]] bool isOwner() const noexcept override {
     return true;
   }
+  [[nodiscard]] size_t getExternalMemorySize() const override {
+    return size();
+  }
 
 public:
   [[nodiscard]] AHardwareBuffer* getBuffer() const {

--- a/packages/react-native-nitro-modules/cpp/core/ArrayBuffer.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/ArrayBuffer.cpp
@@ -69,6 +69,10 @@ bool NativeArrayBuffer::isOwner() const noexcept {
   return _deleteFunc != nullptr;
 }
 
+size_t NativeArrayBuffer::getExternalMemorySize() const {
+  return isOwner() ? _size : 0;
+}
+
 // 3. JSArrayBuffer
 
 JSArrayBuffer::JSArrayBuffer(jsi::Runtime& runtime, BorrowingReference<jsi::ArrayBuffer> jsReference)

--- a/packages/react-native-nitro-modules/cpp/core/ArrayBuffer.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/ArrayBuffer.hpp
@@ -48,6 +48,17 @@ public:
    * memory that we didn't allocate, or from JS - which can be deleted at any point).
    */
   virtual bool isOwner() const noexcept = 0;
+  /**
+   * Gets the size of any external memory retained by this `ArrayBuffer`, in bytes.
+   * This is reported to the JS VM when the buffer is converted to a `jsi::ArrayBuffer`
+   * so it can account for memory that is not allocated by the VM itself.
+   *
+   * JS-backed and borrowed buffers return `0` because their memory is either already
+   * tracked by the JS VM or is not retained by this `ArrayBuffer`.
+   */
+  virtual size_t getExternalMemorySize() const {
+    return 0;
+  }
 
 public:
   /**
@@ -106,6 +117,7 @@ public:
   uint8_t* NON_NULL data() override;
   size_t size() const override;
   bool isOwner() const noexcept override;
+  size_t getExternalMemorySize() const override;
 
 private:
   uint8_t* NON_NULL _data;

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+ArrayBuffer.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+ArrayBuffer.hpp
@@ -84,7 +84,14 @@ struct JSIConverter<T, std::enable_if_t<is_shared_ptr_to_v<T, jsi::MutableBuffer
     // 2. Wrap jsi::MutableBuffer in jsi::NativeState holder & attach it
     auto mutableBufferHolder = std::make_shared<MutableBufferNativeState>(buffer);
     arrayBuffer.setNativeState(runtime, mutableBufferHolder);
-    // 3. Return jsi::ArrayBuffer (with jsi::NativeState) to JS
+    // 3. Notify the JS VM about memory retained outside of its heap
+    if (auto nitroBuffer = std::dynamic_pointer_cast<ArrayBuffer>(buffer)) {
+      size_t externalMemorySize = nitroBuffer->getExternalMemorySize();
+      if (externalMemorySize > 0) {
+        arrayBuffer.setExternalMemoryPressure(runtime, externalMemorySize);
+      }
+    }
+    // 4. Return jsi::ArrayBuffer (with jsi::NativeState) to JS
     return arrayBuffer;
   }
   static inline bool canConvert(jsi::Runtime& runtime, const jsi::Value& value) {


### PR DESCRIPTION
## Summary

- report retained native `ArrayBuffer` allocations to the JS VM through `setExternalMemoryPressure`
- add an overridable external-memory byte count that defaults to zero for JS-backed and borrowed buffers
- report owned C++ buffers, direct JNI `ByteBuffer`s, and Android `HardwareBuffer`s
- add a deterministic Hermes harness test against `js_externalBytes`

## Why

JSI only forwards a `MutableBuffer` to the runtime when constructing an `ArrayBuffer`. In Hermes, JS-allocated ArrayBuffers call `creditExternalMemory`, while the external data block used by the JSI `MutableBuffer` path does not. `size()` still supplies the byte length and malloc-size estimate, but it does not credit the allocation to the GC heuristics.

Relevant engine paths:
- https://github.com/facebook/hermes/blob/dac0be313827a843db751b7978f13f021b1a8c86/API/hermes/hermes.cpp#L2457-L2473
- https://github.com/facebook/hermes/blob/dac0be313827a843db751b7978f13f021b1a8c86/lib/VM/JSArrayBuffer.cpp

## Validation

- `bun typecheck`
- `bun --cwd example lint-ci`
- `./scripts/clang-format.sh`
- `bun --cwd example build:android`
- focused Android/Hermes harness test: 1 passed, 534 skipped