### PR TITLE
test: Verify HybridObject memory pressure

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -47,6 +47,23 @@ export interface TestRunner {
 // 1) It's a lot of allocations and any VM (JS, JVM) will likely trigger GC
 // 2) In JVM, 51_200 is the limit for `jni::global_ref`s, then the app crashes - this intentionally exhausts that
 const MEMORY_LEAK_TEST_ALLOCATION_COUNT = 55_000
+const EXTERNAL_MEMORY_TEST_SIZE = 1024 * 1024
+
+type HermesInternal = {
+  getInstrumentedStats?: () => { js_externalBytes: number }
+}
+
+function getHermesExternalMemorySize(): number {
+  const hermesInternal = (
+    globalThis as typeof globalThis & { HermesInternal?: HermesInternal }
+  ).HermesInternal
+
+  if (hermesInternal?.getInstrumentedStats == null) {
+    throw new Error('Hermes instrumentation is unavailable!')
+  }
+
+  return hermesInternal.getInstrumentedStats().js_externalBytes
+}
 
 /**
  * Options for getTests function
@@ -2465,10 +2482,30 @@ export function getTests(
         .didNotThrow()
         .didReturn('string')
     ),
-    createTest('NitroModules.updateMemorySize(obj) works (roundtrip)', () =>
-      it(() => {
-        NitroModules.updateMemorySize(testObject)
-      }).didNotThrow()
+    createTest(
+      'NitroModules.updateMemorySize(obj) updates external memory pressure',
+      () =>
+        it(() => {
+          const originalString = testObject.stringValue
+
+          try {
+            testObject.stringValue = ''
+            NitroModules.updateMemorySize(testObject)
+
+            testObject.stringValue = 'x'.repeat(EXTERNAL_MEMORY_TEST_SIZE)
+            const externalBytesBefore = getHermesExternalMemorySize()
+            NitroModules.updateMemorySize(testObject)
+            const externalBytesAfter = getHermesExternalMemorySize()
+
+            return externalBytesAfter - externalBytesBefore
+          } finally {
+            testObject.stringValue = originalString
+            NitroModules.updateMemorySize(testObject)
+          }
+        })
+          .didNotThrow()
+          .didReturn('number')
+          .equals(EXTERNAL_MEMORY_TEST_SIZE)
     ),
     createTest('NitroModules.createNativeArrayBuffer(...) works', () =>
       it(() => {
@@ -2485,25 +2522,10 @@ export function getTests(
       'NitroModules.createNativeArrayBuffer(...) reports external memory pressure',
       () =>
         it(() => {
-          type HermesInternal = {
-            getInstrumentedStats?: () => { js_externalBytes: number }
-          }
-          const hermesInternal = (
-            globalThis as typeof globalThis & {
-              HermesInternal?: HermesInternal
-            }
-          ).HermesInternal
-
-          if (hermesInternal?.getInstrumentedStats == null) {
-            throw new Error('Hermes instrumentation is unavailable!')
-          }
-
-          const size = 1024 * 1024
-          const externalBytesBefore =
-            hermesInternal.getInstrumentedStats().js_externalBytes
+          const size = EXTERNAL_MEMORY_TEST_SIZE
+          const externalBytesBefore = getHermesExternalMemorySize()
           const buffer = NitroModules.createNativeArrayBuffer(size)
-          const externalBytesAfter =
-            hermesInternal.getInstrumentedStats().js_externalBytes
+          const externalBytesAfter = getHermesExternalMemorySize()
 
           if (buffer.byteLength !== size) {
             throw new Error(
@@ -2515,7 +2537,7 @@ export function getTests(
         })
           .didNotThrow()
           .didReturn('number')
-          .equals(1024 * 1024)
+          .equals(EXTERNAL_MEMORY_TEST_SIZE)
     ),
     createTest('NitroModules.buildType holds a string', () =>
       it(() => {

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
@@ -21,6 +21,8 @@ class HybridTestObjectKotlin : HybridTestObjectSwiftKotlinSpec() {
   override var numberValue: Double = 0.0
   override var boolValue: Boolean = false
   override var stringValue: String = ""
+  override val memorySize: Long
+    get() = stringValue.length.toLong()
   override var int64Value: Long = 0L
   override var uint64Value: ULong = 0u
   override var optionalString: String? = null

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
@@ -18,6 +18,10 @@
 
 namespace margelo::nitro::test {
 
+size_t HybridTestObjectCpp::getExternalMemorySize() noexcept {
+  return _string.size();
+}
+
 // Properties
 double HybridTestObjectCpp::getNumberValue() {
   return _number;

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
@@ -23,6 +23,9 @@ class HybridTestObjectCpp : public HybridTestObjectCppSpec {
 public:
   HybridTestObjectCpp() : HybridObject(TAG) {}
 
+protected:
+  size_t getExternalMemorySize() noexcept override;
+
 private:
   double _number;
   bool _bool;

--- a/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
@@ -19,6 +19,10 @@ class HybridTestObjectSwift: HybridTestObjectSwiftKotlinSpec {
 
   var stringValue: String = ""
 
+  var memorySize: Int {
+    return stringValue.utf8.count
+  }
+
   var int64Value: Int64 = 0
 
   var uint64Value: UInt64 = 0


### PR DESCRIPTION
## Summary

- make C++, Kotlin, and Swift test HybridObjects report their native string allocation through `memorySize`
- verify `NitroModules.updateMemorySize()` changes Hermes `js_externalBytes` by the exact reported amount
- reuse one Hermes instrumentation helper for HybridObject and ArrayBuffer coverage

## Validation

- `bun typecheck`
- `bun --cwd example lint-ci`
- C++, Kotlin, and Swift format scripts
- `bun --cwd example build:android`
- focused Android/Hermes harness test: 2 passed across C++ and Kotlin HybridObjects

Local iOS compilation could not start because this worktree has no `Pods` installation. The PR iOS jobs will compile and run the shared test against the Swift implementation.