### PR TITLE
fix(nitrogen): ignore optional never properties

### DIFF
--- a/packages/nitrogen/src/syntax/getInterfaceProperties.ts
+++ b/packages/nitrogen/src/syntax/getInterfaceProperties.ts
@@ -12,10 +12,19 @@ export function getInterfaceProperties(
     throw new Error(
       `Interface "${interfaceType.getText()}" does not have a Symbol!`
     )
-  return interfaceType.getProperties().map((prop) => {
+  return interfaceType.getProperties().flatMap((prop) => {
     const propDeclaration = prop
       .getDeclarations()
       .find((declaration) => Node.isPropertySignature(declaration))
+    // `property?: never` is a type-only marker for exclusive unions.
+    // TypeScript resolves the property itself to `undefined`, so inspect its node.
+    if (
+      prop.isOptional() &&
+      propDeclaration?.getTypeNode()?.getType().isNever()
+    ) {
+      return []
+    }
+
     let propType = prop.getDeclaredType()
     if (propType.isAny() || propType.isUnknown()) {
       // the interface is aliased/merged - we need to look into the actual declaration
@@ -35,6 +44,6 @@ export function getInterfaceProperties(
       prop.isOptional() || propType.isNullable(),
       propDeclaration?.getTypeNode()
     )
-    return refType
+    return [refType]
   })
 }

--- a/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
@@ -47,6 +47,7 @@ export interface Car {
   year: number
   make: string
   model: string
+  purelyTypeLevel?: never
   power: number
   powertrain: Powertrain
   driver?: Person


### PR DESCRIPTION
## Summary

- treat optional `never` properties as TypeScript-only exclusivity markers
- inspect the property type node before TypeScript normalizes `property?: never` to `undefined`
- leave required `never` properties on the existing unsupported-type error path
- add a minimal compile-time regression to the existing `Car` spec

## TDD evidence

**RED:** with only `purelyTypeLevel?: never` added, Nitrogen exited 1 while generating `Child`, `TestObjectCpp`, and `TestObjectSwiftKotlin` because the optional property resolved to an unsupported `undefined` type.

**GREEN:** after the parser change, the official `bun specs` command generated 7/7 HybridObjects successfully. The generated C++/Swift/Kotlin output has no `purelyTypeLevel` field and produces no tracked generated-file diff.

## Verification

- `bun specs`
- `bun run build`
- `bun typecheck`
- `bun --cwd packages/nitrogen lint-ci`
- `bun --cwd packages/react-native-nitro-test lint-ci`
- `git diff --check`

No dependency, lockfile, or generated native file changes.

Closes #1482