### PR TITLE
fix: avoid native view registry on web

### DIFF
--- a/packages/react-native-nitro-modules/src/__tests__/getHostComponent.web.test.ts
+++ b/packages/react-native-nitro-modules/src/__tests__/getHostComponent.web.test.ts
@@ -1,0 +1,18 @@
+jest.mock(
+  'react-native/Libraries/NativeComponent/NativeComponentRegistry',
+  () => {
+    throw new Error('NativeComponentRegistry must not be loaded on web')
+  }
+)
+
+import { getHostComponent } from '../views/getHostComponent.web'
+
+describe('getHostComponent on web', () => {
+  it('loads without importing native React Native internals', () => {
+    expect(() =>
+      getHostComponent('TestView', () => {
+        throw new Error('View config must not be read on web')
+      })
+    ).toThrow('Nitro View "TestView" is not supported on web')
+  })
+})

--- a/packages/react-native-nitro-modules/src/views/getHostComponent.web.ts
+++ b/packages/react-native-nitro-modules/src/views/getHostComponent.web.ts
@@ -1,0 +1,21 @@
+import type { HybridViewMethods, HybridViewProps } from './HybridView'
+import type { ReactNativeView, ViewConfig } from './getHostComponent'
+
+export type {
+  NitroViewWrappedCallback,
+  ReactNativeView,
+  ViewConfig,
+} from './getHostComponent'
+
+/**
+ * Nitro Views are native-only and cannot create a HostComponent on web.
+ */
+export function getHostComponent<
+  Props extends HybridViewProps,
+  Methods extends HybridViewMethods,
+>(
+  name: string,
+  _getViewConfig: () => ViewConfig<Props>
+): ReactNativeView<Props, Methods> {
+  throw new Error(`Nitro View "${name}" is not supported on web`)
+}


### PR DESCRIPTION
## Summary

- add a platform-specific `getHostComponent.web.ts` so web resolution never imports React Native's native `NativeComponentRegistry`
- preserve the existing `ViewConfig`, `ReactNativeView`, and callback wrapper type exports through type-only re-exports
- throw a targeted error only when a consumer tries to create a native-only Nitro View on web
- add a regression test whose native-registry mock throws if the web module imports it

The emitted ESM and CommonJS web files contain no runtime imports, `NativeComponentRegistry`, or `react-native/Libraries/NativeComponent` paths.

## Verification

- RED: `bun install` / package typecheck failed because `getHostComponent.web` did not exist
- focused web regression test passes
- `bun run build`
- full core package Jest suite passes (1 test, 1 existing todo)
- monorepo `bun typecheck`
- `bun nitro lint-ci`
- full JavaScript/TypeScript `bun lint`
- built ESM/CJS output inspected and asserted free of native registry imports
- `git diff --check`

Fixes #1216
