### PR TITLE
fix: Handle primitive HybridObject instanceof

### DIFF
--- a/packages/react-native-nitro-modules/src/__tests__/index.test.tsx
+++ b/packages/react-native-nitro-modules/src/__tests__/index.test.tsx
@@ -1,1 +1,22 @@
-it.todo('write a test')
+const mockHybridPrototype = {}
+const mockCreateHybridObject = jest.fn(() => Object.create(mockHybridPrototype))
+
+jest.mock('../NitroModules', () => ({
+  NitroModules: {
+    createHybridObject: mockCreateHybridObject,
+  },
+}))
+
+const { getHybridObjectConstructor } = require('../getHybridObjectConstructor')
+
+describe('getHybridObjectConstructor', () => {
+  it.each([null, undefined, true, 42, 'value', Symbol('value'), 1n])(
+    'returns false for non-object value %p',
+    (value) => {
+      const HybridObject = getHybridObjectConstructor('TestObject')
+
+      expect((value as any) instanceof HybridObject).toBe(false)
+      expect(mockCreateHybridObject).not.toHaveBeenCalled()
+    }
+  )
+})

--- a/packages/react-native-nitro-modules/src/getHybridObjectConstructor.ts
+++ b/packages/react-native-nitro-modules/src/getHybridObjectConstructor.ts
@@ -41,6 +41,13 @@ export function getHybridObjectConstructor<T extends HybridObject<{}>>(
   constructorFunc.prototypeInitialized = false
   Object.defineProperty(constructorFunc, Symbol.hasInstance, {
     value: (instance: unknown) => {
+      if (
+        instance == null ||
+        (typeof instance !== 'object' && typeof instance !== 'function')
+      ) {
+        return false
+      }
+
       if (!constructorFunc.prototypeInitialized) {
         // User didn't call `new T()` yet, so we don't
         // know the prototype yet. Just create one temp object to find


### PR DESCRIPTION
## Summary

- Return `false` before prototype inspection for nullish and primitive `instanceof` operands.
- Avoid lazy native HybridObject allocation for values that cannot be instances.
- Add a seven-value Jest regression matrix.

## Breaking changes

None. Primitive operands now match ordinary JavaScript `instanceof` behavior instead of throwing.

## Verification

- `bun nitro test --runInBand`
- `bun nitro typecheck`
- `bun nitro lint-ci`
- `git diff --check`

## Preview

Not applicable; this is a nonvisual runtime correction.

Fixes #1543