### PR TITLE
fix: Validate native ArrayBuffer sizes

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -2539,6 +2539,21 @@ export function getTests(
           .didReturn('number')
           .equals(EXTERNAL_MEMORY_TEST_SIZE)
     ),
+    createTest('createNativeArrayBuffer rejects negative sizes', () =>
+      it(() => NitroModules.createNativeArrayBuffer(-1)).didThrow(
+        'ArrayBuffer size must be a finite, non-negative number'
+      )
+    ),
+    createTest('createNativeArrayBuffer rejects infinite sizes', () =>
+      it(() => NitroModules.createNativeArrayBuffer(Infinity)).didThrow(
+        'ArrayBuffer size must be a finite, non-negative number'
+      )
+    ),
+    createTest('createNativeArrayBuffer rejects oversized values', () =>
+      it(() => NitroModules.createNativeArrayBuffer(Number.MAX_VALUE)).didThrow(
+        'ArrayBuffer size must be a finite, non-negative number'
+      )
+    ),
     createTest('NitroModules.buildType holds a string', () =>
       it(() => {
         return NitroModules.buildType

--- a/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.cpp
+++ b/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.cpp
@@ -9,6 +9,8 @@
 #include "HybridObjectRegistry.hpp"
 #include "JSIConverter.hpp"
 #include "NitroDefines.hpp"
+#include <cmath>
+#include <limits>
 
 namespace margelo::nitro {
 
@@ -80,6 +82,10 @@ std::shared_ptr<HybridObject> HybridNitroModulesProxy::updateMemorySize(const st
 }
 
 std::shared_ptr<ArrayBuffer> HybridNitroModulesProxy::createNativeArrayBuffer(double size) {
+  if (!std::isfinite(size) || size < 0 || static_cast<long double>(size) > static_cast<long double>(std::numeric_limits<size_t>::max()))
+      [[unlikely]] {
+    throw std::invalid_argument("ArrayBuffer size must be a finite, non-negative number within the platform size limit!");
+  }
   return ArrayBuffer::allocate(static_cast<size_t>(size));
 }
 


### PR DESCRIPTION
## Summary

- Reject non-finite, negative, and platform-out-of-range native ArrayBuffer sizes before conversion.
- Add native harness coverage for negative, infinite, and oversized JavaScript inputs.
- Rebase onto current main while preserving the newly added external-memory-pressure harness coverage.

## Breaking changes

Invalid sizes now reject deterministically instead of reaching an unsafe conversion/allocation. Valid sizes are unchanged.

## Verification

- Current-main root build, package/example typechecks, package lint, and `git diff --check` passed.
- Original focused branch also passed C++ format, a full iOS Simulator native build, and focused iOS Harness: 8 tests across both native test matrices; 520 unrelated tests skipped. The rebased source fix is identical; only the adjacent upstream harness test required conflict resolution.

## Preview

Not applicable; this is a nonvisual native validation fix.

Fixes #1545