### PR TITLE
fix: Allow nullable Kotlin Promise results

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -1564,6 +1564,11 @@ export function getTests(
         .didNotThrow()
         .equals(undefined)
     ),
+    createTest('awaitNullablePromise() works', async () =>
+      (await it(() => testObject.awaitNullablePromise()))
+        .didNotThrow()
+        .equals(undefined)
+    ),
     createTest('twoPromises can run in parallel', async () =>
       (
         await it(async () => {

--- a/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/Promise.kt
+++ b/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/Promise.kt
@@ -67,7 +67,7 @@ class Promise<T> {
   fun then(listener: (result: T) -> Unit): Promise<T> {
     addOnResolvedListener { boxedResult ->
       @Suppress("UNCHECKED_CAST")
-      val result = boxedResult as? T ?: throw Error("Failed to cast Object to T!")
+      val result = boxedResult as T
       listener(result)
     }
     return this

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
@@ -324,6 +324,12 @@ class HybridTestObjectKotlin : HybridTestObjectSwiftKotlinSpec() {
     return Promise.resolved(null)
   }
 
+  override fun awaitNullablePromise(): Promise<Double?> {
+    return Promise.async {
+      Promise.resolved<Double?>(null).await()
+    }
+  }
+
   override fun awaitAndGetPromise(promise: Promise<Double>): Promise<Double> {
     return Promise.async {
       val result = promise.await()

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
@@ -619,6 +619,13 @@ std::shared_ptr<Promise<std::optional<double>>> HybridTestObjectCpp::promiseThat
   return Promise<std::optional<double>>::resolved(std::nullopt);
 }
 
+std::shared_ptr<Promise<std::optional<double>>> HybridTestObjectCpp::awaitNullablePromise() {
+  return Promise<std::optional<double>>::async([]() {
+    auto promise = Promise<std::optional<double>>::resolved(std::nullopt);
+    return promise->await().get();
+  });
+}
+
 void HybridTestObjectCpp::callAll(const std::function<void()>& first, const std::function<void()>& second,
                                   const std::function<void()>& third) {
   first();

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
@@ -207,6 +207,7 @@ public:
   std::shared_ptr<Promise<double>> promiseReturnsInstantlyAsync() override;
   std::shared_ptr<Promise<void>> promiseThatResolvesVoidInstantly() override;
   std::shared_ptr<Promise<std::optional<double>>> promiseThatResolvesToUndefined() override;
+  std::shared_ptr<Promise<std::optional<double>>> awaitNullablePromise() override;
   Car getCar() override;
   bool isCarElectric(const Car& car) override;
   bool areCarsEqual(const Car& a, const Car& b) override;

--- a/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
@@ -472,6 +472,12 @@ class HybridTestObjectSwift: HybridTestObjectSwiftKotlinSpec {
     return Promise.resolved(withResult: nil)
   }
 
+  func awaitNullablePromise() throws -> Promise<Double?> {
+    return Promise.async {
+      try await Promise<Double?>.resolved(withResult: nil).await()
+    }
+  }
+
   func awaitAndGetPromise(promise: Promise<Double>) throws -> Promise<Double> {
     return .async {
       let result = try await promise.await()

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -1108,6 +1108,22 @@ namespace margelo::nitro::test {
       return __promise;
     }();
   }
+  std::shared_ptr<Promise<std::optional<double>>> JHybridTestObjectSwiftKotlinSpec::awaitNullablePromise() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("awaitNullablePromise");
+    auto __result = method(_javaPart);
+    return [&]() {
+      auto __promise = Promise<std::optional<double>>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
+        __promise->resolve(__result != nullptr ? std::make_optional(__result->value()) : std::nullopt);
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
+  }
   std::shared_ptr<Promise<double>> JHybridTestObjectSwiftKotlinSpec::awaitAndGetPromise(const std::shared_ptr<Promise<double>>& promise) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JPromise::javaobject> /* promise */)>("awaitAndGetPromise");
     auto __result = method(_javaPart, [&]() {

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -144,6 +144,7 @@ namespace margelo::nitro::test {
     std::shared_ptr<Promise<double>> promiseReturnsInstantlyAsync() override;
     std::shared_ptr<Promise<void>> promiseThatResolvesVoidInstantly() override;
     std::shared_ptr<Promise<std::optional<double>>> promiseThatResolvesToUndefined() override;
+    std::shared_ptr<Promise<std::optional<double>>> awaitNullablePromise() override;
     std::shared_ptr<Promise<double>> awaitAndGetPromise(const std::shared_ptr<Promise<double>>& promise) override;
     std::shared_ptr<Promise<Car>> awaitAndGetComplexPromise(const std::shared_ptr<Promise<Car>>& promise) override;
     std::shared_ptr<Promise<void>> awaitPromise(const std::shared_ptr<Promise<void>>& promise) override;

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec.kt
@@ -34,13 +34,13 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @get:DoNotStrip
   @get:Keep
   abstract val thisObject: HybridTestObjectSwiftKotlinSpec
-
+  
   @get:DoNotStrip
   @get:Keep
   @set:DoNotStrip
   @set:Keep
   abstract var optionalHybrid: HybridTestObjectSwiftKotlinSpec?
-
+  
   @get:DoNotStrip
   @get:Keep
   @set:DoNotStrip
@@ -389,7 +389,7 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @DoNotStrip
   @Keep
   abstract fun awaitNullablePromise(): Promise<Double?>
-
+  
   @DoNotStrip
   @Keep
   abstract fun awaitAndGetPromise(promise: Promise<Double>): Promise<Double>

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec.kt
@@ -34,13 +34,13 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @get:DoNotStrip
   @get:Keep
   abstract val thisObject: HybridTestObjectSwiftKotlinSpec
-  
+
   @get:DoNotStrip
   @get:Keep
   @set:DoNotStrip
   @set:Keep
   abstract var optionalHybrid: HybridTestObjectSwiftKotlinSpec?
-  
+
   @get:DoNotStrip
   @get:Keep
   @set:DoNotStrip
@@ -386,6 +386,10 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @Keep
   abstract fun promiseThatResolvesToUndefined(): Promise<Double?>
   
+  @DoNotStrip
+  @Keep
+  abstract fun awaitNullablePromise(): Promise<Double?>
+
   @DoNotStrip
   @Keep
   abstract fun awaitAndGetPromise(promise: Promise<Double>): Promise<Double>

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -680,6 +680,14 @@ namespace margelo::nitro::test {
       auto __value = std::move(__result.value());
       return __value;
     }
+    inline std::shared_ptr<Promise<std::optional<double>>> awaitNullablePromise() override {
+      auto __result = _swiftPart.awaitNullablePromise();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
     inline std::shared_ptr<Promise<double>> awaitAndGetPromise(const std::shared_ptr<Promise<double>>& promise) override {
       auto __result = _swiftPart.awaitAndGetPromise(promise);
       if (__result.hasError()) [[unlikely]] {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -86,6 +86,7 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: HybridObject {
   func promiseReturnsInstantlyAsync() throws -> Promise<Double>
   func promiseThatResolvesVoidInstantly() throws -> Promise<Void>
   func promiseThatResolvesToUndefined() throws -> Promise<Double?>
+  func awaitNullablePromise() throws -> Promise<Double?>
   func awaitAndGetPromise(promise: Promise<Double>) throws -> Promise<Double>
   func awaitAndGetComplexPromise(promise: Promise<Car>) throws -> Promise<Car>
   func awaitPromise(promise: Promise<Void>) throws -> Promise<Void>

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -85,7 +85,7 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
     }
   }
 
-
+  
 
   /**
    * Get the memory size of the Swift class (plus size of any other allocations)
@@ -131,7 +131,7 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
       }()
     }
   }
-
+  
   public final var optionalHybrid: bridge.std__optional_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__ {
     @inline(__always)
     get {
@@ -1607,7 +1607,7 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
       return bridge.create_Result_std__shared_ptr_Promise_std__optional_double____(__exceptionPtr)
     }
   }
-
+  
   @inline(__always)
   public final func awaitNullablePromise() -> bridge.Result_std__shared_ptr_Promise_std__optional_double____ {
     do {
@@ -1632,7 +1632,7 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
       return bridge.create_Result_std__shared_ptr_Promise_std__optional_double____(__exceptionPtr)
     }
   }
-
+  
   @inline(__always)
   public final func awaitAndGetPromise(promise: bridge.std__shared_ptr_Promise_double__) -> bridge.Result_std__shared_ptr_Promise_double___ {
     do {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -85,7 +85,7 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
     }
   }
 
-  
+
 
   /**
    * Get the memory size of the Swift class (plus size of any other allocations)
@@ -131,7 +131,7 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
       }()
     }
   }
-  
+
   public final var optionalHybrid: bridge.std__optional_std__shared_ptr_HybridTestObjectSwiftKotlinSpec__ {
     @inline(__always)
     get {
@@ -1607,7 +1607,32 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
       return bridge.create_Result_std__shared_ptr_Promise_std__optional_double____(__exceptionPtr)
     }
   }
-  
+
+  @inline(__always)
+  public final func awaitNullablePromise() -> bridge.Result_std__shared_ptr_Promise_std__optional_double____ {
+    do {
+      let __result = try self.__implementation.awaitNullablePromise()
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_std__optional_double___ in
+        let __promise = bridge.create_std__shared_ptr_Promise_std__optional_double___()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_std__optional_double___(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve({ () -> bridge.std__optional_double_ in
+              if let __unwrappedValue = __result {
+                return bridge.create_std__optional_double_(__unwrappedValue)
+              } else {
+                return .init()
+              }
+            }()) })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_std__optional_double____(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_std__optional_double____(__exceptionPtr)
+    }
+  }
+
   @inline(__always)
   public final func awaitAndGetPromise(promise: bridge.std__shared_ptr_Promise_double__) -> bridge.Result_std__shared_ptr_Promise_double___ {
     do {

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -113,6 +113,7 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("promiseReturnsInstantlyAsync", &HybridTestObjectCppSpec::promiseReturnsInstantlyAsync);
       prototype.registerHybridMethod("promiseThatResolvesVoidInstantly", &HybridTestObjectCppSpec::promiseThatResolvesVoidInstantly);
       prototype.registerHybridMethod("promiseThatResolvesToUndefined", &HybridTestObjectCppSpec::promiseThatResolvesToUndefined);
+      prototype.registerHybridMethod("awaitNullablePromise", &HybridTestObjectCppSpec::awaitNullablePromise);
       prototype.registerHybridMethod("awaitAndGetPromise", &HybridTestObjectCppSpec::awaitAndGetPromise);
       prototype.registerHybridMethod("awaitAndGetComplexPromise", &HybridTestObjectCppSpec::awaitAndGetComplexPromise);
       prototype.registerHybridMethod("awaitPromise", &HybridTestObjectCppSpec::awaitPromise);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -222,6 +222,7 @@ namespace margelo::nitro::test {
       virtual std::shared_ptr<Promise<double>> promiseReturnsInstantlyAsync() = 0;
       virtual std::shared_ptr<Promise<void>> promiseThatResolvesVoidInstantly() = 0;
       virtual std::shared_ptr<Promise<std::optional<double>>> promiseThatResolvesToUndefined() = 0;
+      virtual std::shared_ptr<Promise<std::optional<double>>> awaitNullablePromise() = 0;
       virtual std::shared_ptr<Promise<double>> awaitAndGetPromise(const std::shared_ptr<Promise<double>>& promise) = 0;
       virtual std::shared_ptr<Promise<Car>> awaitAndGetComplexPromise(const std::shared_ptr<Promise<Car>>& promise) = 0;
       virtual std::shared_ptr<Promise<void>> awaitPromise(const std::shared_ptr<Promise<void>>& promise) = 0;

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
@@ -105,6 +105,7 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("promiseReturnsInstantlyAsync", &HybridTestObjectSwiftKotlinSpec::promiseReturnsInstantlyAsync);
       prototype.registerHybridMethod("promiseThatResolvesVoidInstantly", &HybridTestObjectSwiftKotlinSpec::promiseThatResolvesVoidInstantly);
       prototype.registerHybridMethod("promiseThatResolvesToUndefined", &HybridTestObjectSwiftKotlinSpec::promiseThatResolvesToUndefined);
+      prototype.registerHybridMethod("awaitNullablePromise", &HybridTestObjectSwiftKotlinSpec::awaitNullablePromise);
       prototype.registerHybridMethod("awaitAndGetPromise", &HybridTestObjectSwiftKotlinSpec::awaitAndGetPromise);
       prototype.registerHybridMethod("awaitAndGetComplexPromise", &HybridTestObjectSwiftKotlinSpec::awaitAndGetComplexPromise);
       prototype.registerHybridMethod("awaitPromise", &HybridTestObjectSwiftKotlinSpec::awaitPromise);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
@@ -209,6 +209,7 @@ namespace margelo::nitro::test {
       virtual std::shared_ptr<Promise<double>> promiseReturnsInstantlyAsync() = 0;
       virtual std::shared_ptr<Promise<void>> promiseThatResolvesVoidInstantly() = 0;
       virtual std::shared_ptr<Promise<std::optional<double>>> promiseThatResolvesToUndefined() = 0;
+      virtual std::shared_ptr<Promise<std::optional<double>>> awaitNullablePromise() = 0;
       virtual std::shared_ptr<Promise<double>> awaitAndGetPromise(const std::shared_ptr<Promise<double>>& promise) = 0;
       virtual std::shared_ptr<Promise<Car>> awaitAndGetComplexPromise(const std::shared_ptr<Promise<Car>>& promise) = 0;
       virtual std::shared_ptr<Promise<void>> awaitPromise(const std::shared_ptr<Promise<void>>& promise) = 0;

--- a/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
@@ -248,6 +248,7 @@ interface SharedTestObjectProps {
   promiseReturnsInstantlyAsync(): Promise<number>
   promiseThatResolvesVoidInstantly(): Promise<void>
   promiseThatResolvesToUndefined(): Promise<number | undefined>
+  awaitNullablePromise(): Promise<number | undefined>
 
   // Complex Promises
   awaitAndGetPromise(promise: Promise<number>): Promise<number>


### PR DESCRIPTION
## Summary

- Preserve valid null values when Kotlin `Promise<T>` uses a nullable generic type.
- Add a generated cross-platform `awaitNullablePromise` spec and runtime harness regression.
- Regenerate bindings with current Nitrogen 0.37.1.

## Breaking changes

None. Nullable promise results now fulfill their declared contract instead of rejecting.

## Verification

- Frozen install/postinstall, Nitrogen regeneration, root build, and all-workspace typecheck passed.
- Full C++/Swift/Kotlin/TypeScript lint and format checks passed.
- Android Debug build passed.
- Focused Android Harness: 2 tests passed across both native implementations; 544 unrelated tests skipped.
- `git diff --check` passed.

## Preview

Not applicable; this is a nonvisual native runtime correction.

Fixes #1547