### PR TITLE
fix: Surface Worklets initialization errors

### DIFF
--- a/packages/react-native-nitro-modules/src/__tests__/index.test.tsx
+++ b/packages/react-native-nitro-modules/src/__tests__/index.test.tsx
@@ -1,1 +1,37 @@
-it.todo('write a test')
+jest.mock('../NitroModules', () => ({
+  NitroModules: { box: jest.fn(() => ({ unbox: jest.fn() })) },
+}))
+jest.mock('react-native-worklets', () => ({
+  registerCustomSerializable: jest.fn(),
+}))
+
+import { installWorkletsSupport } from '../worklets/installWorkletsSupport'
+
+const { box: mockBox } = jest.requireMock('../NitroModules').NitroModules
+const { registerCustomSerializable: mockRegisterCustomSerializable } =
+  jest.requireMock('react-native-worklets')
+
+describe('installWorkletsSupport()', () => {
+  beforeEach(() => {
+    mockBox.mockClear()
+    mockRegisterCustomSerializable.mockReset()
+  })
+
+  it('propagates Nitro boxing errors', () => {
+    const error = new Error('Failed to box NitroModules')
+    mockBox.mockImplementationOnce(() => {
+      throw error
+    })
+
+    expect(() => installWorkletsSupport()).toThrow(error)
+  })
+
+  it('propagates Worklets registration errors', () => {
+    const error = new Error('Failed to register custom serializer')
+    mockRegisterCustomSerializable.mockImplementationOnce(() => {
+      throw error
+    })
+
+    expect(() => installWorkletsSupport()).toThrow(error)
+  })
+})

--- a/packages/react-native-nitro-modules/src/worklets/installWorkletsSupport.ts
+++ b/packages/react-native-nitro-modules/src/worklets/installWorkletsSupport.ts
@@ -2,29 +2,31 @@ import type { HybridObject } from '../HybridObject'
 import { NitroModules } from '../NitroModules'
 
 export function installWorkletsSupport() {
+  let worklets: typeof import('react-native-worklets')
   try {
-    const { registerCustomSerializable } =
+    worklets =
       require('react-native-worklets') as typeof import('react-native-worklets')
-
-    const boxedNitroProxy = NitroModules.box(NitroModules)
-    registerCustomSerializable({
-      name: 'nitro.HybridObject',
-      determine(value): value is HybridObject<{}> {
-        'worklet'
-        const nitroProxy = boxedNitroProxy.unbox()
-        return nitroProxy.isHybridObject(value)
-      },
-      pack(value) {
-        'worklet'
-        const nitroProxy = boxedNitroProxy.unbox()
-        return nitroProxy.box(value)
-      },
-      unpack(value) {
-        'worklet'
-        return value.unbox()
-      },
-    })
   } catch {
     // react-native-worklets not installed.
+    return
   }
+
+  const boxedNitroProxy = NitroModules.box(NitroModules)
+  worklets.registerCustomSerializable({
+    name: 'nitro.HybridObject',
+    determine(value): value is HybridObject<{}> {
+      'worklet'
+      const nitroProxy = boxedNitroProxy.unbox()
+      return nitroProxy.isHybridObject(value)
+    },
+    pack(value) {
+      'worklet'
+      const nitroProxy = boxedNitroProxy.unbox()
+      return nitroProxy.box(value)
+    },
+    unpack(value) {
+      'worklet'
+      return value.unbox()
+    },
+  })
 }


### PR DESCRIPTION
## Summary

- Limit the optional Worklets fallback to module loading.
- Let Nitro boxing and custom serializer registration failures propagate.
- Add focused regressions for both previously hidden initialization errors.

## Breaking changes

None. An installed but broken integration now reports its initialization error instead of silently disabling itself.

## Verification

- Root build and all-workspace typechecks passed.
- Full C++/Swift/Kotlin/TypeScript lint and format checks passed.
- Package Jest suite and `git diff --check` passed.

## Preview

Not applicable; this is a nonvisual initialization correction.

Fixes #1549