### PR TITLE
fix: Handle zero-worker ThreadPools

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -1554,6 +1554,24 @@ export function getTests(
           .didNotThrow()
           .equals(true)
     ),
+    ...(testObject.name === 'TestObjectCpp'
+      ? [
+          createTest('ThreadPool starts a worker for its first task', () =>
+            it(() =>
+              (testObject as TestObjectCpp).zeroWorkerThreadPoolRunsTasks()
+            )
+              .didNotThrow()
+              .equals(true)
+          ),
+          createTest('ThreadPool rejects invalid worker limits', () =>
+            it(() =>
+              (testObject as TestObjectCpp).invalidThreadPoolSizesThrow()
+            )
+              .didNotThrow()
+              .equals(true)
+          ),
+        ]
+      : []),
     createTest('promiseThatResolvesVoidInstantly() works', async () =>
       (await it(() => testObject.promiseThatResolvesVoidInstantly()))
         .didNotThrow()

--- a/packages/react-native-nitro-modules/cpp/threading/ThreadPool.cpp
+++ b/packages/react-native-nitro-modules/cpp/threading/ThreadPool.cpp
@@ -8,11 +8,19 @@
 #include "ThreadPool.hpp"
 #include "NitroLogger.hpp"
 #include "ThreadUtils.hpp"
+#include <stdexcept>
 
 namespace margelo::nitro {
 
 ThreadPool::ThreadPool(const char* name, size_t initialThreadsCount, size_t maxThreadsCount)
     : _isAlive(true), _threadCountLimit(maxThreadsCount), _name(name) {
+  if (maxThreadsCount == 0) [[unlikely]] {
+    throw std::invalid_argument("ThreadPool must allow at least one worker!");
+  }
+  if (initialThreadsCount > maxThreadsCount) [[unlikely]] {
+    throw std::invalid_argument("ThreadPool initial worker count cannot exceed its maximum worker count!");
+  }
+
   Logger::log(LogLevel::Info, TAG, "Creating ThreadPool \"%s\" with %i initial threads (max: %i)...", name, initialThreadsCount,
               maxThreadsCount);
 
@@ -63,8 +71,8 @@ void ThreadPool::run(std::function<void()>&& task) {
     if (!_isAlive) {
       throw std::runtime_error("Cannot queue the given task - the ThreadPool has already been stopped!");
     }
-    // If there are tasks still waiting to be finished, just start a new Thread.
-    if (!_tasks.empty() && _threadCount < _threadCountLimit) {
+    // Start the first worker lazily, or expand when tasks are already waiting.
+    if ((_threadCount == 0 || !_tasks.empty()) && _threadCount < _threadCountLimit) {
       addThread(lock);
     }
     _tasks.push(std::move(task));

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
@@ -8,6 +8,7 @@
 #include "HybridTestObjectCpp.hpp"
 #include <NitroModules/AnyMap.hpp>
 #include <NitroModules/NitroLogger.hpp>
+#include <NitroModules/ThreadPool.hpp>
 #include <chrono>
 #include <sstream>
 #include <thread>
@@ -771,6 +772,31 @@ std::shared_ptr<Promise<std::shared_ptr<HybridTestObjectCppSpec>>> HybridTestObj
   // keeps the resolve()-vs-toJSI window wide so the C++ Promise `_state` race surfaces under TSan.
   return Promise<std::shared_ptr<HybridTestObjectCppSpec>>::async(
       []() -> std::shared_ptr<HybridTestObjectCppSpec> { return std::make_shared<HybridTestObjectCpp>(); });
+}
+
+bool HybridTestObjectCpp::zeroWorkerThreadPoolRunsTasks() {
+  bool didRun = false;
+  {
+    ThreadPool threadPool("zero-worker-test", 0, 1);
+    threadPool.run([&didRun] { didRun = true; });
+  }
+  return didRun;
+}
+
+bool HybridTestObjectCpp::invalidThreadPoolSizesThrow() {
+  try {
+    ThreadPool noCapacity("no-capacity-test", 0, 0);
+    return false;
+  } catch (const std::invalid_argument&) {
+    // Expected.
+  }
+
+  try {
+    ThreadPool tooManyInitialWorkers("too-many-workers-test", 2, 1);
+    return false;
+  } catch (const std::invalid_argument&) {
+    return true;
+  }
 }
 
 jsi::Value HybridTestObjectCpp::rawJsiFunc(jsi::Runtime& runtime, const jsi::Value&, const jsi::Value* args, size_t count) {

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
@@ -227,6 +227,8 @@ public:
   std::shared_ptr<ArrayBuffer> createHardwareBuffer(double width, double height, double layers, HardwareBufferFormat format) override;
   std::shared_ptr<HybridTestObjectCppSpec> newTestObject() override;
   std::shared_ptr<Promise<std::shared_ptr<HybridTestObjectCppSpec>>> newTestObjectAsync() override;
+  bool zeroWorkerThreadPoolRunsTasks() override;
+  bool invalidThreadPoolSizesThrow() override;
 
   std::shared_ptr<HybridBaseSpec> createBase() override;
   std::shared_ptr<HybridChildSpec> createChild() override;

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -60,6 +60,8 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("passTuple", &HybridTestObjectCppSpec::passTuple);
       prototype.registerHybridMethod("newTestObject", &HybridTestObjectCppSpec::newTestObject);
       prototype.registerHybridMethod("newTestObjectAsync", &HybridTestObjectCppSpec::newTestObjectAsync);
+      prototype.registerHybridMethod("zeroWorkerThreadPoolRunsTasks", &HybridTestObjectCppSpec::zeroWorkerThreadPoolRunsTasks);
+      prototype.registerHybridMethod("invalidThreadPoolSizesThrow", &HybridTestObjectCppSpec::invalidThreadPoolSizesThrow);
       prototype.registerHybridMethod("getVariantHybrid", &HybridTestObjectCppSpec::getVariantHybrid);
       prototype.registerHybridMethod("getVariantHybridEnum", &HybridTestObjectCppSpec::getVariantHybridEnum);
       prototype.registerHybridMethod("bounceAnyHybrid", &HybridTestObjectCppSpec::bounceAnyHybrid);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -169,6 +169,8 @@ namespace margelo::nitro::test {
       virtual std::tuple<double, std::string, bool> passTuple(const std::tuple<double, std::string, bool>& tuple) = 0;
       virtual std::shared_ptr<HybridTestObjectCppSpec> newTestObject() = 0;
       virtual std::shared_ptr<Promise<std::shared_ptr<HybridTestObjectCppSpec>>> newTestObjectAsync() = 0;
+      virtual bool zeroWorkerThreadPoolRunsTasks() = 0;
+      virtual bool invalidThreadPoolSizesThrow() = 0;
       virtual std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Person> getVariantHybrid(const std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Person>& variant) = 0;
       virtual std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Powertrain> getVariantHybridEnum(const std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Powertrain>& variant) = 0;
       virtual std::shared_ptr<HybridObject> bounceAnyHybrid(const std::shared_ptr<HybridObject>& object) = 0;

--- a/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
@@ -380,6 +380,8 @@ export interface TestObjectCpp
   // Returns a HybridObject from a Promise resolved off the JS thread. Used to reproduce the data
   // race between resolve() and JSIConverter::toJSI.
   newTestObjectAsync(): Promise<TestObjectCpp>
+  zeroWorkerThreadPoolRunsTasks(): boolean
+  invalidThreadPoolSizesThrow(): boolean
   optionalHybrid?: TestObjectCpp
   getVariantHybrid(variant: TestObjectCpp | Person): TestObjectCpp | Person
   getVariantHybridEnum(


### PR DESCRIPTION
## Summary

- Start the first worker lazily when a positive-capacity ThreadPool was created with zero initial workers.
- Reject zero-capacity and initial-above-maximum configurations during construction.
- Add generated C++ test methods and focused Android Harness regressions.

## Breaking changes

No valid configuration changes. Impossible worker limits now reject immediately instead of queuing forever or exceeding the declared maximum.

## Verification

- Baseline focused Harness reproduced the missing task; fixed Harness: 2 tests passed, 544 unrelated skipped.
- Android Debug and full iOS Simulator builds passed.
- Root build, all-workspace typechecks, full native/TypeScript lint and format, and `git diff --check` passed.

## Preview

Not applicable; this is a nonvisual threading correction.

Fixes #1551