### PR TITLE
fix: serialize Promise settlement

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -1554,6 +1554,17 @@ export function getTests(
           .didNotThrow()
           .equals(true)
     ),
+    ...(testObject.name === 'TestObjectCpp'
+      ? [
+          createTest('Promise settlement is single-shot', () =>
+            it(() =>
+              (testObject as TestObjectCpp).duplicatePromiseSettlementThrows()
+            )
+              .didNotThrow()
+              .equals(true)
+          ),
+        ]
+      : []),
     createTest('promiseThatResolvesVoidInstantly() works', async () =>
       (await it(() => testObject.promiseThatResolvesVoidInstantly()))
         .didNotThrow()

--- a/packages/react-native-nitro-modules/cpp/core/Promise.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.cpp
@@ -52,13 +52,11 @@ std::shared_ptr<Promise<void>> Promise<void>::rejected(const std::exception_ptr&
 }
 
 void Promise<void>::resolve() {
-#ifdef NITRO_DEBUG
-  assertPromiseState(*this, PromiseTask::WANTS_TO_RESOLVE);
-#endif
   std::vector<OnResolvedFunc> listeners;
   std::vector<OnRejectedFunc> dropped;
   {
     std::unique_lock lock(_mutex);
+    ensurePending(lock, "resolve");
     _isResolved = true;
     listeners = std::move(_onResolvedListeners);
     dropped = std::move(_onRejectedListeners);
@@ -73,13 +71,11 @@ void Promise<void>::reject(const std::exception_ptr& exception) {
     throw std::runtime_error("Cannot reject Promise<void> with a null exception_ptr!");
   }
 
-#ifdef NITRO_DEBUG
-  assertPromiseState(*this, PromiseTask::WANTS_TO_REJECT);
-#endif
   std::vector<OnRejectedFunc> listeners;
   std::vector<OnResolvedFunc> dropped;
   {
     std::unique_lock lock(_mutex);
+    ensurePending(lock, "reject");
     _error = exception;
     listeners = std::move(_onRejectedListeners);
     dropped = std::move(_onResolvedListeners);
@@ -143,6 +139,13 @@ const std::exception_ptr& Promise<void>::getError() const {
     throw std::runtime_error("Cannot get error when Promise<void> is not yet rejected!");
   }
   return _error;
+}
+
+void Promise<void>::ensurePending(const std::unique_lock<std::mutex>& lock, const char* action) const {
+  if (!isPending(lock)) [[unlikely]] {
+    std::string state = isResolved(lock) ? "resolved" : "rejected";
+    throw std::runtime_error("Cannot " + std::string(action) + " Promise<void> - it is already " + state + "!");
+  }
 }
 
 } // namespace margelo::nitro

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "AssertPromiseState.hpp"
 #include "NitroDefines.hpp"
 #include "NitroTypeInfo.hpp"
 #include "ThreadPool.hpp"
@@ -98,14 +97,12 @@ public:
    * Resolves this Promise with the given result, and calls any pending listeners.
    */
   void resolve(TResult&& result) {
-#ifdef NITRO_DEBUG
-    assertPromiseState(*this, PromiseTask::WANTS_TO_RESOLVE);
-#endif
     std::vector<OnResolvedFunc> listeners;
     std::vector<OnRejectedFunc> dropped;
     const TResult* resolvedValue;
     {
       std::unique_lock lock(_mutex);
+      ensurePending(lock, "resolve");
       _state = std::move(result);
       resolvedValue = &std::get<TResult>(_state);
       listeners = std::move(_onResolvedListeners);
@@ -116,13 +113,11 @@ public:
     }
   }
   void resolve(const TResult& result) {
-#ifdef NITRO_DEBUG
-    assertPromiseState(*this, PromiseTask::WANTS_TO_RESOLVE);
-#endif
     std::vector<OnResolvedFunc> listeners;
     std::vector<OnRejectedFunc> dropped;
     {
       std::unique_lock lock(_mutex);
+      ensurePending(lock, "resolve");
       _state = result;
       listeners = std::move(_onResolvedListeners);
       dropped = std::move(_onRejectedListeners);
@@ -140,13 +135,11 @@ public:
       throw std::runtime_error("Cannot reject Promise<" + typeName + "> with a null exception_ptr!");
     }
 
-#ifdef NITRO_DEBUG
-    assertPromiseState(*this, PromiseTask::WANTS_TO_REJECT);
-#endif
     std::vector<OnRejectedFunc> listeners;
     std::vector<OnResolvedFunc> dropped;
     {
       std::unique_lock lock(_mutex);
+      ensurePending(lock, "reject");
       _state = exception;
       listeners = std::move(_onRejectedListeners);
       dropped = std::move(_onResolvedListeners);
@@ -292,6 +285,14 @@ private:
     return std::holds_alternative<std::monostate>(_state);
   }
 
+  inline void ensurePending(const std::unique_lock<std::mutex>& lock, const char* action) const {
+    if (!isPending(lock)) [[unlikely]] {
+      std::string state = isResolved(lock) ? "resolved" : "rejected";
+      throw std::runtime_error("Cannot " + std::string(action) + " Promise<" + TypeInfo::getFriendlyTypename<TResult>() +
+                               "> - it is already " + state + "!");
+    }
+  }
+
 private:
   std::variant<std::monostate, TResult, std::exception_ptr> _state;
   std::vector<OnResolvedFunc> _onResolvedListeners;
@@ -361,6 +362,8 @@ private:
   inline bool isPending(const std::unique_lock<std::mutex>&) const noexcept {
     return !_isResolved && _error == nullptr;
   }
+
+  void ensurePending(const std::unique_lock<std::mutex>& lock, const char* action) const;
 
 private:
   mutable std::mutex _mutex;

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
@@ -773,6 +773,36 @@ std::shared_ptr<Promise<std::shared_ptr<HybridTestObjectCppSpec>>> HybridTestObj
       []() -> std::shared_ptr<HybridTestObjectCppSpec> { return std::make_shared<HybridTestObjectCpp>(); });
 }
 
+bool HybridTestObjectCpp::duplicatePromiseSettlementThrows() {
+  auto resolved = Promise<double>::resolved(1.0);
+  try {
+    resolved->resolve(2.0);
+    return false;
+  } catch (const std::runtime_error&) {
+    // Expected.
+  }
+  try {
+    resolved->reject(std::make_exception_ptr(std::runtime_error("late rejection")));
+    return false;
+  } catch (const std::runtime_error&) {
+    // Expected.
+  }
+
+  auto rejected = Promise<void>::rejected(std::make_exception_ptr(std::runtime_error("first rejection")));
+  try {
+    rejected->resolve();
+    return false;
+  } catch (const std::runtime_error&) {
+    // Expected.
+  }
+  try {
+    rejected->reject(std::make_exception_ptr(std::runtime_error("second rejection")));
+    return false;
+  } catch (const std::runtime_error&) {
+    return resolved->getResult() == 1.0 && rejected->isRejected();
+  }
+}
+
 jsi::Value HybridTestObjectCpp::rawJsiFunc(jsi::Runtime& runtime, const jsi::Value&, const jsi::Value* args, size_t count) {
   jsi::Array array(runtime, count);
   for (size_t i = 0; i < count; i++) {

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
@@ -227,6 +227,7 @@ public:
   std::shared_ptr<ArrayBuffer> createHardwareBuffer(double width, double height, double layers, HardwareBufferFormat format) override;
   std::shared_ptr<HybridTestObjectCppSpec> newTestObject() override;
   std::shared_ptr<Promise<std::shared_ptr<HybridTestObjectCppSpec>>> newTestObjectAsync() override;
+  bool duplicatePromiseSettlementThrows() override;
 
   std::shared_ptr<HybridBaseSpec> createBase() override;
   std::shared_ptr<HybridChildSpec> createChild() override;

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -60,6 +60,7 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("passTuple", &HybridTestObjectCppSpec::passTuple);
       prototype.registerHybridMethod("newTestObject", &HybridTestObjectCppSpec::newTestObject);
       prototype.registerHybridMethod("newTestObjectAsync", &HybridTestObjectCppSpec::newTestObjectAsync);
+      prototype.registerHybridMethod("duplicatePromiseSettlementThrows", &HybridTestObjectCppSpec::duplicatePromiseSettlementThrows);
       prototype.registerHybridMethod("getVariantHybrid", &HybridTestObjectCppSpec::getVariantHybrid);
       prototype.registerHybridMethod("getVariantHybridEnum", &HybridTestObjectCppSpec::getVariantHybridEnum);
       prototype.registerHybridMethod("bounceAnyHybrid", &HybridTestObjectCppSpec::bounceAnyHybrid);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -169,6 +169,7 @@ namespace margelo::nitro::test {
       virtual std::tuple<double, std::string, bool> passTuple(const std::tuple<double, std::string, bool>& tuple) = 0;
       virtual std::shared_ptr<HybridTestObjectCppSpec> newTestObject() = 0;
       virtual std::shared_ptr<Promise<std::shared_ptr<HybridTestObjectCppSpec>>> newTestObjectAsync() = 0;
+      virtual bool duplicatePromiseSettlementThrows() = 0;
       virtual std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Person> getVariantHybrid(const std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Person>& variant) = 0;
       virtual std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Powertrain> getVariantHybridEnum(const std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Powertrain>& variant) = 0;
       virtual std::shared_ptr<HybridObject> bounceAnyHybrid(const std::shared_ptr<HybridObject>& object) = 0;

--- a/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
@@ -380,6 +380,7 @@ export interface TestObjectCpp
   // Returns a HybridObject from a Promise resolved off the JS thread. Used to reproduce the data
   // race between resolve() and JSIConverter::toJSI.
   newTestObjectAsync(): Promise<TestObjectCpp>
+  duplicatePromiseSettlementThrows(): boolean
   optionalHybrid?: TestObjectCpp
   getVariantHybrid(variant: TestObjectCpp | Person): TestObjectCpp | Person
   getVariantHybridEnum(


### PR DESCRIPTION
## Summary

- enforce single-shot settlement for `Promise<T>` and `Promise<void>` in every build configuration
- validate and transition Promise state under the same mutex, closing concurrent resolve/reject races
- preserve the original result or rejection after rejected duplicate settlements
- add a generated C++ regression exercised through the example harness

## Breaking changes

None. Invalid duplicate Promise settlement now throws consistently in release builds as it already did in debug builds.

## Verification

- root build, typecheck, lint, and C++ lint passed
- Android Debug focused harness passed (1/1)
- Android Release assembled successfully
- iOS Debug Simulator full build and focused harness passed (1/1)
- `git diff --check` passed

Fixes #1553
