### PR TITLE
fix: honor Nitrogen config path

### DIFF
--- a/packages/nitrogen/src/config/NitroConfig.ts
+++ b/packages/nitrogen/src/config/NitroConfig.ts
@@ -21,6 +21,10 @@ export class NitroConfig {
     this.config = config
   }
 
+  static loadFromFile(configPath: string): void {
+    this.singleton = new NitroConfig(readUserConfig(configPath))
+  }
+
   static get current(): NitroConfig {
     if (this.singleton == null) {
       console.log(

--- a/packages/nitrogen/src/index.ts
+++ b/packages/nitrogen/src/index.ts
@@ -10,6 +10,7 @@ import { promises as fs } from 'fs'
 import { isValidLogLevel, setLogLevel } from './Logger.js'
 import { initNewNitroModule } from './init.js'
 import { NITROGEN_VERSION } from './config/nitrogenVersion.js'
+import { NitroConfig } from './config/NitroConfig.js'
 
 const commandName = 'nitrogen'
 
@@ -57,6 +58,7 @@ await yargs(hideBin(process.argv))
     async (argv) => {
       const basePath = argv.basePath
       const outputDirectory = argv.out
+      NitroConfig.loadFromFile(argv.config)
       await runNitrogenCommand(basePath, outputDirectory)
     }
   )


### PR DESCRIPTION
## Summary

- load `NitroConfig` from the CLI's parsed `--config` path before generation starts
- retain `./nitro.json` as the default path
- make custom config paths work when Nitrogen is invoked outside the module directory

## Breaking changes

None.

## Verification

- custom-path reproduction changed from failing to generating 7/7 specs
- default configuration path still generates 7/7 specs
- full build, typecheck, lint, and `git diff --check` passed

Fixes #1554
