### PR TITLE
fix: fail empty Nitrogen runs

### DIFF
--- a/packages/nitrogen/src/nitrogen.ts
+++ b/packages/nitrogen/src/nitrogen.ts
@@ -85,7 +85,7 @@ export async function runNitrogen({
         `To create a Nitro Module, create a TypeScript file with the "${chalk.underline('.nitro.ts')}" suffix ` +
         'and export an interface that extends HybridObject<T>.'
     )
-    process.exit()
+    process.exit(1)
   }
 
   const usedPlatforms: Platform[] = []
@@ -189,6 +189,7 @@ export async function runNitrogen({
           `    ❌  No specs found in ${sourceFile.getBaseName()}!`
         )
       )
+      process.exitCode = 1
     }
   }
 


### PR DESCRIPTION
## Summary

- exit with status 1 when the search contains no `*.nitro.ts` files
- set a nonzero exit status when a spec-suffixed file generates no HybridObject or HybridView specs
- make CI and build integrations reliably detect empty generation runs

## Breaking changes

None. Runs that already log fatal empty-spec errors now report failure to their caller.

## Verification

- empty-directory reproduction changed from exit 0 to exit 1
- ordinary interface in `Invalid.nitro.ts` now exits 1
- full build, post-build typecheck, lint, and `git diff --check` passed

Fixes #1555
