### PR TITLE
fix: discard impossible Promise listeners

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -1554,6 +1554,19 @@ export function getTests(
           .didNotThrow()
           .equals(true)
     ),
+    ...(testObject.name === 'TestObjectCpp'
+      ? [
+          createTest('settled Promises release opposite listeners', () =>
+            it(() =>
+              (
+                testObject as TestObjectCpp
+              ).settledPromiseReleasesOppositeListeners()
+            )
+              .didNotThrow()
+              .equals(true)
+          ),
+        ]
+      : []),
     createTest('promiseThatResolvesVoidInstantly() works', async () =>
       (await it(() => testObject.promiseThatResolvesVoidInstantly()))
         .didNotThrow()

--- a/packages/react-native-nitro-modules/cpp/core/Promise.cpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.cpp
@@ -94,7 +94,7 @@ void Promise<void>::addOnResolvedListener(OnResolvedFunc&& onResolved) {
   if (isResolved(lock)) {
     lock.unlock();
     onResolved();
-  } else {
+  } else if (isPending(lock)) {
     _onResolvedListeners.push_back(std::move(onResolved));
   }
 }
@@ -103,7 +103,7 @@ void Promise<void>::addOnResolvedListener(const OnResolvedFunc& onResolved) {
   if (isResolved(lock)) {
     lock.unlock();
     onResolved();
-  } else {
+  } else if (isPending(lock)) {
     _onResolvedListeners.push_back(onResolved);
   }
 }
@@ -113,7 +113,7 @@ void Promise<void>::addOnRejectedListener(OnRejectedFunc&& onRejected) {
     std::exception_ptr error = _error;
     lock.unlock();
     onRejected(error);
-  } else {
+  } else if (isPending(lock)) {
     // Promise is not yet rejected, put the listener in our queue.
     _onRejectedListeners.push_back(std::move(onRejected));
   }
@@ -124,7 +124,7 @@ void Promise<void>::addOnRejectedListener(const OnRejectedFunc& onRejected) {
     std::exception_ptr error = _error;
     lock.unlock();
     onRejected(error);
-  } else {
+  } else if (isPending(lock)) {
     // Promise is not yet rejected, put the listener in our queue.
     _onRejectedListeners.push_back(onRejected);
   }

--- a/packages/react-native-nitro-modules/cpp/core/Promise.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/Promise.hpp
@@ -168,7 +168,7 @@ public:
       lock.unlock();
       // Promise is already resolved! Call the callback immediately
       onResolved(result);
-    } else {
+    } else if (isPending(lock)) {
       // Promise is not yet resolved, put the listener in our queue.
       _onResolvedListeners.push_back(std::move(onResolved));
     }
@@ -180,7 +180,7 @@ public:
       lock.unlock();
       // Promise is already resolved! Call the callback immediately
       onResolved(result);
-    } else {
+    } else if (isPending(lock)) {
       // Promise is not yet resolved, put the listener in our queue.
       _onResolvedListeners.push_back(onResolved);
     }
@@ -197,7 +197,7 @@ public:
       lock.unlock();
       // Promise is already rejected! Call the callback immediately
       onRejected(error);
-    } else {
+    } else if (isPending(lock)) {
       // Promise is not yet rejected, put the listener in our queue.
       _onRejectedListeners.push_back(std::move(onRejected));
     }
@@ -209,7 +209,7 @@ public:
       lock.unlock();
       // Promise is already rejected! Call the callback immediately
       onRejected(error);
-    } else {
+    } else if (isPending(lock)) {
       // Promise is not yet rejected, put the listener in our queue.
       _onRejectedListeners.push_back(onRejected);
     }

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
@@ -773,6 +773,22 @@ std::shared_ptr<Promise<std::shared_ptr<HybridTestObjectCppSpec>>> HybridTestObj
       []() -> std::shared_ptr<HybridTestObjectCppSpec> { return std::make_shared<HybridTestObjectCpp>(); });
 }
 
+bool HybridTestObjectCpp::settledPromiseReleasesOppositeListeners() {
+  auto resolved = Promise<double>::resolved(1.0);
+  auto rejectedCapture = std::make_shared<int>(1);
+  std::weak_ptr<int> rejectedWeak = rejectedCapture;
+  resolved->addOnRejectedListener([capture = rejectedCapture](const std::exception_ptr&) { (void)capture; });
+  rejectedCapture.reset();
+
+  auto rejected = Promise<void>::rejected(std::make_exception_ptr(std::runtime_error("rejected")));
+  auto resolvedCapture = std::make_shared<int>(1);
+  std::weak_ptr<int> resolvedWeak = resolvedCapture;
+  rejected->addOnResolvedListener([capture = resolvedCapture]() { (void)capture; });
+  resolvedCapture.reset();
+
+  return rejectedWeak.expired() && resolvedWeak.expired();
+}
+
 jsi::Value HybridTestObjectCpp::rawJsiFunc(jsi::Runtime& runtime, const jsi::Value&, const jsi::Value* args, size_t count) {
   jsi::Array array(runtime, count);
   for (size_t i = 0; i < count; i++) {

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
@@ -227,6 +227,7 @@ public:
   std::shared_ptr<ArrayBuffer> createHardwareBuffer(double width, double height, double layers, HardwareBufferFormat format) override;
   std::shared_ptr<HybridTestObjectCppSpec> newTestObject() override;
   std::shared_ptr<Promise<std::shared_ptr<HybridTestObjectCppSpec>>> newTestObjectAsync() override;
+  bool settledPromiseReleasesOppositeListeners() override;
 
   std::shared_ptr<HybridBaseSpec> createBase() override;
   std::shared_ptr<HybridChildSpec> createChild() override;

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -60,6 +60,7 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("passTuple", &HybridTestObjectCppSpec::passTuple);
       prototype.registerHybridMethod("newTestObject", &HybridTestObjectCppSpec::newTestObject);
       prototype.registerHybridMethod("newTestObjectAsync", &HybridTestObjectCppSpec::newTestObjectAsync);
+      prototype.registerHybridMethod("settledPromiseReleasesOppositeListeners", &HybridTestObjectCppSpec::settledPromiseReleasesOppositeListeners);
       prototype.registerHybridMethod("getVariantHybrid", &HybridTestObjectCppSpec::getVariantHybrid);
       prototype.registerHybridMethod("getVariantHybridEnum", &HybridTestObjectCppSpec::getVariantHybridEnum);
       prototype.registerHybridMethod("bounceAnyHybrid", &HybridTestObjectCppSpec::bounceAnyHybrid);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -169,6 +169,7 @@ namespace margelo::nitro::test {
       virtual std::tuple<double, std::string, bool> passTuple(const std::tuple<double, std::string, bool>& tuple) = 0;
       virtual std::shared_ptr<HybridTestObjectCppSpec> newTestObject() = 0;
       virtual std::shared_ptr<Promise<std::shared_ptr<HybridTestObjectCppSpec>>> newTestObjectAsync() = 0;
+      virtual bool settledPromiseReleasesOppositeListeners() = 0;
       virtual std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Person> getVariantHybrid(const std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Person>& variant) = 0;
       virtual std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Powertrain> getVariantHybridEnum(const std::variant<std::shared_ptr<HybridTestObjectCppSpec>, Powertrain>& variant) = 0;
       virtual std::shared_ptr<HybridObject> bounceAnyHybrid(const std::shared_ptr<HybridObject>& object) = 0;

--- a/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
@@ -380,6 +380,7 @@ export interface TestObjectCpp
   // Returns a HybridObject from a Promise resolved off the JS thread. Used to reproduce the data
   // race between resolve() and JSIConverter::toJSI.
   newTestObjectAsync(): Promise<TestObjectCpp>
+  settledPromiseReleasesOppositeListeners(): boolean
   optionalHybrid?: TestObjectCpp
   getVariantHybrid(variant: TestObjectCpp | Person): TestObjectCpp | Person
   getVariantHybridEnum(


### PR DESCRIPTION
## Summary

- queue C++ Promise listeners only while the Promise is pending
- immediately release opposite-outcome listeners added after settlement
- cover resolved/rejection and rejected/resolution ownership with weak-pointer regressions

## Breaking changes

None. Callbacks that could never execute are no longer retained.

## Verification

- exact Android baseline regression failed; fixed Android and iOS Harness checks pass (1/1 each)
- regenerated specs, full build, post-build typecheck, lint, and C++ format pass
- Android Debug assemble and full iOS Debug Simulator build pass
- `git diff --check` passes

Fixes #1559
