### PR TITLE
fix: guard disposed HybridObject method calls

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -1737,6 +1737,18 @@ export function getTests(
         gc()
       }).didNotThrow()
     ),
+    createTest('HybridObject methods throw after dispose()', () =>
+      it(() => {
+        const object = testObject.newTestObject()
+        object.dispose()
+        object.toString()
+      }).didThrow('did you accidentally call `dispose()` on this object?')
+    ),
+    createTest('HybridObject methods reject the wrong receiver', () =>
+      it(() => testObject.simpleFunc.call(HybridPlatformObject)).didThrow(
+        "`this` has a NativeState, but it's the wrong type!"
+      )
+    ),
     createTest('callWithOptional(undefined)', async () =>
       (
         await it<number | undefined>(() => {

--- a/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
@@ -220,22 +220,18 @@ private:
 
     // 3. Get `NativeState` from the jsi::Object and check if it is non-null
     std::shared_ptr<jsi::NativeState> nativeState = object.getNativeState(runtime);
-#ifdef NITRO_DEBUG
     if (nativeState == nullptr) [[unlikely]] {
       throw jsi::JSError(runtime, "Cannot " + getHybridFuncDebugInfo<THybrid>(funcKind, funcName) +
                                       " - `this`'s `NativeState` is `null`, "
                                       "did you accidentally call `dispose()` on this object?");
     }
-#endif
 
     // 4. Try casting it to our desired target type.
     std::shared_ptr<THybrid> hybridInstance = std::dynamic_pointer_cast<THybrid>(nativeState);
-#ifdef NITRO_DEBUG
     if (hybridInstance == nullptr) [[unlikely]] {
       throw jsi::JSError(runtime, "Cannot " + getHybridFuncDebugInfo<THybrid>(funcKind, funcName) +
                                       " - `this` has a NativeState, but it's the wrong type!");
     }
-#endif
     return hybridInstance;
   }
 


### PR DESCRIPTION
## Summary

- keep the cheap null and wrong-type NativeState guards active in release builds
- preserve the existing detailed debug-only prechecks
- cover disposed receivers and borrowed methods on the wrong HybridObject type across C++ and Swift/Kotlin implementations

## Breaking changes

None. Invalid method receivers now throw the existing actionable JSI errors consistently in release builds.

## Verification

- root build, typecheck, lint, C++ lint, and `git diff --check` pass
- Android Debug build and targeted Harness pass 4/4
- Android arm64 Release assembles successfully
- iOS Simulator Debug build and targeted Harness pass 4/4

Fixes #1561
