### PR TITLE
fix: preserve __proto__ record keys

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -960,6 +960,19 @@ export function getTests(
         .didNotThrow()
         .equals(TEST_MAP_4)
     ),
+    createTest('copyAnyMap(...) preserves __proto__ keys', () =>
+      it(() => {
+        const map = { ['__proto__']: { value: 'kept' } }
+        const copy = testObject.copyAnyMap(map)
+        return [
+          Object.prototype.hasOwnProperty.call(copy, '__proto__'),
+          Reflect.get(copy, '__proto__'),
+          Object.getPrototypeOf(copy) === Object.prototype,
+        ]
+      })
+        .didNotThrow()
+        .equals([true, { value: 'kept' }, true])
+    ),
 
     // Test errors
     createTest('funcThatThrows() throws', () =>
@@ -1453,6 +1466,19 @@ export function getTests(
         .didNotThrow()
         .didReturn('object')
         .equals(TEST_MAP_3)
+    ),
+    createTest('bounceSimpleMap(map) preserves __proto__ keys', () =>
+      it(() => {
+        const map = { ['__proto__']: 42 }
+        const copy = testObject.bounceSimpleMap(map)
+        return [
+          Object.prototype.hasOwnProperty.call(copy, '__proto__'),
+          Reflect.get(copy, '__proto__'),
+          Object.getPrototypeOf(copy) === Object.prototype,
+        ]
+      })
+        .didNotThrow()
+        .equals([true, 42, true])
     ),
     createTest('bounceOptionalMap(map) keeps undefined values', () =>
       it(() => testObject.bounceOptionalMap({ a: 'b', c: undefined }))

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+AnyMap.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+AnyMap.hpp
@@ -58,9 +58,8 @@ struct JSIConverter<std::shared_ptr<AnyMap>> final {
   static inline jsi::Value toJSI(jsi::Runtime& runtime, std::shared_ptr<AnyMap> map) {
     jsi::Object object(runtime);
     for (const auto& item : map->getMap()) {
-      jsi::String key = jsi::String::createFromUtf8(runtime, item.first);
       jsi::Value value = JSIConverter<AnyValue>::toJSI(runtime, item.second);
-      object.setProperty(runtime, std::move(key), std::move(value));
+      setRecordProperty(runtime, object, item.first, std::move(value));
     }
     return object;
   }

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+UnorderedMap.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIConverter+UnorderedMap.hpp
@@ -43,7 +43,7 @@ struct JSIConverter<std::unordered_map<std::string, ValueType>> final {
     jsi::Object object(runtime);
     for (const auto& [key, value] : map) {
       jsi::Value jsValue = JSIConverter<ValueType>::toJSI(runtime, value);
-      object.setProperty(runtime, PropNameIDCache::get(runtime, key), std::move(jsValue));
+      setRecordProperty(runtime, object, key, std::move(jsValue));
     }
     return object;
   }

--- a/packages/react-native-nitro-modules/cpp/jsi/JSIHelpers.hpp
+++ b/packages/react-native-nitro-modules/cpp/jsi/JSIHelpers.hpp
@@ -7,8 +7,12 @@
 
 #pragma once
 
+#include "CommonGlobals.hpp"
+#include "PropNameIDCache.hpp"
 #include "ThreadUtils.hpp"
 #include <jsi/jsi.h>
+#include <string>
+#include <utility>
 
 namespace margelo::nitro {
 
@@ -36,6 +40,20 @@ static inline bool isPlainObject(jsi::Runtime& runtime, const jsi::Object& objec
     return false;
   }
   return true;
+}
+
+/**
+ * Sets an own property while preserving `__proto__` as record data instead of
+ * invoking Object.prototype's legacy prototype setter.
+ */
+static inline void setRecordProperty(jsi::Runtime& runtime, const jsi::Object& object, const std::string& key, jsi::Value&& value) {
+  if (key == "__proto__") [[unlikely]] {
+    CommonGlobals::Object::defineProperty(
+        runtime, object, key.c_str(),
+        PlainPropertyDescriptor{.configurable = true, .enumerable = true, .value = std::move(value), .writable = true});
+  } else {
+    object.setProperty(runtime, PropNameIDCache::get(runtime, key), std::move(value));
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- preserve `__proto__` as record data during native-to-JavaScript AnyMap and typed Record conversion
- keep the output's ordinary Object prototype for object and primitive values
- centralize the exceptional define-property path while retaining cached ordinary property writes
- cover C++ and Kotlin/Swift implementations through both AnyMap and typed map APIs

## Breaking changes

None.

## Verification

- exact Android baseline failed all 4 targeted cases; fixed Android and iOS Harness checks pass 4/4 each
- specs, root build, typecheck, Nitro/example lint, C++ lint, and package Jest pass
- Android Debug build and clean iOS Simulator build pass
- `git diff --check` passes

Fixes #1563
