### PR TITLE
fix: correct Android native registration guidance

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -2585,6 +2585,24 @@ export function getTests(
         .didNotThrow()
         .equals(true)
     ),
+    createTest(
+      'NitroModules.createHybridObject(...) error names registerAllNatives()',
+      () =>
+        it(() => {
+          try {
+            NitroModules.createHybridObject('__MissingHybridObjectForTest__')
+            return false
+          } catch (error) {
+            return (
+              error instanceof Error &&
+              error.message.includes('registerAllNatives()') &&
+              !error.message.includes('::registerNatives()')
+            )
+          }
+        })
+          .didNotThrow()
+          .equals(true)
+    ),
     createTest('NitroModules.isHybridObject(testObject) to be true', () =>
       it(() => {
         return NitroModules.isHybridObject(testObject)

--- a/packages/nitrogen/src/autolinking/android/createHybridObjectInitializer.ts
+++ b/packages/nitrogen/src/autolinking/android/createHybridObjectInitializer.ts
@@ -82,7 +82,7 @@ ${createFileMetadataString(`${autolinkingClassName}.hpp`)}
 
 namespace ${cxxNamespace} {
 
-  [[deprecated("Use registerNatives() instead.")]]
+  [[deprecated("Use registerAllNatives() instead.")]]
   int initialize(JavaVM* vm);
 
   /**
@@ -94,7 +94,7 @@ namespace ${cxxNamespace} {
    * JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
    *   return facebook::jni::initialize(vm, []() {
    *     // register all ${cppLibName} HybridObjects
-   *     ${cxxNamespace}::registerNatives();
+   *     ${cxxNamespace}::registerAllNatives();
    *     // any other custom registrations go here.
    *   });
    * }

--- a/packages/react-native-nitro-modules/cpp/registry/HybridObjectRegistry.cpp
+++ b/packages/react-native-nitro-modules/cpp/registry/HybridObjectRegistry.cpp
@@ -78,7 +78,7 @@ std::shared_ptr<HybridObject> HybridObjectRegistry::createHybridObject(const std
                    "- If you use Nitrogen, make sure your library (*Package.kt)/app (MainApplication.kt) calls "
                    "`$$androidCxxLibName$$OnLoad.initializeNative()` somewhere on app-startup.\n"
                    "- If you use Nitrogen, make sure your `cpp-adapter.cpp`/`OnLoad.cpp` calls "
-                   "`margelo::nitro::$$cxxNamespace$$::registerNatives()` inside `facebook::jni::initialize(...)`.\n"
+                   "`margelo::nitro::$$cxxNamespace$$::registerAllNatives()` inside `facebook::jni::initialize(...)`.\n"
                    "- If you use Nitrogen, inspect the generated `$$androidCxxLibName$$OnLoad.cpp` file.\n"
                    "- If you don't use Nitrogen, make sure you called `HybridObjectRegistry.registerHybridObject(...)`."
                    "- All registered HybridObjects: [" +

--- a/packages/react-native-nitro-test-external/nitrogen/generated/android/NitroTestExternalOnLoad.hpp
+++ b/packages/react-native-nitro-test-external/nitrogen/generated/android/NitroTestExternalOnLoad.hpp
@@ -11,7 +11,7 @@
 
 namespace margelo::nitro::test::external {
 
-  [[deprecated("Use registerNatives() instead.")]]
+  [[deprecated("Use registerAllNatives() instead.")]]
   int initialize(JavaVM* vm);
 
   /**
@@ -23,7 +23,7 @@ namespace margelo::nitro::test::external {
    * JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
    *   return facebook::jni::initialize(vm, []() {
    *     // register all NitroTestExternal HybridObjects
-   *     margelo::nitro::test::external::registerNatives();
+   *     margelo::nitro::test::external::registerAllNatives();
    *     // any other custom registrations go here.
    *   });
    * }

--- a/packages/react-native-nitro-test/nitrogen/generated/android/NitroTestOnLoad.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/NitroTestOnLoad.hpp
@@ -11,7 +11,7 @@
 
 namespace margelo::nitro::test {
 
-  [[deprecated("Use registerNatives() instead.")]]
+  [[deprecated("Use registerAllNatives() instead.")]]
   int initialize(JavaVM* vm);
 
   /**
@@ -23,7 +23,7 @@ namespace margelo::nitro::test {
    * JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
    *   return facebook::jni::initialize(vm, []() {
    *     // register all NitroTest HybridObjects
-   *     margelo::nitro::test::registerNatives();
+   *     margelo::nitro::test::registerAllNatives();
    *     // any other custom registrations go here.
    *   });
    * }


### PR DESCRIPTION
## Summary

- point the generated initialize deprecation replacement at `registerAllNatives()`
- correct the generated JNI_OnLoad example in both tracked generated headers
- correct HybridObjectRegistry's missing-registration setup error
- add an exact runtime guidance regression across C++ and Kotlin/Swift test suites

## Breaking changes

None.

## Verification

- untouched Android APK failed both guidance assertions; rebuilt APK passes 2/2
- regenerated specs, root build/typecheck, example lint, C++ lint, and `git diff --check` pass
- Android Debug native build passes
- one parallel typecheck/build race was discarded; the clean sequential rerun passed

Fixes #1565
