### PR TITLE
fix: validate JavaScript enum values

### DIFF
--- a/example/src/getTests.ts
+++ b/example/src/getTests.ts
@@ -521,6 +521,22 @@ export function getTests(
         .didReturn(typeof OldEnum.SECOND)
         .equals(OldEnum.SECOND)
     ),
+    createTest('set optionalOldEnum rejects invalid numbers', () =>
+      it(() => {
+        const invalidValues = [9999, 1.5, NaN, Infinity, -Infinity]
+        let rejectedValues = 0
+        for (const value of invalidValues) {
+          try {
+            testObject.optionalOldEnum = value as OldEnum
+          } catch {
+            rejectedValues++
+          }
+        }
+        return rejectedValues
+      })
+        .didNotThrow()
+        .equals(5)
+    ),
     createTest('get hasBoolean', () =>
       it(() => {
         return testObject.hasBoolean

--- a/packages/nitrogen/src/syntax/c++/CppEnum.ts
+++ b/packages/nitrogen/src/syntax/c++/CppEnum.ts
@@ -45,12 +45,13 @@ export function createCppEnum(
     )
     .join('\n')
   const cxxNamespace = NitroConfig.current.getCxxNamespace('c++')
+  const validValues = enumMembers.map((member) => member.value).join(', ')
+  const minValue = getEnumMinValue(enumMembers)
+  const maxValue = getEnumMaxValue(enumMembers)
 
   let isInsideValidValues: string | undefined
   if (isIncrementingEnum(enumMembers)) {
     // It's just incrementing one after another, so we can simplify this to a bounds check
-    const minValue = getEnumMinValue(enumMembers)
-    const maxValue = getEnumMaxValue(enumMembers)
     isInsideValidValues = `
 // Check if we are within the bounds of the enum.
 return integer >= ${minValue} && integer <= ${maxValue};
@@ -93,6 +94,9 @@ namespace margelo::nitro {
   template <>
   struct JSIConverter<${fullyQualifiedTypename}> final {
     static inline ${fullyQualifiedTypename} fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
+      if (!canConvert(runtime, arg)) [[unlikely]] {
+        throw std::invalid_argument("Cannot convert JS value to ${typename} - expected one of [${validValues}]!");
+      }
       int enumValue = JSIConverter<int>::fromJSI(runtime, arg);
       return static_cast<${fullyQualifiedTypename}>(enumValue);
     }
@@ -105,6 +109,10 @@ namespace margelo::nitro {
         return false;
       }
       double number = value.getNumber();
+      if (number != number || number < ${minValue} || number > ${maxValue}) {
+        // Reject NaN and values outside the enum's bounds before converting to int.
+        return false;
+      }
       int integer = static_cast<int>(number);
       if (number != integer) {
         // The integer is not the same value as the double - we truncated floating points.

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/OldEnum.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/OldEnum.hpp
@@ -37,6 +37,9 @@ namespace margelo::nitro {
   template <>
   struct JSIConverter<margelo::nitro::test::OldEnum> final {
     static inline margelo::nitro::test::OldEnum fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
+      if (!canConvert(runtime, arg)) [[unlikely]] {
+        throw std::invalid_argument("Cannot convert JS value to OldEnum - expected one of [0, 1, 2]!");
+      }
       int enumValue = JSIConverter<int>::fromJSI(runtime, arg);
       return static_cast<margelo::nitro::test::OldEnum>(enumValue);
     }
@@ -49,6 +52,10 @@ namespace margelo::nitro {
         return false;
       }
       double number = value.getNumber();
+      if (number != number || number < 0 || number > 2) {
+        // Reject NaN and values outside the enum's bounds before converting to int.
+        return false;
+      }
       int integer = static_cast<int>(number);
       if (number != integer) {
         // The integer is not the same value as the double - we truncated floating points.

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/WeirdNumbersEnum.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/WeirdNumbersEnum.hpp
@@ -37,6 +37,9 @@ namespace margelo::nitro {
   template <>
   struct JSIConverter<margelo::nitro::test::WeirdNumbersEnum> final {
     static inline margelo::nitro::test::WeirdNumbersEnum fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
+      if (!canConvert(runtime, arg)) [[unlikely]] {
+        throw std::invalid_argument("Cannot convert JS value to WeirdNumbersEnum - expected one of [0, 32, 64]!");
+      }
       int enumValue = JSIConverter<int>::fromJSI(runtime, arg);
       return static_cast<margelo::nitro::test::WeirdNumbersEnum>(enumValue);
     }
@@ -49,6 +52,10 @@ namespace margelo::nitro {
         return false;
       }
       double number = value.getNumber();
+      if (number != number || number < 0 || number > 64) {
+        // Reject NaN and values outside the enum's bounds before converting to int.
+        return false;
+      }
       int integer = static_cast<int>(number);
       if (number != integer) {
         // The integer is not the same value as the double - we truncated floating points.


### PR DESCRIPTION
## Summary

- validate direct generated numeric-enum conversions before casting
- reject NaN, infinities, and out-of-range values before converting a JavaScript number to `int`
- cover invalid direct enum assignments through both C++ and Swift/Kotlin TestObject implementations
- commit the regenerated enum headers

## Breaking changes

Invalid JavaScript numbers that were previously cast into undeclared closed-enum values now throw during conversion. Declared numeric enum values are unchanged.

## Verification

- exact untouched iOS Harness rejected 0/5 invalid values in both native implementation paths; fixed regression passes 2/2
- focused enum suite passes 22/22
- full root build, workspace typecheck, lint-all, package Jest, native iOS build, Android arm64 Debug build, and `git diff --check` pass

Fixes #1567