### PR TITLE
fix: support aliased HybridView imports

### DIFF
--- a/packages/nitrogen/src/getPlatformSpecs.ts
+++ b/packages/nitrogen/src/getPlatformSpecs.ts
@@ -1,6 +1,6 @@
 import type { PlatformSpec } from 'react-native-nitro-modules'
 import type { InterfaceDeclaration, Type, TypeAliasDeclaration } from 'ts-morph'
-import { Node, Symbol } from 'ts-morph'
+import { Symbol } from 'ts-morph'
 import { getBaseTypes } from './utils.js'
 
 export type Platform = keyof Required<PlatformSpec>
@@ -185,27 +185,22 @@ export function getHybridObjectPlatforms(
 export function getHybridViewPlatforms(
   view: InterfaceDeclaration | TypeAliasDeclaration
 ): PlatformSpec {
-  if (Node.isTypeAliasDeclaration(view)) {
-    const hybridViewTypeNode = view.getTypeNode()
-
-    const isHybridViewType =
-      Node.isTypeReference(hybridViewTypeNode) &&
-      hybridViewTypeNode.getTypeName().getText() === 'HybridView'
-
-    if (!isHybridViewType) {
-      throw new Error(
-        `${view.getName()} looks like a HybridView, but doesn't seem to alias HybridView<...>!`
-      )
-    }
-
-    const genericArguments = hybridViewTypeNode.getTypeArguments()
-
-    const platformSpecArg = genericArguments[2]
-    if (platformSpecArg != null) {
-      return getPlatformSpec(view.getName(), platformSpecArg.getType())
-    }
+  const hybridViewTag = view
+    .getType()
+    .getIntersectionTypes()
+    .find((type) => type.getSymbol()?.getName() === 'HybridViewTag')
+  if (hybridViewTag == null) {
+    throw new Error(
+      `${view.getName()} looks like a HybridView, but doesn't contain HybridViewTag<...>!`
+    )
   }
 
-  // it uses `HybridObject` without generic arguments. This defaults to platform native languages
-  return { ios: 'swift', android: 'kotlin' }
+  const platformSpecArg = hybridViewTag.getTypeArguments()[0]
+  if (platformSpecArg == null) {
+    throw new Error(
+      `${view.getName()} does not declare any platforms in HybridView<...>!`
+    )
+  }
+
+  return getPlatformSpec(view.getName(), platformSpecArg)
 }

--- a/packages/react-native-nitro-test/src/specs/TestView.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestView.nitro.ts
@@ -1,5 +1,5 @@
 import type {
-  HybridView,
+  HybridView as HybridViewAlias,
   HybridViewMethods,
   HybridViewProps,
 } from 'react-native-nitro-modules'
@@ -20,4 +20,4 @@ export interface TestViewMethods extends HybridViewMethods {
   someMethod(): void
 }
 
-export type TestView = HybridView<TestViewProps, TestViewMethods>
+export type TestView = HybridViewAlias<TestViewProps, TestViewMethods>


### PR DESCRIPTION
## Summary

- derive Hybrid View platforms from the resolved `HybridViewTag<PlatformSpec>` intersection
- support import aliases without depending on the source-level spelling `HybridView`
- preserve default and explicit platform selections
- cover generation through an aliased TestView import

## Breaking changes

None.

## Verification

- exact baseline fixture exited 1 because the aliased type was detected as a Hybrid View and then rejected during platform extraction
- fixed direct regeneration passes 7/7 with zero tracked generated drift
- explicit `{ ios: "c++" }` semantic probe resolves correctly
- full root build, sequential workspace typecheck, lint-all, and `git diff --check` pass
- one parallel typecheck/build race was discarded; the clean sequential run passed

Fixes #1569