### PR TITLE
ci: Add red repro for iOS static-library build break on RN <= 0.83 (glog modulemap)

### DIFF
--- a/.github/workflows/build-ios-rn080.yml
+++ b/.github/workflows/build-ios-rn080.yml
@@ -1,0 +1,73 @@
+name: Build iOS (React Native 0.80)
+
+# Builds the NitroModules pod inside a bare React Native 0.80 app with static
+# libraries (the CocoaPods default). React Native <= 0.83 builds glog from
+# source with a modulemap that cannot be compiled as a clang module, so any
+# NitroModules public header that (transitively) includes <glog/logging.h>
+# breaks every `import NitroModules` from Swift. The example app cannot cover
+# this: its React Native ships glog with a textual-headers modulemap (RN 0.84+).
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/build-ios-rn080.yml'
+      - 'packages/react-native-nitro-modules/cpp/**'
+      - 'packages/react-native-nitro-modules/ios/**'
+      - 'packages/react-native-nitro-modules/*.podspec'
+      - 'packages/react-native-nitro-modules/nitro_pod_utils.rb'
+  pull_request:
+    paths:
+      - '.github/workflows/build-ios-rn080.yml'
+      - 'packages/react-native-nitro-modules/cpp/**'
+      - 'packages/react-native-nitro-modules/ios/**'
+      - 'packages/react-native-nitro-modules/*.podspec'
+      - 'packages/react-native-nitro-modules/nitro_pod_utils.rb'
+
+env:
+  XCODE_VERSION: '26.5'
+  RN_VERSION: '0.80.3'
+
+jobs:
+  build:
+    name: Build NitroModules pod (RN 0.80, static libraries)
+    runs-on: macOS-26
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Select Xcode ${{ env.XCODE_VERSION }}
+        run: sudo xcode-select -s "/Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer"
+
+      - name: Create a bare React Native ${{ env.RN_VERSION }} app
+        working-directory: ${{ runner.temp }}
+        run: npx -y @react-native-community/cli@latest init TestApp --version ${{ env.RN_VERSION }} --skip-git-init --install-pods false
+
+      - name: Add NitroModules to the Podfile
+        working-directory: ${{ runner.temp }}/TestApp/ios
+        env:
+          NITRO_PATH: ${{ github.workspace }}/packages/react-native-nitro-modules
+        run: |
+          ruby - <<'RUBY'
+          podfile = File.read('Podfile')
+          pod_line = "  pod 'NitroModules', :path => '#{ENV['NITRO_PATH']}'\n"
+          raise 'use_native_modules! not found in template Podfile' unless podfile.sub!(/^(\s*config = use_native_modules!\n)/) { "#{$1}#{pod_line}" }
+          File.write('Podfile', podfile)
+          RUBY
+
+      - name: Install Pods
+        working-directory: ${{ runner.temp }}/TestApp/ios
+        run: pod install
+
+      - name: Build NitroModules pod
+        working-directory: ${{ runner.temp }}/TestApp/ios
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project Pods/Pods.xcodeproj \
+            -target NitroModules \
+            -sdk iphonesimulator \
+            -configuration Debug \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            build | xcbeautify --renderer github-actions


### PR DESCRIPTION
Red-CI repro for #1573, per the [contributing guide](https://nitro.margelo.com/docs/resources/contributing) — no fix included, the fix is in a separate PR.

Since 0.37.0, plain CocoaPods iOS builds (static libraries, no `use_frameworks!`) fail on React Native <= 0.83 with:

```
glog/logging.h:512:1: error: import of module 'glog.glog.log_severity' appears within namespace 'google'
react/debug/react_native_assert.h:54:10: error: could not build module 'glog'
<unknown>:0: error: could not build Objective-C module 'NitroModules'
```

0.37.0 added `ReactProp.hpp`, `ViewComponentDescriptor.hpp` and `ViewPropsHolderState.hpp` to `public_header_files`, so they became part of the generated `NitroModules` modulemap; their `<react/renderer/*>` includes reach `<glog/logging.h>`, and glog's modulemap on RN <= 0.83 cannot be compiled as a clang module. RN 0.84+ ships a textual-headers glog modulemap (`scripts/ios-configure-glog.sh`), which is why the example app and existing CI cannot see this — I verified the example also builds fine with RN built fully from source on its RN 0.85.

This adds a workflow that builds the `NitroModules` pod target inside a bare React Native 0.80.3 app with static libraries. It is red on `main` and turns green with the fix PR (which includes this same workflow as its regression test).
