### PR TITLE
fix: Hide React renderer headers from the Swift-facing NitroModules module

### DIFF
--- a/.github/workflows/build-ios-rn080.yml
+++ b/.github/workflows/build-ios-rn080.yml
@@ -1,0 +1,73 @@
+name: Build iOS (React Native 0.80)
+
+# Builds the NitroModules pod inside a bare React Native 0.80 app with static
+# libraries (the CocoaPods default). React Native <= 0.83 builds glog from
+# source with a modulemap that cannot be compiled as a clang module, so any
+# NitroModules public header that (transitively) includes <glog/logging.h>
+# breaks every `import NitroModules` from Swift. The example app cannot cover
+# this: its React Native ships glog with a textual-headers modulemap (RN 0.84+).
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/build-ios-rn080.yml'
+      - 'packages/react-native-nitro-modules/cpp/**'
+      - 'packages/react-native-nitro-modules/ios/**'
+      - 'packages/react-native-nitro-modules/*.podspec'
+      - 'packages/react-native-nitro-modules/nitro_pod_utils.rb'
+  pull_request:
+    paths:
+      - '.github/workflows/build-ios-rn080.yml'
+      - 'packages/react-native-nitro-modules/cpp/**'
+      - 'packages/react-native-nitro-modules/ios/**'
+      - 'packages/react-native-nitro-modules/*.podspec'
+      - 'packages/react-native-nitro-modules/nitro_pod_utils.rb'
+
+env:
+  XCODE_VERSION: '26.5'
+  RN_VERSION: '0.80.3'
+
+jobs:
+  build:
+    name: Build NitroModules pod (RN 0.80, static libraries)
+    runs-on: macOS-26
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Select Xcode ${{ env.XCODE_VERSION }}
+        run: sudo xcode-select -s "/Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer"
+
+      - name: Create a bare React Native ${{ env.RN_VERSION }} app
+        working-directory: ${{ runner.temp }}
+        run: npx -y @react-native-community/cli@latest init TestApp --version ${{ env.RN_VERSION }} --skip-git-init --install-pods false
+
+      - name: Add NitroModules to the Podfile
+        working-directory: ${{ runner.temp }}/TestApp/ios
+        env:
+          NITRO_PATH: ${{ github.workspace }}/packages/react-native-nitro-modules
+        run: |
+          ruby - <<'RUBY'
+          podfile = File.read('Podfile')
+          pod_line = "  pod 'NitroModules', :path => '#{ENV['NITRO_PATH']}'\n"
+          raise 'use_native_modules! not found in template Podfile' unless podfile.sub!(/^(\s*config = use_native_modules!\n)/) { "#{$1}#{pod_line}" }
+          File.write('Podfile', podfile)
+          RUBY
+
+      - name: Install Pods
+        working-directory: ${{ runner.temp }}/TestApp/ios
+        run: pod install
+
+      - name: Build NitroModules pod
+        working-directory: ${{ runner.temp }}/TestApp/ios
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project Pods/Pods.xcodeproj \
+            -target NitroModules \
+            -sdk iphonesimulator \
+            -configuration Debug \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            build | xcbeautify --renderer github-actions

--- a/packages/react-native-nitro-modules/cpp/utils/NitroDefines.hpp
+++ b/packages/react-native-nitro-modules/cpp/utils/NitroDefines.hpp
@@ -31,6 +31,13 @@
 #define _CXX_INTEROP_HAS_ATTRIBUTE(x) 0
 #endif
 
+// Helper to find out if this code is currently being compiled as part of a given clang module
+#ifdef __building_module
+#define NITRO_BUILDING_MODULE(module) __building_module(module)
+#else
+#define NITRO_BUILDING_MODULE(module) 0
+#endif
+
 // Closed/Final Enums
 #if _CXX_INTEROP_HAS_ATTRIBUTE(enum_extensibility)
 // Enum is marked as closed/not extensible

--- a/packages/react-native-nitro-modules/cpp/views/ReactProp.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/ReactProp.hpp
@@ -4,6 +4,13 @@
 
 #pragma once
 
+#include "NitroDefines.hpp"
+
+// This header includes <react/renderer/*> headers, which cannot be compiled as part of a
+// clang module - so it is hidden from the Swift-facing `NitroModules` module and can only
+// be included textually, from C++.
+#if !NITRO_BUILDING_MODULE(NitroModules)
+
 #include "BorrowingReference.hpp"
 #include "IsFunctionProp.hpp"
 #include "JSIConverter.hpp"
@@ -121,3 +128,5 @@ public:
 };
 
 } // namespace margelo::nitro
+
+#endif

--- a/packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/ViewComponentDescriptor.hpp
@@ -4,6 +4,13 @@
 
 #pragma once
 
+#include "NitroDefines.hpp"
+
+// This header includes <react/renderer/*> headers, which cannot be compiled as part of a
+// clang module - so it is hidden from the Swift-facing `NitroModules` module and can only
+// be included textually, from C++.
+#if !NITRO_BUILDING_MODULE(NitroModules)
+
 #include "RawPropsCompat.hpp"
 
 #include <concepts>
@@ -75,3 +82,5 @@ public:
 };
 
 } // namespace margelo::nitro
+
+#endif

--- a/packages/react-native-nitro-modules/cpp/views/ViewPropsHolderState.hpp
+++ b/packages/react-native-nitro-modules/cpp/views/ViewPropsHolderState.hpp
@@ -4,6 +4,13 @@
 
 #pragma once
 
+#include "NitroDefines.hpp"
+
+// This header includes <react/renderer/*> headers, which cannot be compiled as part of a
+// clang module - so it is hidden from the Swift-facing `NitroModules` module and can only
+// be included textually, from C++.
+#if !NITRO_BUILDING_MODULE(NitroModules)
+
 #include <memory>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include <utility>
@@ -48,3 +55,5 @@ private:
 };
 
 } // namespace margelo::nitro
+
+#endif


### PR DESCRIPTION
Fixes #1573.

Since 0.37.0, `ReactProp.hpp`, `ViewComponentDescriptor.hpp` and `ViewPropsHolderState.hpp` are in `public_header_files`, so CocoaPods puts them into the generated `NitroModules` modulemap. Their `<react/renderer/*>` includes reach `<glog/logging.h>`, and on React Native <= 0.83 glog's modulemap cannot be compiled as a clang module (its `logging.h` includes `glog/log_severity.h` from inside `namespace google`). Every Swift `import NitroModules` then fails in static-library builds (the CocoaPods default):

```
glog/logging.h:512:1: error: import of module 'glog.glog.log_severity' appears within namespace 'google'
react/debug/react_native_assert.h:54:10: error: could not build module 'glog'
<unknown>:0: error: could not build Objective-C module 'NitroModules'
```

RN 0.84+ is unaffected (its glog ships a textual-headers modulemap), which is why the example app and existing CI never saw this. #1521 fixed the sibling `use_frameworks!`/`cxxreact` variant only.

Swift never uses these C++ view types — only nitrogen-generated C++ includes them. This guards their contents with clang's `__building_module(NitroModules)`, so they stay public and textually includable from C++, but are empty inside the Swift-facing module build. Also includes the new CI workflow from #1574 as the regression test (red without this fix, green with it).

Verified in a bare React Native 0.80.3 app with static libraries: 0.37.1 fails as above, with this change the `NitroModules` pod builds, and reverting the change makes it fail again. Also builds with `use_frameworks! :linkage => :static` in the same app.
