### PR TITLE
fix(nitrogen): match Kotlin's `is` prefix rule for JVM accessors

### DIFF
--- a/apps/example/src/getTests.ts
+++ b/apps/example/src/getTests.ts
@@ -552,6 +552,22 @@ export function getTests(
         .didNotThrow()
         .equals(true)
     ),
+    createTest('set + get isolatedBoolean', () =>
+      it(() => {
+        testObject.isolatedBoolean = true
+        return testObject.isolatedBoolean
+      })
+        .didNotThrow()
+        .equals(true)
+    ),
+    createTest('set + get isTextValue', () =>
+      it(() => {
+        testObject.isTextValue = 'hello'
+        return testObject.isTextValue
+      })
+        .didNotThrow()
+        .equals('hello')
+    ),
     createTest('set optionalCallback, then undefined', () =>
       it(() => {
         testObject.optionalCallback = () => {}

--- a/packages/nitrogen/src/syntax/Property.ts
+++ b/packages/nitrogen/src/syntax/Property.ts
@@ -14,6 +14,14 @@ export interface PropertyBody {
 
 export type LanguageEnvironment = 'jvm' | 'swift' | 'other'
 
+// Kotlin only shortens accessors when `is` is not followed by a lowercase letter
+// (see `JvmAbi.startsWithIsPrefix`), and it does that for every type - not just booleans.
+function hasJvmIsPrefix(name: string): boolean {
+  if (!name.startsWith('is') || name.length === 2) return false
+  const next = name.charAt(2)
+  return next < 'a' || next > 'z'
+}
+
 export interface PropertyModifiers {
   /**
    * The name of the class that defines this C++ property getter/setter method.
@@ -72,49 +80,34 @@ export class Property implements CodeNode {
   }
 
   getGetterName(environment: LanguageEnvironment): string {
-    if (this.type.kind === 'boolean') {
-      // Boolean accessors where the property starts with "is" or "has" are renamed in JVM and Swift
-      switch (environment) {
-        case 'jvm':
-          if (this.name.startsWith('is')) {
-            // isSomething -> isSomething()
-            return this.name
-          } else {
-            break
-          }
-        case 'swift':
-          if (this.name.startsWith('is')) {
-            // isSomething -> isSomething()
-            return this.name
-          } else if (this.name.startsWith('has')) {
-            // hasSomething -> hasSomething()
-            return this.name
-          } else {
-            break
-          }
-        default:
-          break
-      }
+    switch (environment) {
+      case 'jvm':
+        if (hasJvmIsPrefix(this.name)) {
+          // isSomething -> isSomething()
+          return this.name
+        }
+        break
+      case 'swift':
+        // Swift only shortens boolean accessors that start with "is" or "has"
+        if (
+          this.type.kind === 'boolean' &&
+          (this.name.startsWith('is') || this.name.startsWith('has'))
+        ) {
+          // isSomething -> isSomething()
+          return this.name
+        }
+        break
+      default:
+        break
     }
     // isSomething -> getIsSomething()
     return `get${capitalizeName(this.name)}`
   }
 
   getSetterName(environment: LanguageEnvironment): string {
-    if (this.type.kind === 'boolean') {
-      // Boolean accessors where the property starts with "is" are renamed in JVM
-      switch (environment) {
-        case 'jvm':
-          if (this.name.startsWith('is')) {
-            // isSomething -> setSomething()
-            const cleanName = this.name.replace('is', '')
-            return `set${capitalizeName(cleanName)}`
-          } else {
-            break
-          }
-        default:
-          break
-      }
+    if (environment === 'jvm' && hasJvmIsPrefix(this.name)) {
+      // isSomething -> setSomething()
+      return `set${capitalizeName(this.name.slice(2))}`
     }
     // isSomething -> setIsSomething()
     return `set${capitalizeName(this.name)}`

--- a/packages/nitrogen/src/syntax/Property.ts
+++ b/packages/nitrogen/src/syntax/Property.ts
@@ -107,7 +107,7 @@ export class Property implements CodeNode {
   getSetterName(environment: LanguageEnvironment): string {
     if (environment === 'jvm' && hasJvmIsPrefix(this.name)) {
       // isSomething -> setSomething()
-      return `set${capitalizeName(this.name.slice(2))}`
+      return `set${this.name.slice(2)}`
     }
     // isSomething -> setIsSomething()
     return `set${capitalizeName(this.name)}`

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
@@ -52,6 +52,8 @@ class HybridTestObjectKotlin : HybridTestObjectSwiftKotlinSpec() {
   override val isBoolean = false
   override var hasBooleanWritable = false
   override var isBooleanWritable = false
+  override var isolatedBoolean = false
+  override var isTextValue = ""
 
   override fun simpleFunc() {
     // do nothing

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
@@ -184,6 +184,22 @@ void HybridTestObjectCpp::setHasBooleanWritable(bool hasBooleanWritable) {
   _hasBooleanWritable = hasBooleanWritable;
 }
 
+bool HybridTestObjectCpp::getIsolatedBoolean() {
+  return _isolatedBoolean;
+}
+
+void HybridTestObjectCpp::setIsolatedBoolean(bool isolatedBoolean) {
+  _isolatedBoolean = isolatedBoolean;
+}
+
+std::string HybridTestObjectCpp::getIsTextValue() {
+  return _isTextValue;
+}
+
+void HybridTestObjectCpp::setIsTextValue(const std::string& isTextValue) {
+  _isTextValue = isTextValue;
+}
+
 void HybridTestObjectCpp::setOptionalCallback(const std::optional<std::function<void(double)>>& callback) {
   _optionalCallback = callback;
 }

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
@@ -46,6 +46,8 @@ private:
   bool _hasBooleanWritable;
   bool _isBooleanWritable;
   std::shared_ptr<Promise<double>> _pendingPromise;
+  bool _isolatedBoolean;
+  std::string _isTextValue;
 
 private:
   static inline uint64_t calculateFibonacci(int count) noexcept {
@@ -104,6 +106,10 @@ public:
   void setIsBooleanWritable(bool isBooleanWritable) override;
   bool getHasBooleanWritable() override;
   void setHasBooleanWritable(bool hasBooleanWritable) override;
+  bool getIsolatedBoolean() override;
+  void setIsolatedBoolean(bool isolatedBoolean) override;
+  std::string getIsTextValue() override;
+  void setIsTextValue(const std::string& isTextValue) override;
 
 public:
   // Methods

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
@@ -46,7 +46,7 @@ private:
   bool _hasBooleanWritable;
   bool _isBooleanWritable;
   std::shared_ptr<Promise<double>> _pendingPromise;
-  bool _isolatedBoolean;
+  bool _isolatedBoolean = false;
   std::string _isTextValue;
 
 private:

--- a/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
@@ -52,6 +52,8 @@ class HybridTestObjectSwift: HybridTestObjectSwiftKotlinSpec {
   let isBoolean = false
   var hasBooleanWritable = false
   var isBooleanWritable = false
+  var isolatedBoolean = false
+  var isTextValue = ""
 
   var thisObject: any HybridTestObjectSwiftKotlinSpec {
     return self

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -364,6 +364,24 @@ namespace margelo::nitro::test {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void(jboolean /* isBooleanWritable */)>("setBooleanWritable");
     method(_javaPart, isBooleanWritable);
   }
+  bool JHybridTestObjectSwiftKotlinSpec::getIsolatedBoolean() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean()>("getIsolatedBoolean");
+    auto __result = method(_javaPart);
+    return static_cast<bool>(__result);
+  }
+  void JHybridTestObjectSwiftKotlinSpec::setIsolatedBoolean(bool isolatedBoolean) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jboolean /* isolatedBoolean */)>("setIsolatedBoolean");
+    method(_javaPart, isolatedBoolean);
+  }
+  std::string JHybridTestObjectSwiftKotlinSpec::getIsTextValue() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("isTextValue");
+    auto __result = method(_javaPart);
+    return __result->toStdString();
+  }
+  void JHybridTestObjectSwiftKotlinSpec::setIsTextValue(const std::string& isTextValue) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* isTextValue */)>("setTextValue");
+    method(_javaPart, jni::make_jstring(isTextValue));
+  }
   std::variant<double, std::string> JHybridTestObjectSwiftKotlinSpec::getSomeVariant() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JVariant_Double_String>()>("getSomeVariant");
     auto __result = method(_javaPart);

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -87,6 +87,10 @@ namespace margelo::nitro::test {
     void setHasBooleanWritable(bool hasBooleanWritable) override;
     bool getIsBooleanWritable() override;
     void setIsBooleanWritable(bool isBooleanWritable) override;
+    bool getIsolatedBoolean() override;
+    void setIsolatedBoolean(bool isolatedBoolean) override;
+    std::string getIsTextValue() override;
+    void setIsTextValue(const std::string& isTextValue) override;
     std::variant<double, std::string> getSomeVariant() override;
     void setSomeVariant(const std::variant<double, std::string>& someVariant) override;
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec.kt
@@ -165,6 +165,18 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   @get:Keep
   @set:DoNotStrip
   @set:Keep
+  abstract var isolatedBoolean: Boolean
+  
+  @get:DoNotStrip
+  @get:Keep
+  @set:DoNotStrip
+  @set:Keep
+  abstract var isTextValue: String
+  
+  @get:DoNotStrip
+  @get:Keep
+  @set:DoNotStrip
+  @set:Keep
   abstract var someVariant: Variant_Double_String
 
   // Methods

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -262,6 +262,19 @@ namespace margelo::nitro::test {
     inline void setIsBooleanWritable(bool isBooleanWritable) noexcept override {
       _swiftPart.setIsBooleanWritable(std::forward<decltype(isBooleanWritable)>(isBooleanWritable));
     }
+    inline bool getIsolatedBoolean() noexcept override {
+      return _swiftPart.isolatedBoolean();
+    }
+    inline void setIsolatedBoolean(bool isolatedBoolean) noexcept override {
+      _swiftPart.setIsolatedBoolean(std::forward<decltype(isolatedBoolean)>(isolatedBoolean));
+    }
+    inline std::string getIsTextValue() noexcept override {
+      auto __result = _swiftPart.getIsTextValue();
+      return __result;
+    }
+    inline void setIsTextValue(const std::string& isTextValue) noexcept override {
+      _swiftPart.setIsTextValue(isTextValue);
+    }
     inline std::variant<double, std::string> getSomeVariant() noexcept override {
       auto __result = _swiftPart.getSomeVariant();
       return __result;

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -31,6 +31,8 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: HybridObject {
   var isBoolean: Bool { get }
   var hasBooleanWritable: Bool { get set }
   var isBooleanWritable: Bool { get set }
+  var isolatedBoolean: Bool { get set }
+  var isTextValue: String { get set }
   var someVariant: Variant_Double_String { get set }
 
   // Methods

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -456,6 +456,28 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
     }
   }
   
+  public final var isolatedBoolean: Bool {
+    @inline(__always)
+    get {
+      return self.__implementation.isolatedBoolean
+    }
+    @inline(__always)
+    set {
+      self.__implementation.isolatedBoolean = newValue
+    }
+  }
+  
+  public final var isTextValue: std.string {
+    @inline(__always)
+    get {
+      return std.string(self.__implementation.isTextValue)
+    }
+    @inline(__always)
+    set {
+      self.__implementation.isTextValue = String(newValue)
+    }
+  }
+  
   public final var someVariant: bridge.std__variant_double__std__string_ {
     @inline(__always)
     get {

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -53,6 +53,10 @@ namespace margelo::nitro::test {
       prototype.registerHybridSetter("hasBooleanWritable", &HybridTestObjectCppSpec::setHasBooleanWritable);
       prototype.registerHybridGetter("isBooleanWritable", &HybridTestObjectCppSpec::getIsBooleanWritable);
       prototype.registerHybridSetter("isBooleanWritable", &HybridTestObjectCppSpec::setIsBooleanWritable);
+      prototype.registerHybridGetter("isolatedBoolean", &HybridTestObjectCppSpec::getIsolatedBoolean);
+      prototype.registerHybridSetter("isolatedBoolean", &HybridTestObjectCppSpec::setIsolatedBoolean);
+      prototype.registerHybridGetter("isTextValue", &HybridTestObjectCppSpec::getIsTextValue);
+      prototype.registerHybridSetter("isTextValue", &HybridTestObjectCppSpec::setIsTextValue);
       prototype.registerHybridGetter("someVariant", &HybridTestObjectCppSpec::getSomeVariant);
       prototype.registerHybridSetter("someVariant", &HybridTestObjectCppSpec::setSomeVariant);
       prototype.registerHybridMethod("getVariantTuple", &HybridTestObjectCppSpec::getVariantTuple);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -159,6 +159,10 @@ namespace margelo::nitro::test {
       virtual void setHasBooleanWritable(bool hasBooleanWritable) = 0;
       virtual bool getIsBooleanWritable() = 0;
       virtual void setIsBooleanWritable(bool isBooleanWritable) = 0;
+      virtual bool getIsolatedBoolean() = 0;
+      virtual void setIsolatedBoolean(bool isolatedBoolean) = 0;
+      virtual std::string getIsTextValue() = 0;
+      virtual void setIsTextValue(const std::string& isTextValue) = 0;
       virtual std::variant<double, std::string> getSomeVariant() = 0;
       virtual void setSomeVariant(const std::variant<double, std::string>& someVariant) = 0;
 

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
@@ -51,6 +51,10 @@ namespace margelo::nitro::test {
       prototype.registerHybridSetter("hasBooleanWritable", &HybridTestObjectSwiftKotlinSpec::setHasBooleanWritable);
       prototype.registerHybridGetter("isBooleanWritable", &HybridTestObjectSwiftKotlinSpec::getIsBooleanWritable);
       prototype.registerHybridSetter("isBooleanWritable", &HybridTestObjectSwiftKotlinSpec::setIsBooleanWritable);
+      prototype.registerHybridGetter("isolatedBoolean", &HybridTestObjectSwiftKotlinSpec::getIsolatedBoolean);
+      prototype.registerHybridSetter("isolatedBoolean", &HybridTestObjectSwiftKotlinSpec::setIsolatedBoolean);
+      prototype.registerHybridGetter("isTextValue", &HybridTestObjectSwiftKotlinSpec::getIsTextValue);
+      prototype.registerHybridSetter("isTextValue", &HybridTestObjectSwiftKotlinSpec::setIsTextValue);
       prototype.registerHybridGetter("someVariant", &HybridTestObjectSwiftKotlinSpec::getSomeVariant);
       prototype.registerHybridSetter("someVariant", &HybridTestObjectSwiftKotlinSpec::setSomeVariant);
       prototype.registerHybridMethod("newTestObject", &HybridTestObjectSwiftKotlinSpec::newTestObject);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
@@ -152,6 +152,10 @@ namespace margelo::nitro::test {
       virtual void setHasBooleanWritable(bool hasBooleanWritable) = 0;
       virtual bool getIsBooleanWritable() = 0;
       virtual void setIsBooleanWritable(bool isBooleanWritable) = 0;
+      virtual bool getIsolatedBoolean() = 0;
+      virtual void setIsolatedBoolean(bool isolatedBoolean) = 0;
+      virtual std::string getIsTextValue() = 0;
+      virtual void setIsTextValue(const std::string& isTextValue) = 0;
       virtual std::variant<double, std::string> getSomeVariant() = 0;
       virtual void setSomeVariant(const std::variant<double, std::string>& someVariant) = 0;
 

--- a/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
@@ -162,6 +162,10 @@ interface SharedTestObjectProps {
   readonly isBoolean: boolean
   hasBooleanWritable: boolean
   isBooleanWritable: boolean
+  // Kotlin only simplifies `is*` when it is not followed by a lowercase letter,
+  // and it does so for every type - not just booleans.
+  isolatedBoolean: boolean
+  isTextValue: string
 
   // Basic function tests
   simpleFunc(): void


### PR DESCRIPTION
## What breaks

`packages/nitrogen/src/syntax/Property.ts:103` (`getSetterName`) and `:74` (`getGetterName`) modelled Kotlin's `is` prefix rule as "the property is a `boolean` **and** `name.startsWith('is')`".

Kotlin's actual rule (`JvmAbi.startsWithIsPrefix`) is different in two ways:

1. The character after `is` must **not** be a lowercase letter. `isBlue` is shortened, `isolatedBoolean` is not.
2. It applies to **every** property type, not just `Boolean`. `var isTextValue: String` is shortened too.

Because the JNI bridge looks methods up by name at runtime, a mismatch is not caught by the Android build. It throws on first access:

| Kotlin property | kotlinc/javap emits | nitrogen generated (before) |
| --- | --- | --- |
| `var isolatedBoolean: Boolean` | `getIsolatedBoolean()` / `setIsolatedBoolean(..)` | `isolatedBoolean()` / `setOlatedBoolean(..)` |
| `var isTextValue: String` | `isTextValue()` / `setTextValue(..)` | `getIsTextValue()` / `setIsTextValue(..)` |

Note `setOlatedBoolean`: the old code did `name.replace('is', '')`, so `isolatedBoolean` became `OlatedBoolean`.

iOS is unaffected. Swift/C++ interop really does use a plain `is`/`has` prefix check and really is boolean only, so that branch is kept as it was, just moved out of the shared `boolean` gate.

## Fix

`Property.ts` now has a single `hasJvmIsPrefix()` helper that mirrors `JvmAbi.startsWithIsPrefix`, used by both the JVM getter and setter name. The Swift branch keeps its own (boolean, `is`/`has`) rule.

## Test

Two properties on `SharedTestObjectProps` (next to the existing `has*`/`is*` block added in #1223), one per shape, plus a `set + get` assertion for each in `apps/example/src/getTests.ts`, so the Harness workflows cover them on both platforms:

```ts
isolatedBoolean: boolean
isTextValue: string
```

`isTextValue` rather than `isStringValue`, because `isStringValue` collides with the existing `stringValue` property on the same class (both would be `setStringValue(String)`, which kotlinc rejects with a platform declaration clash).

## How I proved it

Ground truth from the real Kotlin compiler, on the property declarations nitrogen generates in `HybridTestObjectSwiftKotlinSpec.kt`:

```
$ javap -cp outspec Spec
public abstract class Spec {
  public abstract java.lang.String getStringValue();
  public abstract void setStringValue(java.lang.String);
  public abstract boolean getHasBoolean();
  public abstract boolean isBoolean();
  public abstract boolean getHasBooleanWritable();
  public abstract void setHasBooleanWritable(boolean);
  public abstract boolean isBooleanWritable();
  public abstract void setBooleanWritable(boolean);
  public abstract boolean getIsolatedBoolean();
  public abstract void setIsolatedBoolean(boolean);
  public abstract java.lang.String isTextValue();
  public abstract void setTextValue(java.lang.String);
}
```

With the fix, `bun specs` generates exactly those names in `JHybridTestObjectSwiftKotlinSpec.cpp`:

```cpp
getMethod<jboolean()>("getIsolatedBoolean");
getMethod<void(jboolean /* isolatedBoolean */)>("setIsolatedBoolean");
getMethod<jni::local_ref<jni::JString>()>("isTextValue");
getMethod<void(jni::alias_ref<jni::JString> /* isTextValue */)>("setTextValue");
```

Reverting only `Property.ts` and re-running `bun specs` gives four lookups that do not exist on the Kotlin class:

```cpp
getMethod<jboolean()>("isolatedBoolean");
getMethod<void(jboolean /* isolatedBoolean */)>("setOlatedBoolean");
getMethod<jni::local_ref<jni::JString>()>("getIsTextValue");
getMethod<void(jni::alias_ref<jni::JString> /* isTextValue */)>("setIsTextValue");
```

I also checked the iOS side against `swiftc -cxx-interoperability-mode=default -emit-clang-header-path`, which emits `isolatedBoolean()` / `setIsolatedBoolean(..)` and `getIsTextValue()` / `setIsTextValue(..)`, matching the generated `HybridTestObjectSwiftKotlinSpecSwift.hpp`.

## Checks

* `bun specs` run, generated files committed. Apart from the two new properties, no generated output changed.
* `bun run build`, `bun typecheck`, `bun lint`, `bun lint-ci` in every package, `bun lint-cpp`, `bun lint-swift`, `bun lint-kotlin`: all clean, no files changed by the formatters.
* I could not run the Harness suite (no device available here), so the two new runtime assertions are verified by CI, not locally.

## Breaking changes

A Nitro module with a Kotlin `is*` property in one of these two shapes changes its generated JNI lookup names. That code could not have worked before, so nothing that currently runs is affected.

