### PR TITLE
fix(ios): avoid shared pointer Bool conversion in generated Swift bridges

### DIFF
--- a/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
+++ b/packages/nitrogen/src/syntax/swift/SwiftHybridObjectBridge.ts
@@ -205,7 +205,7 @@ ${hasBase ? `open class ${name.HybridTSpecCxx} : ${baseClasses.join(', ')}` : `o
    */
   public func getCxxPart() -> bridge.${bridge.specializationName} {
     let cachedCxxPart = self.__cxxPart.lock()
-    if Bool(fromCxx: cachedCxxPart) {
+    if cachedCxxPart.use_count() > 0 {
       return cachedCxxPart
     } else {
       let newCxxPart = bridge.${bridge.funcName}(self.toUnsafe())

--- a/packages/react-native-nitro-test-external/nitrogen/generated/ios/swift/HybridSomeExternalObjectSpec_cxx.swift
+++ b/packages/react-native-nitro-test-external/nitrogen/generated/ios/swift/HybridSomeExternalObjectSpec_cxx.swift
@@ -75,7 +75,7 @@ open class HybridSomeExternalObjectSpec_cxx {
    */
   public func getCxxPart() -> bridge.std__shared_ptr_HybridSomeExternalObjectSpec_ {
     let cachedCxxPart = self.__cxxPart.lock()
-    if Bool(fromCxx: cachedCxxPart) {
+    if cachedCxxPart.use_count() > 0 {
       return cachedCxxPart
     } else {
       let newCxxPart = bridge.create_std__shared_ptr_HybridSomeExternalObjectSpec_(self.toUnsafe())

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridBaseSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridBaseSpec_cxx.swift
@@ -75,7 +75,7 @@ open class HybridBaseSpec_cxx {
    */
   public func getCxxPart() -> bridge.std__shared_ptr_HybridBaseSpec_ {
     let cachedCxxPart = self.__cxxPart.lock()
-    if Bool(fromCxx: cachedCxxPart) {
+    if cachedCxxPart.use_count() > 0 {
       return cachedCxxPart
     } else {
       let newCxxPart = bridge.create_std__shared_ptr_HybridBaseSpec_(self.toUnsafe())

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridChildSpec_cxx.swift
@@ -75,7 +75,7 @@ open class HybridChildSpec_cxx : HybridBaseSpec_cxx {
    */
   public func getCxxPart() -> bridge.std__shared_ptr_HybridChildSpec_ {
     let cachedCxxPart = self.__cxxPart.lock()
-    if Bool(fromCxx: cachedCxxPart) {
+    if cachedCxxPart.use_count() > 0 {
       return cachedCxxPart
     } else {
       let newCxxPart = bridge.create_std__shared_ptr_HybridChildSpec_(self.toUnsafe())

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridPlatformObjectSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridPlatformObjectSpec_cxx.swift
@@ -75,7 +75,7 @@ open class HybridPlatformObjectSpec_cxx {
    */
   public func getCxxPart() -> bridge.std__shared_ptr_HybridPlatformObjectSpec_ {
     let cachedCxxPart = self.__cxxPart.lock()
-    if Bool(fromCxx: cachedCxxPart) {
+    if cachedCxxPart.use_count() > 0 {
       return cachedCxxPart
     } else {
       let newCxxPart = bridge.create_std__shared_ptr_HybridPlatformObjectSpec_(self.toUnsafe())

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridRecyclableTestViewSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridRecyclableTestViewSpec_cxx.swift
@@ -75,7 +75,7 @@ open class HybridRecyclableTestViewSpec_cxx {
    */
   public func getCxxPart() -> bridge.std__shared_ptr_HybridRecyclableTestViewSpec_ {
     let cachedCxxPart = self.__cxxPart.lock()
-    if Bool(fromCxx: cachedCxxPart) {
+    if cachedCxxPart.use_count() > 0 {
       return cachedCxxPart
     } else {
       let newCxxPart = bridge.create_std__shared_ptr_HybridRecyclableTestViewSpec_(self.toUnsafe())

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -76,7 +76,7 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
    */
   public func getCxxPart() -> bridge.std__shared_ptr_HybridTestObjectSwiftKotlinSpec_ {
     let cachedCxxPart = self.__cxxPart.lock()
-    if Bool(fromCxx: cachedCxxPart) {
+    if cachedCxxPart.use_count() > 0 {
       return cachedCxxPart
     } else {
       let newCxxPart = bridge.create_std__shared_ptr_HybridTestObjectSwiftKotlinSpec_(self.toUnsafe())

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestViewSpec_cxx.swift
@@ -75,7 +75,7 @@ open class HybridTestViewSpec_cxx {
    */
   public func getCxxPart() -> bridge.std__shared_ptr_HybridTestViewSpec_ {
     let cachedCxxPart = self.__cxxPart.lock()
-    if Bool(fromCxx: cachedCxxPart) {
+    if cachedCxxPart.use_count() > 0 {
       return cachedCxxPart
     } else {
       let newCxxPart = bridge.create_std__shared_ptr_HybridTestViewSpec_(self.toUnsafe())


### PR DESCRIPTION
## Summary
Replace the cached shared-pointer Bool conversion with a use_count() check in the Swift bridge generator, and regenerate the seven checked-in bridges. No API changes.

Current Xcode rejects Bool(fromCxx: cachedCxxPart) because the imported shared_ptr does not conform to CxxConvertibleToBool. This failed the unchanged iOS Release source in #1582: https://github.com/margelo/nitro/actions/runs/33857794566/job/100975015762

This is an independent prerequisite for the atomic stack: #1582 (example move), #1583 (benchmark app), #1584 (version guard). The correction was extracted from the earlier benchmark implementation so neither the move nor performance PR needs to contain it.

## Validation
- bun specs regenerated only the expected seven Swift bridges.
- Nitrogen TypeScript and ESLint pass; git diff --check passes.
- These same generated changes compile in a local Xcode 26.6 Release simulator build; its standalone benchmark app completed all 40 cases successfully.
- Fresh CI will validate the existing example independently.