### PR TITLE
perf: skip optional argument fallback for fixed-arity HybridFunctions

### DIFF
--- a/apps/example/src/getTests.ts
+++ b/apps/example/src/getTests.ts
@@ -572,6 +572,34 @@ export function getTests(
         .didNotThrow()
         .equals(18)
     ),
+    createTest('addNumbers(...) one-too-few', () =>
+      it(() =>
+        // @ts-expect-error - Exercise the native argument-count check.
+        testObject.addNumbers(5)
+      ).didThrow(
+        `Error: \`${testObject.name}.addNumbers(...)\` expected 2 arguments, but received 1!`
+      )
+    ),
+    createTest('addNumbers(...) one-too-many', () =>
+      it(() =>
+        // @ts-expect-error - Exercise the native argument-count check.
+        testObject.addNumbers(5, 13, 21)
+      ).didThrow(
+        `Error: \`${testObject.name}.addNumbers(...)\` expected 2 arguments, but received 3!`
+      )
+    ),
+    createTest('addNumbers(...) explicit undefined throws', () =>
+      it(() =>
+        // @ts-expect-error - Required arguments still validate their types.
+        testObject.addNumbers(5, undefined)
+      ).didThrow()
+    ),
+    createTest('addNumbers(...) wrong type throws', () =>
+      it(() =>
+        // @ts-expect-error - Required arguments still validate their types.
+        testObject.addNumbers('5', 13)
+      ).didThrow()
+    ),
     createTest('addStrings("hello ", "world") = "hello world"', () =>
       it(() => testObject.addStrings('hello ', 'world'))
         .didNotThrow()
@@ -581,6 +609,14 @@ export function getTests(
       it(() => testObject.simpleFunc())
         .didNotThrow()
         .didReturn('undefined')
+    ),
+    createTest('simpleFunc(...) one-too-many', () =>
+      it(() =>
+        // @ts-expect-error - Zero-argument methods still validate their count.
+        testObject.simpleFunc(1)
+      ).didThrow(
+        `Error: \`${testObject.name}.simpleFunc(...)\` expected 0 arguments, but received 1!`
+      )
     ),
     createTest('multipleArguments(...)', () =>
       it(() => testObject.multipleArguments(13, 'hello!', true))
@@ -994,6 +1030,11 @@ export function getTests(
         .didReturn('string')
         .equals('value omitted!')
     ),
+    createTest('tryOptionalParams(...) explicit undefined', () =>
+      it(() => testObject.tryOptionalParams(13, true, undefined))
+        .didNotThrow()
+        .equals('value omitted!')
+    ),
     createTest('tryOptionalParams(...) provided', () =>
       it(() => testObject.tryOptionalParams(13, true, 'hello'))
         .didNotThrow()
@@ -1030,6 +1071,14 @@ export function getTests(
         .didNotThrow()
         .equals('hello!')
     ),
+    createTest('tryMiddleParam(...) missing required last argument', () =>
+      it(() =>
+        // @ts-expect-error - An optional in the middle cannot shorten the argument list.
+        testObject.tryMiddleParam(13, undefined)
+      ).didThrow(
+        `Error: \`${testObject.name}.tryMiddleParam(...)\` expected 3 arguments, but received 2!`
+      )
+    ),
     createTest('tryMiddleParam(...) true', () =>
       it(() => testObject.tryMiddleParam(13, true, 'passed'))
         .didNotThrow()
@@ -1042,6 +1091,11 @@ export function getTests(
     ),
     createTest('tryOptionalEnum(...) undefined', () =>
       it(() => testObject.tryOptionalEnum(undefined))
+        .didNotThrow()
+        .equals(undefined)
+    ),
+    createTest('tryOptionalEnum(...) omitted', () =>
+      it(() => testObject.tryOptionalEnum())
         .didNotThrow()
         .equals(undefined)
     ),

--- a/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
+++ b/packages/react-native-nitro-modules/cpp/core/HybridFunction.hpp
@@ -168,15 +168,24 @@ private:
                                       /* JS Runtime */ jsi::Runtime& runtime,
                                       /* JS Arguments */ const jsi::Value* NON_NULL args,
                                       /* JS Arguments count */ size_t argsSize, std::index_sequence<Is...>) {
-    static const jsi::Value defaultValue;
+    auto invoke = [&]() -> ReturnType {
+      if constexpr (trailing_optionals_count_v<Args...> == 0) {
+        // The argument count was already validated. Avoid the default value's static initialization guard
+        // for signatures where no arguments can be omitted (including zero-argument methods).
+        return (obj->*method)(JSIConverter<std::decay_t<Args>>::fromJSI(runtime, args[Is])...);
+      } else {
+        static const jsi::Value defaultValue;
+        return (obj->*method)(JSIConverter<std::decay_t<Args>>::fromJSI(runtime, Is < argsSize ? args[Is] : defaultValue)...);
+      }
+    };
 
     if constexpr (std::is_void_v<ReturnType>) {
       // It's a void method.
-      (obj->*method)(JSIConverter<std::decay_t<Args>>::fromJSI(runtime, Is < argsSize ? args[Is] : defaultValue)...);
+      invoke();
       return jsi::Value::undefined();
     } else {
       // It's returning some C++ type, we need to convert that to a JSI value now.
-      ReturnType result = (obj->*method)(JSIConverter<std::decay_t<Args>>::fromJSI(runtime, Is < argsSize ? args[Is] : defaultValue)...);
+      ReturnType result = invoke();
       return JSIConverter<ReturnType>::toJSI(runtime, std::forward<ReturnType>(result));
     }
   }


### PR DESCRIPTION
## Summary

Avoid instantiating `callMethod()`'s static undefined fallback when a HybridFunction signature has no trailing optional arguments.

The argument count is already validated before entering `callMethod()`. An `if constexpr` now uses `args[Is]` directly for fixed-arity signatures, including zero-argument functions and signatures with non-trailing optionals. Signatures with trailing optional arguments retain the existing undefined fallback. A local invocation lambda shares the existing void/non-void return conversion without duplicating it.

No receiver binding, JNI, virtual dispatch, public API, codegen, argument-count validation, or JSI type-checking changes.

## Why

Previously, even required-only calls declared `static const jsi::Value defaultValue`. Its initialization/lifetime guard survived optimized compilation despite the fallback never being needed on that path. Moving the declaration into the optional-only compile-time branch removes that guard and its initialization/exit-destructor registration code from fixed-arity instantiations. Simply making the value automatic would introduce a per-call JSI destructor instead.

## Regression coverage

Add eight cases to the existing native test suite (each runs against C++ and Swift/Kotlin):

- Required argument counts: too few / too many.
- Explicit `undefined` and an incorrect type for required numbers.
- Too many arguments to a zero-argument void method.
- Explicit `undefined` for a trailing optional.
- Missing a required argument after a non-trailing optional.
- Omitting the only argument of an all-optional method.

Existing cases cover successful required calls, void methods, omitted/provided optionals, multiple trailing optionals, and explicit undefined in the middle of an argument list.

## Validation

- [x] Monorepo package build (`bun run build`, Node 24.16.0 / Bun 1.3.14).
- [x] Example TypeScript check.
- [x] ESLint for the changed test file; C++ formatting with the repository's clang-format configuration; `git diff --check`.
- [x] Before/after Android ARM64 compile of actual `HybridFunction::createHybridFunction` instantiations using NDK 29.0.14206865, React Native 0.85.3 headers, C++20, `-O2 -DNDEBUG`: the default-value guard exists before the change for `(double, double) -> double` and `() -> void`, and is absent afterward. The `(double, optional<double>) -> double` fallback and guard remain.
- [x] Same before/after ARM64 iOS Simulator compilation with Apple Clang 21.0.0 confirms the same guard removal and optional fallback preservation.
- [x] Android ARM64 debug example build (`:app:assembleDebug`).
- [x] Android native harness: **554/554 tests passed**, including all 16 added regression executions against C++ and Kotlin (Android 14 ARM64 emulator, debug build, `minSdk 26` matching the CI harness configuration).
- [x] GitHub CI: default Android native harness, Android builds at minSdk 24 and 26, TypeScript compilation/lint, C++ formatting, and Nitrogen generation on Linux/Windows.
- [ ] iOS native harness and remaining sanitizer jobs (CI still running at handoff).

The initial local minSdk 24 harness run passed 545/554 tests; the nine failures were HardwareBuffer cases whose native implementation requires a compile-time minSdk of at least 26. Rebuilding with the existing CI harness's minSdk 26 configuration passed all 554. The temporary build-configuration edit was reverted and is not part of this PR.

This PR claims removal of verified generated-code overhead, not a newly measured end-to-end percentage speedup. The earlier benchmark experiment motivated this fix but is not a timing measurement of this exact patch.

In the current Android compiler output, the required scalar path loses the four guard instructions (`adrp`, `add`, `ldarb`, `tbz`). The exact argument-count check, both checked `asNumber()` calls, and the virtual member invocation remain. These are assembly observations, not cycle counts or timings.
