### PR TITLE
fix: Fail iOS TSan CI on sanitizer reports

### DIFF
--- a/.github/workflows/harness-ios.yml
+++ b/.github/workflows/harness-ios.yml
@@ -174,8 +174,30 @@ jobs:
 
       - name: Run Harness E2E tests
         uses: callstackincubator/react-native-harness@v1.4.1
+        env:
+          SIMCTL_CHILD_TSAN_OPTIONS: ${{ matrix.sanitizer.name == 'TSan' && 'halt_on_error=1:log_path=/tmp/nitro-tsan' || '' }}
         with:
           runner: ios
           projectRoot: apps/example
           app: ios/build/Build/Products/Debug-iphonesimulator/NitroExample.app
           packageManager: bun
+
+      - name: Check TSan reports
+        if: always() && matrix.sanitizer.name == 'TSan'
+        shell: bash
+        run: |
+          shopt -s nullglob
+          reports=(/tmp/nitro-tsan.*)
+          if [ ${#reports[@]} -gt 0 ]; then
+            cat "${reports[@]}"
+            echo "::error::ThreadSanitizer reported an error."
+            exit 1
+          fi
+
+      - name: Upload TSan reports
+        if: always() && matrix.sanitizer.name == 'TSan'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: tsan-reports-ios
+          path: /tmp/nitro-tsan.*
+          if-no-files-found: ignore


### PR DESCRIPTION
An instrumented iOS app can report a data race and continue running, so passing Harness assertions do not establish a clean TSan run. Set `SIMCTL_CHILD_TSAN_OPTIONS=halt_on_error=1:log_path=/tmp/nitro-tsan` for the TSan row, print and fail on any report files even if Harness passed, and upload the reports after failures.

Validation:
- Built and launched a deliberate C++ data race in an iOS 26.5 simulator with Apple's TSan runtime. With default options it printed the marker after the race; with `halt_on_error=1` it stopped before that marker and wrote a symbolized report.
- `simctl launch --console` returned zero in both cases, confirming the need to check report files explicitly. The exact workflow check exits 1 with the real report and 0 without reports. A clean instrumented simulator app creates no report files.
- `actionlint` and `git diff --check` pass. Full Harness CI runs on this PR.

References: [TSan runtime options](https://clang.llvm.org/docs/ThreadSanitizer.html#run-time-flags), [Harness 1.4.1 app-session handling](https://github.com/callstackincubator/react-native-harness/blob/ccba4de5f4b6d9996482c376224a0292434e5980/packages/platform-ios/src/app-session.ts#L87-L113).
