### PR TITLE
fix: Run legacy Android ASan on API 33

### DIFF
--- a/.github/workflows/harness-android.yml
+++ b/.github/workflows/harness-android.yml
@@ -8,9 +8,8 @@ on:
   workflow_dispatch:
     inputs:
       device_api_level:
-        description: "Android API level for the emulator"
+        description: "Override the Android API level for both jobs"
         required: false
-        default: "36"
         type: string
       device_profile:
         description: "Device profile"
@@ -18,9 +17,8 @@ on:
         default: "pixel_7"
         type: string
       avd_name:
-        description: "AVD name"
+        description: "Override the AVD name for both jobs"
         required: false
-        default: "Pixel_7_API_36"
         type: string
   push:
     branches:
@@ -70,11 +68,8 @@ on:
       - "apps/example/rn-harness.config.mjs"
 
 env:
-  # Device configuration - can be overridden by workflow_dispatch inputs
-  DEVICE_API_LEVEL: ${{ github.event.inputs.device_api_level || '36' }}
   DEVICE_ARCH: x86_64
   DEVICE_PROFILE: ${{ github.event.inputs.device_profile || 'pixel_7' }}
-  AVD_NAME: ${{ github.event.inputs.avd_name || 'Pixel_7_API_36' }}
   AVD_DISK_SIZE: 1G
   AVD_HEAP_SIZE: 1G
 
@@ -90,8 +85,17 @@ jobs:
         sanitizer:
           - name: Default
             gradle_property: ""
+            device_api_level: "36"
+            avd_name: Pixel_7_API_36
           - name: ASan
             gradle_property: "address"
+            # Keep legacy x86_64 ASan on the API 33 image verified in #1530.
+            # HWASan requires ARM64; this workflow uses an x86_64 emulator.
+            device_api_level: "33"
+            avd_name: Pixel_7_API_33
+    env:
+      DEVICE_API_LEVEL: ${{ github.event.inputs.device_api_level || matrix.sanitizer.device_api_level }}
+      AVD_NAME: ${{ github.event.inputs.avd_name || matrix.sanitizer.avd_name }}
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
The API 36 x86_64 ASan job has failed during app startup before running any tests. Run the ASan row on API 33, keep the Default row on API 36, and preserve manual device overrides. This extracts only the emulator configuration from #1530.

The same API 33 configuration passed both Android rows in three earlier runs: [32909241009](https://github.com/margelo/nitro/actions/runs/32909241009), [32909937474](https://github.com/margelo/nitro/actions/runs/32909937474), and [32910631876](https://github.com/margelo/nitro/actions/runs/32910631876). Those runs also contained the separate test fixes from #1530; they establish prior configuration coverage, not a guarantee that every test on this standalone PR is stable.

Android now recommends [HWASan](https://developer.android.com/ndk/guides/hwasan), which requires ARM64. The existing CI emulator is x86_64, so this keeps its legacy ASan coverage using the previously tested image. ASan remains unsupported by Android; the evidence for this image choice is the previous successful CI runs.

Validation: `actionlint` and `git diff --check` pass. The fresh [ASan Harness step passed](https://github.com/margelo/nitro/actions/runs/33967572252/job/101310281112). The unchanged Default row failed during `adb install` before executing tests; its log does not include the underlying installation error.
