### PR TITLE
test: Allow the async stress test to finish under sanitizers

### DIFF
--- a/apps/example/rn-harness.config.mjs
+++ b/apps/example/rn-harness.config.mjs
@@ -33,7 +33,8 @@ const config = {
   ],
   defaultRunner: 'android',
   resetEnvironmentBetweenTestFiles: 'runtime',
-  testTimeout: process.env.CI === 'true' ? 30000 : 10000,
+  // The async HybridObject stress test has its own 120-second deadline.
+  testTimeout: process.env.CI === 'true' ? 150000 : 10000,
   platformReadyTimeout: process.env.CI === 'true' ? 420000 : 300000,
   bridgeTimeout: process.env.CI === 'true' ? 180000 : 60000,
   bundleStartTimeout: process.env.CI === 'true' ? 120000 : 60000,

--- a/apps/example/src/getTests.ts
+++ b/apps/example/src/getTests.ts
@@ -48,6 +48,7 @@ export interface TestRunner {
 // 2) In JVM, 51_200 is the limit for `jni::global_ref`s, then the app crashes - this intentionally exhausts that
 const MEMORY_LEAK_TEST_ALLOCATION_COUNT = 55_000
 const EXTERNAL_MEMORY_TEST_SIZE = 1024 * 1024
+const PARALLEL_HYBRID_OBJECT_TEST_TIMEOUT = 120_000
 
 type HermesInternal = {
   getInstrumentedStats?: () => { js_externalBytes: number }
@@ -1549,7 +1550,7 @@ export function getTests(
               )
             }
             return true
-          })
+          }, PARALLEL_HYBRID_OBJECT_TEST_TIMEOUT)
         )
           .didNotThrow()
           .equals(true)

--- a/apps/example/src/testing/createTestRunner.ts
+++ b/apps/example/src/testing/createTestRunner.ts
@@ -32,21 +32,24 @@ function timeoutedPromise<T>(
 }
 
 export interface TestRunner {
-  it<T>(action: () => Promise<T>): Promise<State<T>>
-  it<T>(action: () => T): State<T>
+  it<T>(action: () => Promise<T>, timeout?: number): Promise<State<T>>
+  it<T>(action: () => T, timeout?: number): State<T>
 }
 
 /**
  * Creates a test runner with the provided assertion backend.
  */
 export function createTestRunner(backend: AssertionBackend): TestRunner {
-  function it<T>(action: () => Promise<T>): Promise<State<T>>
-  function it<T>(action: () => T): State<T>
-  function it<T>(action: () => T | Promise<T>): State<T> | Promise<State<T>> {
+  function it<T>(action: () => Promise<T>, timeout?: number): Promise<State<T>>
+  function it<T>(action: () => T, timeout?: number): State<T>
+  function it<T>(
+    action: () => T | Promise<T>,
+    timeout?: number
+  ): State<T> | Promise<State<T>> {
     try {
       const syncResult = action()
       if (syncResult instanceof Promise) {
-        const wrapped = timeoutedPromise<T>(syncResult)
+        const wrapped = timeoutedPromise<T>(syncResult, timeout)
         return wrapped
           .then((asyncResult) => new State<T>(asyncResult, undefined, backend))
           .catch((error) => new State<T>(undefined, error, backend))


### PR DESCRIPTION
The 20 × 32 asynchronous HybridObject stress test inherits the assertion helper's 1.5-second deadline, so it can fail before completing its intended sanitizer workload. Add an optional assertion timeout and give this test 120 seconds, preserving all 640 operations per implementation. Allow 150 seconds in CI's outer Harness timeout on both platforms; Harness 1.4.1 does not support a per-test timeout argument.

This extracts the stress-test fix from #1530 and also accounts for the iOS outer timeout. Other assertions retain the helper's existing 1.5-second default.

Validation:
- Workspace packages build; example TypeScript and targeted ESLint pass.
- A local behavioral probe against the actual helper confirms an operation taking 1.65 seconds fails with the default budget and succeeds with an explicit longer budget. A short explicit budget still rejects stalled work; synchronous assertions remain synchronous.
- Config syntax and `git diff --check` pass. Full iOS/Android Harness CI runs on this PR.
