### PR TITLE
test: Check promise concurrency without wall-clock timing

### DIFF
--- a/apps/example/src/getTests.ts
+++ b/apps/example/src/getTests.ts
@@ -1572,12 +1572,22 @@ export function getTests(
     createTest('twoPromises can run in parallel', async () =>
       (
         await it(async () => {
-          const start = performance.now()
-          // 0.5s + 0.5s = ~1s in serial, ~0.5s in parallel
-          await Promise.all([testObject.wait(0.5), testObject.wait(0.5)])
-          const end = performance.now()
-          const didRunInParallel = end - start < 1000
-          return didRunInParallel
+          let started = 0
+          let release = () => {}
+          const bothStarted = new Promise<void>((resolve) => {
+            release = resolve
+          })
+          const onStarted = () => {
+            started++
+            if (started === 2) release()
+            return bothStarted
+          }
+          // Each native operation waits until both have invoked their callback.
+          await Promise.all([
+            testObject.callCallbackThatReturnsPromiseVoid(onStarted),
+            testObject.callCallbackThatReturnsPromiseVoid(onStarted),
+          ])
+          return started === 2
         })
       )
         .didNotThrow()


### PR DESCRIPTION
The concurrency test previously required two 0.5-second native waits to finish within one second. Scheduling delays can violate that threshold in a correct sanitizer build.

Use the existing `callCallbackThatReturnsPromiseVoid` API to start two native operations. Each callback returns the same promise, which resolves only after both callbacks have started. A serialized implementation cannot complete, while a slow concurrent implementation can. No native API or generated code changes are needed.

Validation:
- Workspace packages build; example TypeScript, targeted ESLint, and `git diff --check` pass.
- A local probe executes the actual updated assertion: callbacks delayed by 1.1 seconds pass, and a serialized implementation times out. These probes validate the assertion logic; full native iOS/Android execution runs in this PR's Harness CI.
