### PR TITLE
perf: cover deferred worker promises and native-owned buffers

### DIFF
--- a/apps/benchmark/src/benchmarks/suite.ts
+++ b/apps/benchmark/src/benchmarks/suite.ts
@@ -291,6 +291,20 @@ function createObjectBenchmarks(
     createBufferBenchmark(
       object,
       implementation,
+      'bounce-native-4-kib',
+      object.copyBuffer(smallBuffer),
+      'bounce'
+    ),
+    createBufferBenchmark(
+      object,
+      implementation,
+      'bounce-native-1-mib',
+      object.copyBuffer(largeBuffer),
+      'bounce'
+    ),
+    createBufferBenchmark(
+      object,
+      implementation,
       'copy-4-kib',
       smallBuffer,
       'copy'
@@ -337,6 +351,30 @@ function createObjectBenchmarks(
           checksum += await object.promiseReturnsInstantly()
         }
         return assertNumber(checksum, 'promiseReturnsInstantly')
+      },
+    },
+    {
+      id: `${prefix}/promise/deferred-worker-with-trigger`,
+      version: 1,
+      family: 'promise',
+      implementation,
+      kind: 'async',
+      maxChunkIterations: 5_000,
+      collectNativeGarbage:
+        implementation === 'nitro-platform' && Platform.OS === 'android'
+          ? collectJavaGarbage
+          : undefined,
+      expectedChecksum: (iterations) => iterations * 55,
+      async run(iterations) {
+        let checksum = 0
+        for (let index = 0; index < iterations; index++) {
+          const promise = object.createPendingPromise()
+          // Includes the trigger call: completion cannot race ahead of the
+          // pending Promise's conversion to JS in createPendingPromise().
+          object.resolvePendingPromiseOnWorker()
+          checksum += await promise
+        }
+        return assertNumber(checksum, 'resolvePendingPromiseOnWorker')
       },
     },
   ]

--- a/packages/react-native-nitro-modules/NitroModules.podspec
+++ b/packages/react-native-nitro-modules/NitroModules.podspec
@@ -45,6 +45,7 @@ Pod::Spec.new do |s|
     "cpp/jsi/JSIHelpers.hpp",
     "cpp/platform/NitroLogger.hpp",
     "cpp/threading/Dispatcher.hpp",
+    "cpp/threading/ThreadPool.hpp",
     "cpp/utils/JSCallback.hpp",
     "cpp/utils/FastVectorCopy.hpp",
     "cpp/utils/NitroHash.hpp",

--- a/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
+++ b/packages/react-native-nitro-test/android/src/main/java/com/margelo/nitro/test/HybridTestObjectKotlin.kt
@@ -11,13 +11,22 @@ import com.margelo.nitro.core.NullType
 import com.margelo.nitro.core.Promise
 import com.margelo.nitro.core.resolved
 import com.margelo.nitro.test.external.HybridSomeExternalObjectSpec
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import java.math.BigDecimal
 import java.time.Instant
 
 @Keep
 @DoNotStrip
 class HybridTestObjectKotlin : HybridTestObjectSwiftKotlinSpec() {
+  private var pendingPromise: Promise<Double>? = null
+
+  private companion object {
+    val promiseScope = CoroutineScope(Dispatchers.Default)
+  }
+
   override var numberValue: Double = 0.0
   override var boolValue: Boolean = false
   override var stringValue: String = ""
@@ -313,6 +322,22 @@ class HybridTestObjectKotlin : HybridTestObjectSwiftKotlinSpec() {
   override fun promiseReturnsInstantlyAsync(): Promise<Double> {
     return Promise.async {
       return@async 55.0
+    }
+  }
+
+  override fun createPendingPromise(): Promise<Double> {
+    check(pendingPromise == null) { "A pending Promise is already waiting for completion." }
+    val promise = Promise<Double>()
+    pendingPromise = promise
+    return promise
+  }
+
+  override fun resolvePendingPromiseOnWorker() {
+    val promise = checkNotNull(pendingPromise) { "No pending Promise is waiting for completion." }
+    // Only JS calls access the slot; the worker owns the extracted Promise.
+    pendingPromise = null
+    promiseScope.launch {
+      promise.resolve(55.0)
     }
   }
 

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.cpp
@@ -8,6 +8,7 @@
 #include "HybridTestObjectCpp.hpp"
 #include <NitroModules/AnyMap.hpp>
 #include <NitroModules/NitroLogger.hpp>
+#include <NitroModules/ThreadPool.hpp>
 #include <chrono>
 #include <sstream>
 #include <thread>
@@ -609,6 +610,23 @@ std::shared_ptr<Promise<double>> HybridTestObjectCpp::promiseReturnsInstantly() 
 
 std::shared_ptr<Promise<double>> HybridTestObjectCpp::promiseReturnsInstantlyAsync() {
   return Promise<double>::async([=]() { return 55; });
+}
+
+std::shared_ptr<Promise<double>> HybridTestObjectCpp::createPendingPromise() {
+  if (_pendingPromise) {
+    throw std::runtime_error("A pending Promise is already waiting for completion.");
+  }
+  _pendingPromise = Promise<double>::create();
+  return _pendingPromise;
+}
+
+void HybridTestObjectCpp::resolvePendingPromiseOnWorker() {
+  if (!_pendingPromise) {
+    throw std::runtime_error("No pending Promise is waiting for completion.");
+  }
+  // Only JS calls access the slot; the worker owns the extracted Promise.
+  auto promise = std::move(_pendingPromise);
+  ThreadPool::shared().run([promise = std::move(promise)]() { promise->resolve(55); });
 }
 
 std::shared_ptr<Promise<void>> HybridTestObjectCpp::promiseThatResolvesVoidInstantly() {

--- a/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
+++ b/packages/react-native-nitro-test/cpp/HybridTestObjectCpp.hpp
@@ -45,6 +45,7 @@ private:
   std::optional<std::function<void(double)>> _optionalCallback;
   bool _hasBooleanWritable;
   bool _isBooleanWritable;
+  std::shared_ptr<Promise<double>> _pendingPromise;
 
 private:
   static inline uint64_t calculateFibonacci(int count) noexcept {
@@ -205,6 +206,8 @@ public:
   std::shared_ptr<Promise<void>> promiseThrows() override;
   std::shared_ptr<Promise<double>> promiseReturnsInstantly() override;
   std::shared_ptr<Promise<double>> promiseReturnsInstantlyAsync() override;
+  std::shared_ptr<Promise<double>> createPendingPromise() override;
+  void resolvePendingPromiseOnWorker() override;
   std::shared_ptr<Promise<void>> promiseThatResolvesVoidInstantly() override;
   std::shared_ptr<Promise<std::optional<double>>> promiseThatResolvesToUndefined() override;
   std::shared_ptr<Promise<std::optional<double>>> awaitNullablePromise() override;

--- a/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
+++ b/packages/react-native-nitro-test/ios/HybridTestObjectSwift.swift
@@ -5,10 +5,13 @@
 //  Created by Marc Rousavy on 11.08.24.
 //
 
+import Dispatch
 import NitroModules
 import NitroTestExternal
 
 class HybridTestObjectSwift: HybridTestObjectSwiftKotlinSpec {
+  private var pendingPromise: Promise<Double>?
+
   var optionalArray: [String]? = []
 
   var someVariant: Variant_Double_String = .first(55)
@@ -461,6 +464,26 @@ class HybridTestObjectSwift: HybridTestObjectSwiftKotlinSpec {
   func promiseReturnsInstantlyAsync() throws -> Promise<Double> {
     return Promise.async {
       return 55.0
+    }
+  }
+
+  func createPendingPromise() throws -> Promise<Double> {
+    guard pendingPromise == nil else {
+      throw RuntimeError.error(withMessage: "A pending Promise is already waiting for completion.")
+    }
+    let promise = Promise<Double>()
+    pendingPromise = promise
+    return promise
+  }
+
+  func resolvePendingPromiseOnWorker() throws {
+    guard let promise = pendingPromise else {
+      throw RuntimeError.error(withMessage: "No pending Promise is waiting for completion.")
+    }
+    // Only JS calls access the slot; the worker owns the extracted Promise.
+    pendingPromise = nil
+    DispatchQueue.global().async {
+      promise.resolve(withResult: 55.0)
     }
   }
 

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.cpp
@@ -1077,6 +1077,26 @@ namespace margelo::nitro::test {
       return __promise;
     }();
   }
+  std::shared_ptr<Promise<double>> JHybridTestObjectSwiftKotlinSpec::createPendingPromise() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("createPendingPromise");
+    auto __result = method(_javaPart);
+    return [&]() {
+      auto __promise = Promise<double>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<jni::JDouble>(__boxedResult);
+        __promise->resolve(__result->value());
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
+  }
+  void JHybridTestObjectSwiftKotlinSpec::resolvePendingPromiseOnWorker() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void()>("resolvePendingPromiseOnWorker");
+    method(_javaPart);
+  }
   std::shared_ptr<Promise<void>> JHybridTestObjectSwiftKotlinSpec::promiseThatResolvesVoidInstantly() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("promiseThatResolvesVoidInstantly");
     auto __result = method(_javaPart);

--- a/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/c++/JHybridTestObjectSwiftKotlinSpec.hpp
@@ -142,6 +142,8 @@ namespace margelo::nitro::test {
     std::shared_ptr<Promise<void>> promiseThrows() override;
     std::shared_ptr<Promise<double>> promiseReturnsInstantly() override;
     std::shared_ptr<Promise<double>> promiseReturnsInstantlyAsync() override;
+    std::shared_ptr<Promise<double>> createPendingPromise() override;
+    void resolvePendingPromiseOnWorker() override;
     std::shared_ptr<Promise<void>> promiseThatResolvesVoidInstantly() override;
     std::shared_ptr<Promise<std::optional<double>>> promiseThatResolvesToUndefined() override;
     std::shared_ptr<Promise<std::optional<double>>> awaitNullablePromise() override;

--- a/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec.kt
+++ b/packages/react-native-nitro-test/nitrogen/generated/android/kotlin/com/margelo/nitro/test/HybridTestObjectSwiftKotlinSpec.kt
@@ -380,6 +380,14 @@ abstract class HybridTestObjectSwiftKotlinSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  abstract fun createPendingPromise(): Promise<Double>
+  
+  @DoNotStrip
+  @Keep
+  abstract fun resolvePendingPromiseOnWorker(): Unit
+  
+  @DoNotStrip
+  @Keep
   abstract fun promiseThatResolvesVoidInstantly(): Promise<Unit>
   
   @DoNotStrip

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/c++/HybridTestObjectSwiftKotlinSpecSwift.hpp
@@ -664,6 +664,20 @@ namespace margelo::nitro::test {
       auto __value = std::move(__result.value());
       return __value;
     }
+    inline std::shared_ptr<Promise<double>> createPendingPromise() override {
+      auto __result = _swiftPart.createPendingPromise();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline void resolvePendingPromiseOnWorker() override {
+      auto __result = _swiftPart.resolvePendingPromiseOnWorker();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+    }
     inline std::shared_ptr<Promise<void>> promiseThatResolvesVoidInstantly() override {
       auto __result = _swiftPart.promiseThatResolvesVoidInstantly();
       if (__result.hasError()) [[unlikely]] {

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec.swift
@@ -84,6 +84,8 @@ public protocol HybridTestObjectSwiftKotlinSpec_protocol: HybridObject {
   func promiseThrows() throws -> Promise<Void>
   func promiseReturnsInstantly() throws -> Promise<Double>
   func promiseReturnsInstantlyAsync() throws -> Promise<Double>
+  func createPendingPromise() throws -> Promise<Double>
+  func resolvePendingPromiseOnWorker() throws -> Void
   func promiseThatResolvesVoidInstantly() throws -> Promise<Void>
   func promiseThatResolvesToUndefined() throws -> Promise<Double?>
   func awaitNullablePromise() throws -> Promise<Double?>

--- a/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
+++ b/packages/react-native-nitro-test/nitrogen/generated/ios/swift/HybridTestObjectSwiftKotlinSpec_cxx.swift
@@ -1565,6 +1565,36 @@ open class HybridTestObjectSwiftKotlinSpec_cxx {
   }
   
   @inline(__always)
+  public final func createPendingPromise() -> bridge.Result_std__shared_ptr_Promise_double___ {
+    do {
+      let __result = try self.__implementation.createPendingPromise()
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_double__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_double__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_double__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve(__result) })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_double___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_double___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func resolvePendingPromiseOnWorker() -> bridge.Result_void_ {
+    do {
+      try self.__implementation.resolvePendingPromiseOnWorker()
+      return bridge.create_Result_void_()
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_void_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public final func promiseThatResolvesVoidInstantly() -> bridge.Result_std__shared_ptr_Promise_void___ {
     do {
       let __result = try self.__implementation.promiseThatResolvesVoidInstantly()

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.cpp
@@ -111,6 +111,8 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("promiseThrows", &HybridTestObjectCppSpec::promiseThrows);
       prototype.registerHybridMethod("promiseReturnsInstantly", &HybridTestObjectCppSpec::promiseReturnsInstantly);
       prototype.registerHybridMethod("promiseReturnsInstantlyAsync", &HybridTestObjectCppSpec::promiseReturnsInstantlyAsync);
+      prototype.registerHybridMethod("createPendingPromise", &HybridTestObjectCppSpec::createPendingPromise);
+      prototype.registerHybridMethod("resolvePendingPromiseOnWorker", &HybridTestObjectCppSpec::resolvePendingPromiseOnWorker);
       prototype.registerHybridMethod("promiseThatResolvesVoidInstantly", &HybridTestObjectCppSpec::promiseThatResolvesVoidInstantly);
       prototype.registerHybridMethod("promiseThatResolvesToUndefined", &HybridTestObjectCppSpec::promiseThatResolvesToUndefined);
       prototype.registerHybridMethod("awaitNullablePromise", &HybridTestObjectCppSpec::awaitNullablePromise);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectCppSpec.hpp
@@ -220,6 +220,8 @@ namespace margelo::nitro::test {
       virtual std::shared_ptr<Promise<void>> promiseThrows() = 0;
       virtual std::shared_ptr<Promise<double>> promiseReturnsInstantly() = 0;
       virtual std::shared_ptr<Promise<double>> promiseReturnsInstantlyAsync() = 0;
+      virtual std::shared_ptr<Promise<double>> createPendingPromise() = 0;
+      virtual void resolvePendingPromiseOnWorker() = 0;
       virtual std::shared_ptr<Promise<void>> promiseThatResolvesVoidInstantly() = 0;
       virtual std::shared_ptr<Promise<std::optional<double>>> promiseThatResolvesToUndefined() = 0;
       virtual std::shared_ptr<Promise<std::optional<double>>> awaitNullablePromise() = 0;

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.cpp
@@ -103,6 +103,8 @@ namespace margelo::nitro::test {
       prototype.registerHybridMethod("promiseThrows", &HybridTestObjectSwiftKotlinSpec::promiseThrows);
       prototype.registerHybridMethod("promiseReturnsInstantly", &HybridTestObjectSwiftKotlinSpec::promiseReturnsInstantly);
       prototype.registerHybridMethod("promiseReturnsInstantlyAsync", &HybridTestObjectSwiftKotlinSpec::promiseReturnsInstantlyAsync);
+      prototype.registerHybridMethod("createPendingPromise", &HybridTestObjectSwiftKotlinSpec::createPendingPromise);
+      prototype.registerHybridMethod("resolvePendingPromiseOnWorker", &HybridTestObjectSwiftKotlinSpec::resolvePendingPromiseOnWorker);
       prototype.registerHybridMethod("promiseThatResolvesVoidInstantly", &HybridTestObjectSwiftKotlinSpec::promiseThatResolvesVoidInstantly);
       prototype.registerHybridMethod("promiseThatResolvesToUndefined", &HybridTestObjectSwiftKotlinSpec::promiseThatResolvesToUndefined);
       prototype.registerHybridMethod("awaitNullablePromise", &HybridTestObjectSwiftKotlinSpec::awaitNullablePromise);

--- a/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
+++ b/packages/react-native-nitro-test/nitrogen/generated/shared/c++/HybridTestObjectSwiftKotlinSpec.hpp
@@ -207,6 +207,8 @@ namespace margelo::nitro::test {
       virtual std::shared_ptr<Promise<void>> promiseThrows() = 0;
       virtual std::shared_ptr<Promise<double>> promiseReturnsInstantly() = 0;
       virtual std::shared_ptr<Promise<double>> promiseReturnsInstantlyAsync() = 0;
+      virtual std::shared_ptr<Promise<double>> createPendingPromise() = 0;
+      virtual void resolvePendingPromiseOnWorker() = 0;
       virtual std::shared_ptr<Promise<void>> promiseThatResolvesVoidInstantly() = 0;
       virtual std::shared_ptr<Promise<std::optional<double>>> promiseThatResolvesToUndefined() = 0;
       virtual std::shared_ptr<Promise<std::optional<double>>> awaitNullablePromise() = 0;

--- a/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
+++ b/packages/react-native-nitro-test/src/specs/TestObject.nitro.ts
@@ -246,6 +246,10 @@ interface SharedTestObjectProps {
   promiseThrows(): Promise<void>
   promiseReturnsInstantly(): Promise<number>
   promiseReturnsInstantlyAsync(): Promise<number>
+  // Stays pending until the separate JS call schedules its native completion.
+  // Only one Promise may be waiting for that trigger on each TestObject.
+  createPendingPromise(): Promise<number>
+  resolvePendingPromiseOnWorker(): void
   promiseThatResolvesVoidInstantly(): Promise<void>
   promiseThatResolvesToUndefined(): Promise<number | undefined>
   awaitNullablePromise(): Promise<number | undefined>

--- a/scripts/performance/report-markdown.ts
+++ b/scripts/performance/report-markdown.ts
@@ -9,6 +9,10 @@ const OPERATION_NAMES: Readonly<Record<string, string>> = {
   'ascii-short': 'short ASCII string',
   'bounce-1-mib': 'bounce(1 MiB)',
   'bounce-4-kib': 'bounce(4 KiB)',
+  'bounce-native-4-kib': 'bounce native-owned buffer (4 KiB)',
+  'bounce-native-1-mib': 'bounce native-owned buffer (1 MiB)',
+  'deferred-worker-with-trigger':
+    'deferred worker Promise (includes trigger call)',
   'copy-1-mib': 'copy(1 MiB)',
   'copy-4-kib': 'copy(4 KiB)',
   'create': 'create()',


### PR DESCRIPTION
Adds a native-owned ArrayBuffer bounce at 4 KiB and 1 MiB, plus a deferred Promise roundtrip that is guaranteed pending when returned to JavaScript. JavaScript explicitly triggers worker completion after receiving the Promise; the benchmark name includes that trigger-call cost. The fixture reuses existing worker facilities and keeps one operation in flight. Immediate completion remains covered.

Stacked on #1605. Generated Nitro bindings are checked in. No lifecycle/GC workload or Harness changes are included.

Validation: full Android x86_64 Release app build; actual Swift NitroTest module/header emission, C++ implementation and Swift adapter compilation, Kotlin implementation/generated-spec compilation, TypeScript checks and targeted lint/format checks. A bounded actual iOS Release/Hermes smoke passed C++ and Swift deferred-worker Promise and native-owned buffer bounce cases. Each used distinct calibration/measurement process IDs and completed 20 samples with exactly the calibrated iteration/chunk counts. These establish functional and timing sanity, not CI stability or performance improvements. CI runs are intentionally cancelled immediately after creation to conserve Actions minutes, as requested.
