### PR TITLE
fix(ci): upload example assets only for releases

### DIFF
--- a/.github/workflows/build-android-release.yml
+++ b/.github/workflows/build-android-release.yml
@@ -11,6 +11,8 @@ jobs:
   build_release:
     name: Build Android Example App (release, new architecture)
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
@@ -34,14 +36,14 @@ jobs:
           ./gradlew clean :app:assembleRelease --no-daemon --no-build-cache
 
       - name: Upload APK to Release
-        uses: actions/upload-release-asset@v1
+        if: github.event_name == 'release'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: apps/example/android/app/build/outputs/apk/release/app-release.apk
-          asset_name: "NitroExample-${{ github.event.release.tag_name }}.apk"
-          asset_content_type: application/vnd.android.package-archive
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          ASSET_NAME="NitroExample-${RELEASE_TAG}.apk"
+          mv apps/example/android/app/build/outputs/apk/release/app-release.apk "$ASSET_NAME"
+          gh release upload "$RELEASE_TAG" "$ASSET_NAME" --repo "$GITHUB_REPOSITORY"
 
       # Gradle cache doesn't like daemons
       - name: Stop Gradle Daemon

--- a/.github/workflows/build-ios-release.yml
+++ b/.github/workflows/build-ios-release.yml
@@ -11,6 +11,8 @@ jobs:
   build_release:
     name: Build iOS Example App (release, new architecture)
     runs-on: macos-26
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
@@ -54,11 +56,11 @@ jobs:
           zip -r "$GITHUB_WORKSPACE/NitroExample-Release-Simulator.zip" NitroExample.app
 
       - name: Upload .app to Release
-        uses: actions/upload-release-asset@v1
+        if: github.event_name == 'release'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: NitroExample-Release-Simulator.zip
-          asset_name: "NitroExample-Simulator-${{ github.event.release.tag_name }}.app.zip"
-          asset_content_type: application/zip
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          ASSET_NAME="NitroExample-Simulator-${RELEASE_TAG}.app.zip"
+          mv NitroExample-Release-Simulator.zip "$ASSET_NAME"
+          gh release upload "$RELEASE_TAG" "$ASSET_NAME" --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
The example Release workflows currently build successfully on pull requests, then try to upload a release asset without a release upload URL. Restrict asset uploads to published release events and use the GitHub CLI in place of the unmaintained upload action. Published releases keep the same asset names; pull requests still exercise the builds and packaging.

Validated both workflows with actionlint and executed the exact upload scripts against temporary APK/ZIP fixtures with a stubbed GitHub CLI, checking renamed assets and arguments. No release was published. CI runs for this draft are intentionally cancelled to conserve Actions minutes.
