### PR TITLE
ci: preserve Xcode compiler discovery with ccache launchers

### DIFF
--- a/.github/workflows/build-ios-release.yml
+++ b/.github/workflows/build-ios-release.yml
@@ -38,7 +38,6 @@ jobs:
         run: |
           set -o pipefail
           xcodebuild \
-            CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ \
             -derivedDataPath build -UseModernBuildSystem=YES \
             -workspace NitroExample.xcworkspace \
             -scheme NitroExample \

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -37,9 +37,8 @@ on:
       - '**/nitro.json'
 
 env:
-  USE_CCACHE: 1
   XCODE_VERSION: '26.5'
-  IOS_SIMULATOR_DESTINATION: 'platform=iOS Simulator,arch=arm64,name=iPhone 17 Pro'
+  IOS_SIMULATOR_DESTINATION: 'generic/platform=iOS Simulator'
 
 jobs:
   build:
@@ -58,7 +57,7 @@ jobs:
 
       - name: Set USE_FRAMEWORKS
         if: matrix.use_frameworks != ''
-        run: echo "USE_FRAMEWORKS=${{ matrix.use_frameworks }}" >> $GITHUB_ENV
+        run: echo "USE_FRAMEWORKS=${{ matrix.use_frameworks }}" >> "$GITHUB_ENV"
 
       - name: Install npm dependencies (bun)
         run: bun install
@@ -68,13 +67,14 @@ jobs:
         with:
           max-size: 1.5G
           key: ${{ runner.os }}-${{ runner.arch }}-xcode${{ env.XCODE_VERSION }}-${{ matrix.use_frameworks }}-ccache-example-ios
-          create-symlink: true
       - name: Setup ccache behavior
         run: |
-          echo "CCACHE_SLOPPINESS=clang_index_store,file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,pch_defines,modules,system_headers,time_macros" >> $GITHUB_ENV
-          echo "CCACHE_FILECLONE=true" >> $GITHUB_ENV
-          echo "CCACHE_DEPEND=true" >> $GITHUB_ENV
-          echo "CCACHE_INODECACHE=true" >> $GITHUB_ENV
+          {
+            echo "CCACHE_SLOPPINESS=clang_index_store,file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,pch_defines,modules,system_headers,time_macros"
+            echo "CCACHE_FILECLONE=true"
+            echo "CCACHE_DEPEND=true"
+            echo "CCACHE_INODECACHE=true"
+          } >> "$GITHUB_ENV"
 
       - name: Setup Ruby (bundle)
         uses: ruby/setup-ruby@v1
@@ -110,7 +110,8 @@ jobs:
         run: |
           set -o pipefail
           xcodebuild \
-            CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ \
+            C_COMPILER_LAUNCHER="$(command -v ccache)" \
+            CLANG_ENABLE_EXPLICIT_MODULES_WITH_COMPILER_LAUNCHER=YES \
             -derivedDataPath build -UseModernBuildSystem=YES \
             -workspace NitroExample.xcworkspace \
             -scheme NitroExample \
@@ -119,5 +120,6 @@ jobs:
             -destination '${{ env.IOS_SIMULATOR_DESTINATION }}' \
             -showBuildTimingSummary \
             ONLY_ACTIVE_ARCH=YES \
+            ARCHS=arm64 \
             build \
             CODE_SIGNING_ALLOWED=NO | xcbeautify --renderer github-actions

--- a/.github/workflows/harness-ios.yml
+++ b/.github/workflows/harness-ios.yml
@@ -78,7 +78,6 @@ env:
   DEVICE_MODEL: ${{ github.event.inputs.device_model || 'iPhone 17 Pro' }}
   IOS_VERSION: ${{ github.event.inputs.ios_version || '26.5' }}
   XCODE_VERSION: ${{ github.event.inputs.xcode_version || '26.5' }}
-  USE_CCACHE: 1
   DEVELOPER_DIR: /Applications/Xcode_${{ github.event.inputs.xcode_version || '26.5' }}.app/Contents/Developer
   HARNESS_DEBUG: 1
 
@@ -111,13 +110,14 @@ jobs:
         with:
           max-size: 1.5G
           key: ${{ runner.os }}-${{ runner.arch }}-xcode${{ env.XCODE_VERSION }}-${{ matrix.sanitizer.name }}-ccache-example-ios
-          create-symlink: true
       - name: Setup ccache behavior
         run: |
-          echo "CCACHE_SLOPPINESS=clang_index_store,file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,pch_defines,modules,system_headers,time_macros" >> $GITHUB_ENV
-          echo "CCACHE_FILECLONE=true" >> $GITHUB_ENV
-          echo "CCACHE_DEPEND=true" >> $GITHUB_ENV
-          echo "CCACHE_INODECACHE=true" >> $GITHUB_ENV
+          {
+            echo "CCACHE_SLOPPINESS=clang_index_store,file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,pch_defines,modules,system_headers,time_macros"
+            echo "CCACHE_FILECLONE=true"
+            echo "CCACHE_DEPEND=true"
+            echo "CCACHE_INODECACHE=true"
+          } >> "$GITHUB_ENV"
 
       - name: Setup Ruby (bundle)
         uses: ruby/setup-ruby@v1
@@ -152,11 +152,10 @@ jobs:
         working-directory: apps/example/ios
         run: |
           set -o pipefail
-          CLANG="$(xcrun -f clang)"
-          CLANGXX="$(xcrun -f clang++)"
           SANITIZER_FLAGS="${{ matrix.sanitizer.xcodebuild_flags }}"
           xcodebuild \
-            CC="${CLANG}" CPLUSPLUS="${CLANGXX}" LD="${CLANG}" LDPLUSPLUS="${CLANGXX}" \
+            C_COMPILER_LAUNCHER="$(command -v ccache)" \
+            CLANG_ENABLE_EXPLICIT_MODULES_WITH_COMPILER_LAUNCHER=YES \
             -derivedDataPath build -UseModernBuildSystem=YES \
             -workspace NitroExample.xcworkspace \
             -scheme NitroExample \

--- a/apps/benchmark/ios/NitroBenchmark.xcodeproj/project.pbxproj
+++ b/apps/benchmark/ios/NitroBenchmark.xcodeproj/project.pbxproj
@@ -287,7 +287,6 @@
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
-					"-lc++",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.margelo.nitrobenchmark;
 				PRODUCT_NAME = NitroBenchmark;
@@ -326,7 +325,6 @@
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
-					"-lc++",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.margelo.nitrobenchmark;
 				PRODUCT_NAME = NitroBenchmark;
@@ -398,7 +396,6 @@
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"\"$(SDKROOT)/usr/lib/swift\"",
-					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -473,7 +470,6 @@
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"\"$(SDKROOT)/usr/lib/swift\"",
-					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -15,7 +15,7 @@
     "pods": "cd ios && bundle exec pod install",
     "build:android": "cd android && ./gradlew assembleDebug --no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a",
     "build:android-release": "cd android && ./gradlew assembleRelease --no-daemon",
-    "build:ios": "cd ios && xcodebuild -workspace NitroExample.xcworkspace -scheme NitroExample -configuration Debug -sdk iphonesimulator CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO",
+    "build:ios": "cd ios && xcodebuild -workspace NitroExample.xcworkspace -scheme NitroExample -configuration Debug -sdk iphonesimulator GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO",
     "test:harness": "react-native-harness"
   },
   "dependencies": {

--- a/scripts/performance/build-ios.sh
+++ b/scripts/performance/build-ios.sh
@@ -7,7 +7,6 @@ bundle install
 bun pods
 cd ios
 xcodebuild \
-  CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ \
   -derivedDataPath build-benchmark \
   -workspace NitroBenchmark.xcworkspace \
   -scheme NitroBenchmark \


### PR DESCRIPTION
Xcode could not discover `libclang.dylib` when the iOS builds replaced its compiler with bare `clang` names. Use Xcode's compiler defaults across the example, Release, Harness, and benchmark builds. The example and Harness workflows use `C_COMPILER_LAUNCHER` for ccache and enable its Clang explicit-module opt-in, following [Apple's compiler launcher guidance](https://developer.apple.com/documentation/xcode/build-settings-reference).

Remove ccache compiler symlinks and React Native's compiler/linker wrapper injection together, preserving the real-compiler discovery required by ASan in [#1417](https://github.com/margelo/nitro/pull/1417). Use a generic arm64 simulator destination for the build-only example job, remove the matching local example compiler overrides, and remove redundant benchmark libc++ and Swift toolchain search entries.

Validation for `7ed9557c5fd8a366ec9c9412bbf035c3396435bf`, rebased onto `main` at `576a7bc8c70490d580ef458dcd05f5fda88c325b`:
- Actionlint, ShellCheck, shell syntax, Xcode project syntax, package JSON parsing, and diff checks pass.
- Hosted Xcode 26.5 [Debug builds with and without static frameworks](https://github.com/margelo/nitro/actions/runs/34151299570) and the [Release build](https://github.com/margelo/nitro/actions/runs/34151299610) pass. Main includes #1607's public-header fix for the previous missing `ThreadPool.hpp` failure. The fresh Debug workflow passed on its second attempt after an initial Bun dependency-tarball extraction failure before compilation.
- [iOS Harness Default, ASan and TSan](https://github.com/margelo/nitro/actions/runs/34151299575) each pass all 552 tests, including the final TSan report check. [Android Default and ASan](https://github.com/margelo/nitro/actions/runs/34151299642), TypeScript, Nitrogen on Ubuntu/Windows, and init checks also pass.
- [Performance builds and measurements](https://github.com/margelo/nitro/actions/runs/34151299577) and [trusted publishing](https://github.com/margelo/nitro/actions/runs/34152150908) pass for this exact revision.
- The benchmark build logs show 28 dependency scans and 74 module precompilations across the two apps, without compiler/libclang fallback messages. The Harness builds restore cached Pods and DerivedData and successfully use the compiler launcher without discovery or launcher fallback warnings.

These checks verify compiler discovery and compatibility. They do not establish a controlled build-time or runtime speedup: the fresh launcher builds recorded 158 cacheable calls each with zero hits, and runtime measurements remain variable. The performance workflow also uses the head build script for both revisions, so its before/after table cannot isolate the compiler-script change.

CocoaPods may still generate an obsolete Swift toolchain search path; that warning is outside the checked-in project settings.
