### PR TITLE
perf: compare each benchmark in adjacent app processes

### DIFF
--- a/.github/PERFORMANCE.md
+++ b/.github/PERFORMANCE.md
@@ -1,8 +1,10 @@
 # Release performance CI
 
 `Nitro Performance` builds the dedicated `apps/benchmark` Release/Hermes app.
-Each platform runs base → head → head → base on the same machine, reversing case
-order for the second pair. Each case gets a fresh app process; installation,
+Each platform installs base and head side by side on the same machine. For each
+benchmark it calibrates base in a discarded process, measures base, then measures
+head immediately, before moving to the next benchmark. There is one AB pair,
+with five warmup batches and twenty measured batches per process. Each case gets a fresh app process; installation,
 startup, transport and process restarts are outside timing. There is no automatic
 third pair. Manual reruns are retained as identifiable workflow attempts.
 
@@ -22,14 +24,15 @@ tail latency. The report shows every observed change of at least 5%, including
 Promise cases. This is a presentation threshold, not a calibrated regression
 budget. Expand the report for all metrics, individual process medians, matched
 pair changes, and sample MAD relative to p50. Matching pooled medians do not prove
-equal performance. Two process pairs do not justify confidence intervals.
+equal performance. One pair cannot establish repeatability between launches or justify confidence
+intervals. Repeat measurement jobs or same-revision runs to investigate variation.
 
 Performance is currently report-only. Build, execution and malformed-result
 failures still fail CI. Turning observed differences into a regression gate needs
 empirical validation on unchanged commits and intentional slowdowns on each
 unchanged suite/testbed. No Promise case is permanently exempt. Scheduled/manual
 runs with the same base and head SHA measure baseline variation explicitly.
-Changed benchmark definitions run two head-only measurements as a new baseline,
+Changed benchmark definitions run one head-only measurement per case as a new baseline,
 without executing the old base app or publishing an invented paired baseline.
 This also handles the first rollout of a new runner protocol.
 
@@ -40,6 +43,9 @@ collection. Each measurement job downloads the immutable app artifact ID produce
 by its build job; base and head still run together on one machine. A changed suite
 builds only head. An identical base/head SHA reuses the same binary for both sides.
 Otherwise each revision is built from its own checkout with the same build script.
+Base uses `com.margelo.nitrobenchmark`; head uses `com.margelo.nitrobenchmark.head`.
+Android keeps its Java namespace and fully qualified activity name unchanged.
+For identical SHAs, both roles launch the single installed head binary.
 
 Use GitHub's **Re-run job and dependent jobs** on `measure-android` or
 `measure-ios` to repeat measurements without rebuilding successful ancestors.
@@ -52,8 +58,10 @@ The app artifact includes base/head SHAs, suite hashes, Release configuration,
 architecture and toolchain metadata. iOS apps are tar archives to preserve
 permissions and symlinks. Gradle's basic cache is the sole Android cache owner;
 Gradle still checks source/task inputs, while exact app reuse is by artifact ID.
-There is no new iOS compiler cache. First-run speed or CI stability improvements
-have not been measured; app reuse specifically avoids build work on manual reruns.
+There is no new iOS compiler cache. App reuse avoids build work on manual reruns. With 46 cases, a comparable suite
+uses 138 fresh processes (46 calibration + 46 base + 46 head), down from 230.
+Closer comparisons reduce time separation, but fixed base-first order can still
+introduce bias; same-revision runs are needed to assess that on each testbed.
 
 ## Artifacts and publishing
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -130,7 +130,7 @@ jobs:
             --platform android --base-root base --head-root head \
             --architecture x86_64 --toolchain "$(java -version 2>&1 | head -1) / NDK 29.0.14206865" \
             --output apps/build.json
-          bash head/scripts/performance/build-android.sh "$GITHUB_WORKSPACE/head"
+          bash head/scripts/performance/build-android.sh "$GITHUB_WORKSPACE/head" com.margelo.nitrobenchmark.head
           cp head/apps/benchmark/android/app/build/outputs/apk/release/app-release.apk apps/head.apk
           if [[ "$(jq -r .baseSha apps/build.json)" == "$(jq -r .headSha apps/build.json)" ]]; then
             cp apps/head.apk apps/base.apk
@@ -260,7 +260,7 @@ jobs:
             --platform ios --base-root base --head-root head \
             --architecture arm64 --toolchain "$(xcodebuild -version | tr '\n' ' ')" \
             --output apps/build.json
-          bash head/scripts/performance/build-ios.sh "$GITHUB_WORKSPACE/head"
+          bash head/scripts/performance/build-ios.sh "$GITHUB_WORKSPACE/head" com.margelo.nitrobenchmark.head
           # Tar preserves the executable bits and symlinks inside each .app.
           tar -czf apps/head.app.tar.gz -C head/apps/benchmark/ios/build-benchmark/Build/Products/Release-iphonesimulator NitroBenchmark.app
           if [[ "$(jq -r .baseSha apps/build.json)" == "$(jq -r .headSha apps/build.json)" ]]; then

--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -14,8 +14,8 @@ Debug benchmark or publish anything to Bencher.
 From the repository root:
 
 ```sh
-bash scripts/performance/build-android.sh "$PWD"
-bash scripts/performance/build-ios.sh "$PWD"
+bash scripts/performance/build-android.sh "$PWD" com.margelo.nitrobenchmark.head
+bash scripts/performance/build-ios.sh "$PWD" com.margelo.nitrobenchmark.head
 ```
 
 Both platforms use the normal `Release` configuration, an embedded optimized
@@ -25,18 +25,20 @@ permits cleartext only to `127.0.0.1` and `localhost` for the host receiver.
 
 ## Run locally
 
-For an already booted Android API 36 emulator, after building the APK:
+For an already booted Android API 36 emulator, compare two fresh launches of the
+same built APK to check measurement variation:
 
 ```sh
-bun scripts/performance/run-device.ts \
+bun scripts/performance/run-sequence.ts \
   --platform android \
-  --app apps/benchmark/android/app/build/outputs/apk/release/app-release.apk \
-  --output /tmp/nitro-benchmark.json \
+  --base-app apps/benchmark/android/app/build/outputs/apk/release/app-release.apk \
+  --head-app apps/benchmark/android/app/build/outputs/apk/release/app-release.apk \
+  --base-root "$PWD" \
+  --head-root "$PWD" \
+  --output-directory /tmp/nitro-benchmark \
   --device-id "$(adb get-serialno)" \
-  --run-id android-local-1 \
-  --reverse false \
-  --commit-sha "$(git rev-parse HEAD)" \
-  --suite-hash "$(bun scripts/performance/suite-hash.ts .)" \
+  --base-sha "$(git rev-parse HEAD)" \
+  --head-sha "$(git rev-parse HEAD)" \
   --device 'Local emulator' \
   --os-version 'Android 16 / API 36' \
   --architecture x86_64 \
@@ -49,10 +51,15 @@ The host installs each binary once, then launches a fresh process for each case
 and assembles their results. This releases Nitro's runtime-scoped JSI reference
 bookkeeping between cases; GC alone cannot clear that cache. Each process posts
 one result only after its timing is complete. Per-case raw results are kept beside
-the combined output in a `*-cases/` directory. Reversing the suite reverses the
-case launch order too. Startup, transport, and process restarts are not timed.
+the combined output in `base-1-cases/`, `head-1-cases/`, and
+`calibration-base-cases/` directories. For each case, calibration exits before
+base and head run back to back. Identical SHAs reuse one installed binary. Startup, transport, and process restarts are not timed.
 For iOS, use `--platform ios`, a simulator UDID for `--device-id`, and the built
-`NitroBenchmark.app` for `--app`, with matching simulator/toolchain metadata.
+`NitroBenchmark.app` for `--base-app` and `--head-app`, with matching
+simulator/toolchain metadata.
+To compare different revisions, build base from its own checkout using the default
+app ID (omit the second build-script argument), and build head with the `.head`
+ID shown above. Pass the corresponding app paths, source roots, and commit SHAs.
 Local runs do not upload results.
 
 Each metric targets 150 ms of timed work per sample (roughly

--- a/apps/benchmark/android/app/build.gradle
+++ b/apps/benchmark/android/app/build.gradle
@@ -83,7 +83,7 @@ android {
 
     namespace = "com.margelo.nitrobenchmark"
     defaultConfig {
-        applicationId "com.margelo.nitrobenchmark"
+        applicationId = providers.gradleProperty("nitroBenchmarkApplicationId").getOrElse("com.margelo.nitrobenchmark")
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/scripts/performance/build-android.sh
+++ b/scripts/performance/build-android.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
-cd "${1:?Usage: build-android.sh <checkout-root>}"
+cd "${1:?Usage: build-android.sh <checkout-root> [application-id]}"
 # Keep both revisions on the NDK version recorded by this CI testbed.
 grep -Fq 'ndkVersion = "29.0.14206865"' apps/benchmark/android/build.gradle
 bun install --frozen-lockfile
 cd apps/benchmark/android
-./gradlew :app:assembleRelease --no-daemon --build-cache -PreactNativeArchitectures=x86_64
+./gradlew :app:assembleRelease --no-daemon --build-cache -PreactNativeArchitectures=x86_64 \
+  "-PnitroBenchmarkApplicationId=${2:-com.margelo.nitrobenchmark}"

--- a/scripts/performance/build-artifacts.test.ts
+++ b/scripts/performance/build-artifacts.test.ts
@@ -51,7 +51,7 @@ for (const platform of ['android', 'ios'] as const) {
           script,
           `#!/bin/bash
 set -eu
-echo "$(basename "$1")" >> "$GITHUB_WORKSPACE/builds"
+echo "$(basename "$1") \${2:-com.margelo.nitrobenchmark}" >> "$GITHUB_WORKSPACE/builds"
 if [[ '${platform}' == android ]]; then
   mkdir -p "$1/apps/benchmark/android/app/build/outputs/apk/release"
   echo "$(basename "$1")" > "$1/apps/benchmark/android/app/build/outputs/apk/release/app-release.apk"
@@ -93,7 +93,14 @@ fi
         })
         expect(
           (await Bun.file(path.join(root, 'builds')).text()).trim().split('\n')
-        ).toEqual(mode === 'paired' ? ['head', 'base'] : ['head'])
+        ).toEqual(
+          mode === 'paired'
+            ? [
+                'head com.margelo.nitrobenchmark.head',
+                'base com.margelo.nitrobenchmark',
+              ]
+            : ['head com.margelo.nitrobenchmark.head']
+        )
         const base = path.join(
           root,
           `apps/base.${platform === 'ios' ? 'app.tar.gz' : 'apk'}`

--- a/scripts/performance/build-ios.sh
+++ b/scripts/performance/build-ios.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-cd "${1:?Usage: build-ios.sh <checkout-root>}"
+cd "${1:?Usage: build-ios.sh <checkout-root> [application-id]}"
 bun install --frozen-lockfile
 cd apps/benchmark
 bundle install
@@ -14,6 +14,7 @@ xcodebuild \
   -configuration Release \
   -sdk iphonesimulator \
   -destination 'generic/platform=iOS Simulator' \
+  "PRODUCT_BUNDLE_IDENTIFIER=${2:-com.margelo.nitrobenchmark}" \
   ARCHS=arm64 \
   ONLY_ACTIVE_ARCH=YES \
   CODE_SIGNING_ALLOWED=NO \

--- a/scripts/performance/isolated-cases.test.ts
+++ b/scripts/performance/isolated-cases.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import type { BenchmarkRunResult } from '../../apps/benchmark/src/benchmarks/types'
-import { runIsolatedCases } from './isolated-cases'
+import { combineIsolatedCases } from './isolated-cases'
 
 function result(index: number): BenchmarkRunResult {
   return {
@@ -44,13 +44,8 @@ function result(index: number): BenchmarkRunResult {
 }
 
 describe('fresh-process benchmark cases', () => {
-  test('assembles every case in order without changing samples or revision metadata', async () => {
-    const calls: number[] = []
-    const combined = await runIsolatedCases(async (index) => {
-      calls.push(index)
-      return result(index)
-    })
-    expect(calls).toEqual([0, 1, 2])
+  test('assembles every case in order without changing samples or revision metadata', () => {
+    const combined = combineIsolatedCases([0, 1, 2].map(result))
     expect(combined.metrics.map((m) => m.id)).toEqual(
       [0, 1, 2].map((i) => result(i).metrics[0]!.id)
     )
@@ -61,19 +56,14 @@ describe('fresh-process benchmark cases', () => {
     expect(combined.durationMs).toBe(300)
   })
 
-  test('stops immediately on a missing process result', async () => {
-    const calls: number[] = []
-    await expect(
-      runIsolatedCases(async (index) => {
-        calls.push(index)
-        if (index === 1) throw new Error('app timed out')
-        return result(index)
-      })
-    ).rejects.toThrow('app timed out')
-    expect(calls).toEqual([0, 1])
+  test('rejects incomplete suites', () => {
+    expect(() => combineIsolatedCases([])).toThrow()
+    expect(() => combineIsolatedCases([result(0), result(1)])).toThrow(
+      'Incomplete'
+    )
   })
 
-  test('rejects duplicate cases, wrong revisions, changed settings, and wrong indices', async () => {
+  test('rejects duplicate cases, wrong revisions, changed settings, and wrong indices', () => {
     const changes: ((r: BenchmarkRunResult) => void)[] = [
       (r) => {
         r.metrics[0]!.id = result(0).metrics[0]!.id
@@ -95,27 +85,20 @@ describe('fresh-process benchmark cases', () => {
       },
     ]
     for (const change of changes) {
-      await expect(
-        runIsolatedCases(async (index) => {
-          const r = result(index)
-          if (index === 1) change(r)
-          return r
-        })
-      ).rejects.toThrow()
+      const runs = [0, 1, 2].map(result)
+      change(runs[1]!)
+      expect(() => combineIsolatedCases(runs)).toThrow()
     }
   })
 
-  test('rejects an unbounded suite or a non-isolated first result before launching more', async () => {
+  test('rejects an unbounded suite or a non-isolated result', () => {
     for (const count of [0, 101]) {
-      await expect(
-        runIsolatedCases(async () => ({ ...result(0), benchmarkCount: count }))
-      ).rejects.toThrow()
+      expect(() =>
+        combineIsolatedCases([{ ...result(0), benchmarkCount: count }])
+      ).toThrow()
     }
-    await expect(
-      runIsolatedCases(async () => ({
-        ...result(0),
-        metrics: [result(0).metrics[0]!, result(1).metrics[0]!],
-      }))
-    ).rejects.toThrow('unexpected cases')
+    const runs = [0, 1, 2].map(result)
+    runs[0]!.metrics.push(result(1).metrics[0]!)
+    expect(() => combineIsolatedCases(runs)).toThrow('unexpected cases')
   })
 })

--- a/scripts/performance/isolated-cases.ts
+++ b/scripts/performance/isolated-cases.ts
@@ -1,16 +1,17 @@
 import type { BenchmarkRunResult } from '../../apps/benchmark/src/benchmarks/types'
 import { validateBenchmarkRun, validateExpectedRun } from './schema'
 
-/** Install once; the caller starts and terminates a fresh app process per case. */
-export async function runIsolatedCases(
-  runCase: (index: number) => Promise<BenchmarkRunResult>
-): Promise<BenchmarkRunResult> {
-  const first = validateBenchmarkRun(await runCase(0))
+/** Combine a complete suite without discarding any per-process raw samples. */
+export function combineIsolatedCases(
+  runs: readonly BenchmarkRunResult[]
+): BenchmarkRunResult {
+  const first = validateBenchmarkRun(runs[0])
   const count = first.benchmarkCount!
-  const runs: BenchmarkRunResult[] = []
+  if (runs.length !== count)
+    throw new Error('Incomplete isolated benchmark suite.')
   const ids = new Set<string>()
   for (let index = 0; index < count; index++) {
-    const run = index === 0 ? first : validateBenchmarkRun(await runCase(index))
+    const run = validateBenchmarkRun(runs[index])
     const { work: _firstWork, ...sharedConfiguration } = first.configuration
     validateExpectedRun(run, { ...sharedConfiguration, benchmarkIndex: index })
     if (
@@ -31,7 +32,6 @@ export async function runIsolatedCases(
       )
     }
     ids.add(run.metrics[0]!.id)
-    runs.push(run)
   }
   const configuration = { ...first.configuration }
   delete configuration.benchmarkIndex

--- a/scripts/performance/report-markdown.ts
+++ b/scripts/performance/report-markdown.ts
@@ -124,7 +124,7 @@ export function renderPerformanceReportMarkdown(
   const lines = [
     '## Performance Report',
     '',
-    '> **Report only:** Measurements do not fail this PR. Process pairs describe this run; they do not establish statistical confidence.',
+    '> **Report only:** Measurements do not fail this PR. Each benchmark has one base/head process pair. Samples describe within-process variation; they do not establish repeatability between launches or statistical confidence.',
   ]
   if (options.baseSha === options.headSha) {
     lines.push(
@@ -153,7 +153,7 @@ export function renderPerformanceReportMarkdown(
     lines.push(
       '',
       '<details>',
-      '<summary>All benchmarks and process variation</summary>',
+      '<summary>All benchmarks and sample variation</summary>',
       '',
       table(platform.comparisons, platform.platform),
       '',

--- a/scripts/performance/report-validation.test.ts
+++ b/scripts/performance/report-validation.test.ts
@@ -12,8 +12,7 @@ const SUITE_HASH = 'c'.repeat(64)
 
 function run(
   platform: 'android' | 'ios',
-  revision: 'base' | 'head',
-  sequence: number
+  revision: 'base' | 'head'
 ): BenchmarkRunResult {
   const center = revision === 'base' ? 100 : 120
   const samples = Array.from(
@@ -25,8 +24,8 @@ function run(
     suiteVersion: 1,
     benchmarkCount: 1,
     configuration: {
-      runId: `${platform}-${revision}-${sequence}`,
-      reverse: sequence === 2,
+      runId: `${platform}-${revision}-1`,
+      reverse: false,
       commitSha: revision === 'base' ? BASE_SHA : HEAD_SHA,
       suiteHash: SUITE_HASH,
       platform,
@@ -96,12 +95,10 @@ async function createFixture(root: string): Promise<{
       runAttempt: 1,
     })
     for (const revision of ['base', 'head'] as const) {
-      for (const sequence of [1, 2]) {
-        await writeJson(
-          path.join(directory, `${revision}-${sequence}.json`),
-          run(platform, revision, sequence)
-        )
-      }
+      await writeJson(
+        path.join(directory, `${revision}-1.json`),
+        run(platform, revision)
+      )
     }
   }
 
@@ -216,7 +213,7 @@ describe('trusted performance report validation', () => {
         '<strong>C++</strong> <code>addNumbers()</code>'
       )
       expect(markdown).toContain(
-        '<summary>All benchmarks and process variation</summary>'
+        '<summary>All benchmarks and sample variation</summary>'
       )
       expect(markdown).toContain(
         `Benchmarking Code Diff [\`${BASE_SHA.slice(0, 8)}\`...\`${HEAD_SHA.slice(0, 8)}\`](https://github.com/margelo/nitro/compare/${BASE_SHA}..${HEAD_SHA}) ([view CI run](https://github.com/margelo/nitro/actions/runs/123456789))`
@@ -300,17 +297,9 @@ describe('trusted performance report validation', () => {
     const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-performance-'))
     try {
       const fixture = await createFixture(root)
-      for (const platform of ['android', 'ios'])
-        for (const sequence of [1, 2]) {
-          await rm(
-            path.join(
-              fixture.artifact,
-              'raw',
-              platform,
-              `base-${sequence}.json`
-            )
-          )
-        }
+      for (const platform of ['android', 'ios']) {
+        await rm(path.join(fixture.artifact, 'raw', platform, 'base-1.json'))
+      }
       expect((await validate(fixture)).exitCode).not.toBe(0)
       const file = path.join(fixture.artifact, 'performance-report.json')
       const manifest = JSON.parse(await readFile(file, 'utf8'))
@@ -339,11 +328,13 @@ describe('trusted performance report validation', () => {
           path.join(fixture.output, 'bencher-base-ios.json')
         ).exists()
       ).toBe(false)
-      const headFile = path.join(fixture.artifact, 'raw/ios/head-2.json')
-      const head = await Bun.file(headFile).json()
-      head.metrics[0].iterations += 1
-      await writeJson(headFile, head)
-      expect((await validate(fixture)).error).toContain('unequal work')
+      await writeJson(
+        path.join(fixture.artifact, 'raw/ios/head-2.json'),
+        await Bun.file(
+          path.join(fixture.artifact, 'raw/ios/head-1.json')
+        ).json()
+      )
+      expect((await validate(fixture)).error).toContain('Expected one')
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/scripts/performance/run-device.ts
+++ b/scripts/performance/run-device.ts
@@ -1,8 +1,6 @@
-import type { BenchmarkWork } from '../../apps/benchmark/src/benchmarks/types'
+import type { BenchmarkRunConfiguration } from '../../apps/benchmark/src/benchmarks/types'
 import path from 'node:path'
 import { mkdir, readFile } from 'node:fs/promises'
-import { parseArguments, requiredArgument } from './args'
-import { runIsolatedCases } from './isolated-cases'
 import { validateBenchmarkRun } from './schema'
 
 async function command(
@@ -42,49 +40,36 @@ async function commandOutput(
   return { exitCode, output }
 }
 
-const argumentsMap = parseArguments(Bun.argv.slice(2))
-const platform = requiredArgument(argumentsMap, 'platform')
-if (platform !== 'android' && platform !== 'ios') {
-  throw new Error('--platform must be android or ios.')
-}
-const app = path.resolve(requiredArgument(argumentsMap, 'app'))
-const output = path.resolve(requiredArgument(argumentsMap, 'output'))
-const deviceId = requiredArgument(argumentsMap, 'device-id')
-const casesDirectory = path.join(
-  path.dirname(output),
-  `${path.basename(output, '.json')}-cases`
-)
-const receiverArguments = [
-  path.join(import.meta.dir, 'receive.ts'),
-  '--platform',
-  platform,
-  '--run-id',
-  requiredArgument(argumentsMap, 'run-id'),
-  '--reverse',
-  requiredArgument(argumentsMap, 'reverse'),
-  '--commit-sha',
-  requiredArgument(argumentsMap, 'commit-sha'),
-  '--suite-hash',
-  requiredArgument(argumentsMap, 'suite-hash'),
-  '--device',
-  requiredArgument(argumentsMap, 'device'),
-  '--os-version',
-  requiredArgument(argumentsMap, 'os-version'),
-  '--architecture',
-  requiredArgument(argumentsMap, 'architecture'),
-  '--toolchain',
-  requiredArgument(argumentsMap, 'toolchain'),
-]
-
-async function runCase(
-  index: number,
-  calibration: boolean,
-  work?: BenchmarkWork
+/** Each call launches a fresh process and terminates it before returning. */
+export async function runDeviceCase(
+  deviceId: string,
+  appId: string,
+  configuration: BenchmarkRunConfiguration & { benchmarkIndex: number },
+  output: string
 ) {
-  const caseOutput = path.join(
-    casesDirectory,
-    `${calibration ? 'calibration' : 'case'}-${index}.json`
-  )
+  const { platform, benchmarkIndex: index, calibration, work } = configuration
+  await mkdir(path.dirname(output), { recursive: true })
+  const receiverArguments = [
+    path.join(import.meta.dir, 'receive.ts'),
+    '--platform',
+    platform,
+    '--run-id',
+    configuration.runId,
+    '--reverse',
+    String(configuration.reverse),
+    '--commit-sha',
+    configuration.commitSha,
+    '--suite-hash',
+    configuration.suiteHash,
+    '--device',
+    configuration.device,
+    '--os-version',
+    configuration.osVersion,
+    '--architecture',
+    configuration.architecture,
+    '--toolchain',
+    configuration.toolchain,
+  ]
   const receiver = Bun.spawn(
     [
       'bun',
@@ -101,7 +86,7 @@ async function runCase(
             String(work.chunkIterations),
           ]),
       '--output',
-      caseOutput,
+      output,
       '--benchmark-index',
       String(index),
       '--timeout-ms',
@@ -122,7 +107,7 @@ async function runCase(
         deviceId,
         'shell',
         'pidof',
-        'com.margelo.nitrobenchmark',
+        appId,
       ])
       if (process.exitCode !== 0 || process.output.trim().length === 0) {
         throw new Error(
@@ -134,18 +119,23 @@ async function runCase(
   }
 
   try {
+    let ready = false
     for (let attempt = 0; attempt < 50; attempt++) {
       try {
         const response = await fetch('http://127.0.0.1:8173/config')
-        if (response.ok) break
+        if (response.ok) {
+          ready = true
+          break
+        }
       } catch {
-        if (attempt === 49) throw new Error('Benchmark receiver did not start.')
+        // The receiver is still starting.
       }
       await Bun.sleep(100)
     }
 
+    if (!ready) throw new Error('Benchmark receiver did not start.')
+
     if (platform === 'android') {
-      const packageName = 'com.margelo.nitrobenchmark'
       await command('adb', [
         '-s',
         deviceId,
@@ -154,16 +144,15 @@ async function runCase(
         'start',
         '-W',
         '-n',
-        `${packageName}/.MainActivity`,
+        `${appId}/com.margelo.nitrobenchmark.MainActivity`,
       ])
     } else {
-      const bundleIdentifier = 'com.margelo.nitrobenchmark'
       await command('xcrun', [
         'simctl',
         'launch',
         '--terminate-running-process',
         deviceId,
-        bundleIdentifier,
+        appId,
       ])
     }
 
@@ -178,11 +167,11 @@ async function runCase(
       ? Promise.race([receiverCompletion, monitorAndroidProcess()])
       : receiverCompletion)
     const result = validateBenchmarkRun(
-      JSON.parse(await readFile(caseOutput, 'utf8'))
+      JSON.parse(await readFile(output, 'utf8'))
     )
     const metric = result.metrics[0]!
     console.info(
-      `[NitroBenchmark] ${calibration ? 'calibration' : 'measurement'} case ${index + 1}/${result.benchmarkCount}: ${metric.id}, ${metric.iterations} ops/sample`
+      `[NitroBenchmark] ${new Date().toISOString()} ${configuration.runId} ${calibration ? 'calibration' : 'measurement'} case ${index + 1}/${result.benchmarkCount}: ${metric.id}, ${metric.iterations} ops/sample`
     )
     return result
   } catch (error) {
@@ -204,7 +193,7 @@ async function runCase(
         'dumpsys',
         'activity',
         'exit-info',
-        'com.margelo.nitrobenchmark',
+        appId,
       ])
       const diagnostics = `${logs.output}\n${exits.output}`
       await Bun.write(output.replace(/\.json$/, '.failure.log'), diagnostics)
@@ -216,85 +205,31 @@ async function runCase(
     if (platform === 'android') {
       await command(
         'adb',
-        [
-          '-s',
-          deviceId,
-          'shell',
-          'am',
-          'force-stop',
-          'com.margelo.nitrobenchmark',
-        ],
+        ['-s', deviceId, 'shell', 'am', 'force-stop', appId],
         true
       )
     } else {
-      await command(
-        'xcrun',
-        ['simctl', 'terminate', deviceId, 'com.margelo.nitrobenchmark'],
-        true
-      )
+      await command('xcrun', ['simctl', 'terminate', deviceId, appId], true)
     }
     receiver.kill()
     await receiver.exited
   }
 }
 
-// Installing once preserves the same binary while fresh processes release the
-// runtime-scoped JSI cache between cases. No install/launch work enters timing.
-await mkdir(casesDirectory, { recursive: true })
-if (platform === 'android') {
-  await command(
-    'adb',
-    ['-s', deviceId, 'uninstall', 'com.margelo.nitrobenchmark'],
-    true
-  )
-  await command('adb', ['-s', deviceId, 'install', '-r', app])
-  await command('adb', ['-s', deviceId, 'reverse', 'tcp:8173', 'tcp:8173'])
-} else {
-  await command(
-    'xcrun',
-    ['simctl', 'terminate', deviceId, 'com.margelo.nitrobenchmark'],
-    true
-  )
-  await command(
-    'xcrun',
-    ['simctl', 'uninstall', deviceId, 'com.margelo.nitrobenchmark'],
-    true
-  )
-  await command('xcrun', ['simctl', 'install', deviceId, app])
-}
-const workFile = argumentsMap.get('work-plan')?.[0]
-const plan =
-  workFile == null
-    ? undefined
-    : validateBenchmarkRun(JSON.parse(await readFile(workFile, 'utf8')))
-const work = plan?.metrics.map(({ id, iterations, chunkIterations }) => ({
-  id,
-  iterations,
-  chunkIterations,
-}))
-if (
-  plan != null &&
-  (plan.configuration.calibration !== true ||
-    plan.configuration.suiteHash !==
-      requiredArgument(argumentsMap, 'suite-hash'))
-) {
-  throw new Error('Work plan must be calibration for the measured suite.')
-}
-if (
-  plan != null &&
-  plan.configuration.reverse !== (argumentsMap.get('reverse')?.[0] === 'true')
-)
-  work?.reverse()
-const result = await runIsolatedCases(async (index) => {
-  if (argumentsMap.has('calibration')) return runCase(index, true)
-  let counts = work?.[index]
-  if (counts == null) {
-    if (work != null) throw new Error('Work plan is missing a benchmark case.')
-    const calibration = await runCase(index, true)
-    const { id, iterations, chunkIterations } = calibration.metrics[0]!
-    counts = { id, iterations, chunkIterations }
+/** Install once; app identities let revisions coexist on the same device. */
+export async function installApp(
+  platform: 'android' | 'ios',
+  deviceId: string,
+  app: string,
+  appId: string
+): Promise<void> {
+  if (platform === 'android') {
+    await command('adb', ['-s', deviceId, 'uninstall', appId], true)
+    await command('adb', ['-s', deviceId, 'install', '-r', app])
+    await command('adb', ['-s', deviceId, 'reverse', 'tcp:8173', 'tcp:8173'])
+  } else {
+    await command('xcrun', ['simctl', 'terminate', deviceId, appId], true)
+    await command('xcrun', ['simctl', 'uninstall', deviceId, appId], true)
+    await command('xcrun', ['simctl', 'install', deviceId, app])
   }
-  // runCase terminates its process before returning, including calibration.
-  return runCase(index, false, counts)
-})
-await Bun.write(output, `${JSON.stringify(result, null, 2)}\n`)
+}

--- a/scripts/performance/run-sequence.test.ts
+++ b/scripts/performance/run-sequence.test.ts
@@ -7,13 +7,20 @@ import { calculateSuiteHash } from './suite-hash'
 // Exercise the real controller/receiver with a tiny process standing in for
 // simctl's app. Runner tests separately exercise timed work and slowdown bounds.
 test.each([
-  [false, false],
-  [true, false],
-  [false, true],
-  [true, true],
-])(
-  'fresh processes share calibrated work; changed suite = %s, saved apps = %s',
-  async (changedSuite, savedApps) => {
+  ['ios', 'paired', false],
+  ['ios', 'paired', true],
+  ['ios', 'changed-suite', true],
+  ['ios', 'same-sha', true],
+  ['android', 'paired', true],
+  ['android', 'same-sha', true],
+  ['android', 'changed-suite', true],
+  ['ios', 'invalid-result', true],
+] as const)(
+  '%s per-case comparisons: %s, saved apps = %s',
+  async (platform, mode, savedApps) => {
+    const changedSuite = mode === 'changed-suite'
+    const sameBinary = mode === 'same-sha'
+    const headSha = sameBinary ? 'a'.repeat(40) : 'b'.repeat(40)
     const directory = await mkdtemp(path.join(os.tmpdir(), 'nitro-sequence-'))
     try {
       const simulator = path.join(directory, 'simulator.ts')
@@ -26,8 +33,11 @@ test.each([
       const index = configuration.reverse ? 1 - configuration.benchmarkIndex : configuration.benchmarkIndex
       const id = ['javascript/control/first', 'javascript/control/second'][index]
       const work = configuration.work ?? { id, iterations: [1000, 500][index], chunkIterations: [250, 100][index] }
-      if (work.id !== id) throw new Error('Work was assigned to the wrong reversed case.')
-      await appendFile(process.env.SIMULATOR_LOG, JSON.stringify({ pid: process.pid, configuration, work }) + '\\n')
+      if (work.id !== id) throw new Error('Work was assigned to the wrong case.')
+      const appId = process.argv[2]
+      const expectedId = process.env.SAME_BINARY === 'true' || configuration.runId.includes('-head-') ? 'com.margelo.nitrobenchmark.head' : 'com.margelo.nitrobenchmark'
+      if (appId !== expectedId) throw new Error('Launched the wrong app: ' + appId)
+      await appendFile(process.env.SIMULATOR_LOG, JSON.stringify({ pid: process.pid, appId, configuration, work }) + '\\n')
       const count = configuration.calibration ? 0 : 20
       const response = await fetch('http://127.0.0.1:8173/result', {
         method: 'POST', body: JSON.stringify({
@@ -35,18 +45,34 @@ test.each([
           environment: { reactNativeVersion: '0.85.3', hermes: true, dev: false, nitroBuildType: 'release' },
           runner: { targetBatchDurationMs: 150, warmupCount: count === 0 ? 0 : 5, sampleCount: count },
           startedAt: new Date().toISOString(), durationMs: 100,
-          metrics: [{ ...work, version: 1, family: 'control', implementation: 'javascript', samplesNsPerOp: Array(count).fill(100), checksum: 0 }],
+          metrics: [{ ...work, version: 1, family: 'control', implementation: 'javascript', samplesNsPerOp: Array(process.env.INVALID_RESULT === 'true' && configuration.runId.includes('-head-') ? 1 : count).fill(100), checksum: 0 }],
         }),
       })
       if (!response.ok) throw new Error(await response.text())
     `
       )
-      const xcrun = path.join(directory, 'xcrun')
+      const commandsLog = path.join(directory, 'commands.jsonl')
+      const fakeDevice = path.join(directory, 'device.ts')
       await Bun.write(
-        xcrun,
-        `#!/bin/sh\nif [ "$2" = launch ]; then exec '${process.execPath}' '${simulator}'; fi\n`
+        fakeDevice,
+        `
+        import { appendFile } from 'node:fs/promises'
+        const args = process.argv.slice(2)
+        await appendFile(process.env.COMMANDS_LOG, JSON.stringify(args) + '\\n')
+        if (args.includes('launch') || args.includes('start')) {
+          const appId = args.at(-1).split('/')[0]
+          const child = Bun.spawn([process.execPath, ${JSON.stringify(simulator)}, appId], { stdout: 'inherit', stderr: 'inherit' })
+          process.exit(await child.exited)
+        }
+        if (args.includes('pidof')) console.log('12345')
+      `
       )
-      await chmod(xcrun, 0o755)
+      const tool = path.join(directory, platform === 'ios' ? 'xcrun' : 'adb')
+      await Bun.write(
+        tool,
+        `#!/bin/sh\nexec '${process.execPath}' '${fakeDevice}' "$@"\n`
+      )
+      await chmod(tool, 0o755)
       const output = path.join(directory, 'results')
       const log = path.join(directory, 'processes.jsonl')
       const root = path.resolve(import.meta.dir, '../..')
@@ -64,9 +90,9 @@ test.each([
       await Bun.write(
         metadataPath,
         JSON.stringify({
-          platform: 'ios',
+          platform,
           baseSha: 'a'.repeat(40),
-          headSha: 'b'.repeat(40),
+          headSha,
           baseSuiteHash: await calculateSuiteHash(
             changedSuite ? baseRoot : root
           ),
@@ -83,11 +109,11 @@ test.each([
           'bun',
           path.join(import.meta.dir, 'run-sequence.ts'),
           '--platform',
-          'ios',
+          platform,
           '--base-app',
-          directory,
+          path.join(directory, 'base.app'),
           '--head-app',
-          directory,
+          path.join(directory, 'head.app'),
           ...(savedApps
             ? ['--build-metadata', metadataPath]
             : [
@@ -99,7 +125,7 @@ test.each([
           '--base-sha',
           'a'.repeat(40),
           '--head-sha',
-          'b'.repeat(40),
+          headSha,
           '--output-directory',
           output,
           '--device-id',
@@ -118,6 +144,9 @@ test.each([
             ...process.env,
             PATH: `${directory}:${process.env.PATH}`,
             SIMULATOR_LOG: log,
+            COMMANDS_LOG: commandsLog,
+            SAME_BINARY: String(sameBinary),
+            INVALID_RESULT: String(mode === 'invalid-result'),
             GITHUB_RUN_ID: '123',
             GITHUB_RUN_ATTEMPT: '2',
             BUILD_ARTIFACT_ID: '456',
@@ -132,13 +161,69 @@ test.each([
         new Response(child.stdout).text(),
         new Response(child.stderr).text(),
       ])
+      const processes = (await readFile(log, 'utf8'))
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line))
+      const commands: string[][] = (await readFile(commandsLog, 'utf8'))
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line))
+      if (mode === 'invalid-result') {
+        expect(exitCode).not.toBe(0)
+        expect(processes).toHaveLength(3)
+        expect(
+          processes.every((entry) => entry.configuration.benchmarkIndex === 0)
+        ).toBe(true)
+        expect(commands.at(-1)).toEqual([
+          'simctl',
+          'terminate',
+          'fixture',
+          'com.margelo.nitrobenchmark.head',
+        ])
+        expect(await Bun.file(path.join(output, 'head-1.json')).exists()).toBe(
+          false
+        )
+        return
+      }
       expect({
         exitCode,
         error: exitCode === 0 ? '' : stdout + stderr,
-      }).toEqual({
-        exitCode: 0,
-        error: '',
-      })
+      }).toEqual({ exitCode: 0, error: '' })
+      const installs = commands.filter((args) => args.includes('install'))
+      expect(installs.map((args) => args.at(-1))).toEqual(
+        sameBinary || changedSuite
+          ? [path.join(directory, 'head.app')]
+          : [path.join(directory, 'head.app'), path.join(directory, 'base.app')]
+      )
+      const launches = commands.filter(
+        (args) => args.includes('launch') || args.includes('start')
+      )
+      expect(launches.map((args) => args.at(-1))).toEqual(
+        processes.map((entry) =>
+          platform === 'ios'
+            ? entry.appId
+            : `${entry.appId}/com.margelo.nitrobenchmark.MainActivity`
+        )
+      )
+      // Every app is stopped before starting the next case, including calibration.
+      const lifecycle = commands.filter((args) =>
+        ['launch', 'start', 'terminate', 'force-stop'].some((op) =>
+          args.includes(op)
+        )
+      )
+      const firstLaunch = lifecycle.findIndex(
+        (args) => args.includes('launch') || args.includes('start')
+      )
+      expect(
+        lifecycle
+          .slice(firstLaunch)
+          .map((args) =>
+            args.includes('terminate') || args.includes('force-stop')
+              ? 'stop'
+              : 'start'
+          )
+      ).toEqual(processes.flatMap(() => ['start', 'stop']))
       if (savedApps) {
         expect(
           (await Bun.file(path.join(output, 'build.json')).json()).runAttempt
@@ -147,37 +232,30 @@ test.each([
           await Bun.file(path.join(output, 'measurement.json')).json()
         ).toEqual({ buildArtifactId: 456, runAttempt: 2 })
       }
-      const processes = (await readFile(log, 'utf8'))
-        .trim()
-        .split('\n')
-        .map((line) => JSON.parse(line))
       expect(new Set(processes.map((entry) => entry.pid)).size).toBe(
-        changedSuite ? 6 : 10
+        changedSuite ? 4 : 6
       )
       expect(
-        processes
-          .slice(0, 2)
-          .every((entry) => entry.configuration.calibration === true)
-      ).toBe(true)
-      expect(
-        processes.slice(2).map((entry) => entry.configuration.runId)
+        processes.map((entry) => [
+          entry.configuration.benchmarkIndex,
+          entry.configuration.runId,
+          entry.configuration.calibration === true,
+        ])
       ).toEqual(
-        changedSuite
-          ? ['ios-head-1', 'ios-head-1', 'ios-head-2', 'ios-head-2']
-          : [
-              'ios-base-1',
-              'ios-base-1',
-              'ios-head-1',
-              'ios-head-1',
-              'ios-head-2',
-              'ios-head-2',
-              'ios-base-2',
-              'ios-base-2',
-            ]
+        [0, 1].flatMap((index) =>
+          changedSuite
+            ? [
+                [index, `${platform}-head-0`, true],
+                [index, `${platform}-head-1`, false],
+              ]
+            : [
+                [index, `${platform}-base-0`, true],
+                [index, `${platform}-base-1`, false],
+                [index, `${platform}-head-1`, false],
+              ]
+        )
       )
-      for (const file of changedSuite
-        ? ['head-1', 'head-2']
-        : ['base-1', 'head-1', 'head-2', 'base-2']) {
+      for (const file of changedSuite ? ['head-1'] : ['base-1', 'head-1']) {
         const run = JSON.parse(
           await readFile(path.join(output, `${file}.json`), 'utf8')
         )

--- a/scripts/performance/run-sequence.ts
+++ b/scripts/performance/run-sequence.ts
@@ -1,15 +1,21 @@
 import { mkdir, readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { parseArguments, requiredArgument } from './args'
-import { validateBenchmarkRun } from './schema'
+import { installApp, runDeviceCase } from './run-device'
+import { combineIsolatedCases } from './isolated-cases'
+import type {
+  BenchmarkRunResult,
+  BenchmarkWork,
+} from '../../apps/benchmark/src/benchmarks/types'
 import { calculateSuiteHash } from './suite-hash'
 import type { BuildMetadata } from './build-metadata'
 
 const argumentsMap = parseArguments(Bun.argv.slice(2))
-const platform = requiredArgument(argumentsMap, 'platform')
-if (platform !== 'android' && platform !== 'ios') {
+const platformArgument = requiredArgument(argumentsMap, 'platform')
+if (platformArgument !== 'android' && platformArgument !== 'ios') {
   throw new Error('--platform must be android or ios.')
 }
+const platform = platformArgument
 const baseApp = path.resolve(requiredArgument(argumentsMap, 'base-app'))
 const headApp = path.resolve(requiredArgument(argumentsMap, 'head-app'))
 const baseSha = requiredArgument(argumentsMap, 'base-sha')
@@ -72,85 +78,73 @@ await Bun.write(
   `${JSON.stringify({ baseSuiteHash, headSuiteHash }, null, 2)}\n`
 )
 
-async function runOne(
+const comparable = baseSuiteHash === headSuiteHash
+const sameBinary = baseSha === headSha
+const headId = 'com.margelo.nitrobenchmark.head'
+const baseId = sameBinary ? headId : 'com.margelo.nitrobenchmark'
+await installApp(platform, deviceId, headApp, headId)
+if (comparable && !sameBinary) {
+  await installApp(platform, deviceId, baseApp, baseId)
+}
+
+async function runCase(
   revision: 'base' | 'head',
-  sequence: number,
-  reverse: boolean,
-  calibration = false
-): Promise<void> {
+  index: number,
+  work?: BenchmarkWork
+): Promise<BenchmarkRunResult> {
   const isBase = revision === 'base'
-  const output = path.join(
-    outputDirectory,
-    calibration
-      ? `calibration-${revision}.json`
-      : `${revision}-${sequence}.json`
-  )
-  const runId = `${platform}-${revision}-${sequence}`
-  const startedAt = performance.now()
-  console.info(
-    `[NitroBenchmark] ${new Date().toISOString()} ${runId}: starting (${reverse ? 'reverse' : 'forward'} order)`
-  )
-  const command = [
-    'bun',
-    path.join(import.meta.dir, 'run-device.ts'),
-    ...(calibration
-      ? ['--calibration', 'true']
-      : [
-          '--work-plan',
-          path.join(
-            outputDirectory,
-            `calibration-${isBase || baseSuiteHash === headSuiteHash ? 'base' : 'head'}.json`
-          ),
-        ]),
-    '--platform',
-    platform,
-    '--app',
-    isBase ? baseApp : headApp,
-    '--output',
-    output,
-    '--run-id',
-    runId,
-    '--reverse',
-    String(reverse),
-    '--commit-sha',
-    isBase ? baseSha : headSha,
-    '--suite-hash',
-    isBase ? baseSuiteHash : headSuiteHash,
-    '--device-id',
+  const calibration = work == null
+  const name = calibration ? `calibration-${revision}` : `${revision}-1`
+  return runDeviceCase(
     deviceId,
-    '--device',
-    device,
-    '--os-version',
-    osVersion,
-    '--architecture',
-    architecture,
-    '--toolchain',
-    toolchain,
-  ]
-  const child = Bun.spawn(command, { stdout: 'inherit', stderr: 'inherit' })
-  const exitCode = await child.exited
-  if (exitCode !== 0) throw new Error(`${revision} run ${sequence} failed.`)
-  const result = validateBenchmarkRun(
-    JSON.parse(await readFile(output, 'utf8'))
-  )
-  console.info(
-    `[NitroBenchmark] ${new Date().toISOString()} ${runId}: complete; ${result.metrics.length} metrics, suite ${(result.durationMs / 1_000).toFixed(1)}s, wall ${((performance.now() - startedAt) / 1_000).toFixed(1)}s`
+    isBase ? baseId : headId,
+    {
+      platform,
+      runId: `${platform}-${revision}-${calibration ? 0 : 1}`,
+      reverse: false,
+      benchmarkIndex: index,
+      ...(calibration ? { calibration: true as const } : { work }),
+      commitSha: isBase ? baseSha : headSha,
+      suiteHash: isBase ? baseSuiteHash : headSuiteHash,
+      device,
+      osVersion,
+      architecture,
+      toolchain,
+    },
+    path.join(outputDirectory, `${name}-cases`, `case-${index}.json`)
   )
 }
 
-// Derive one plan from base, then discard every calibration process. Changed
-// suites need separate plans and will be reported without a comparison.
-if (baseSuiteHash === headSuiteHash) {
-  await runOne('base', 0, false, true)
-  await runOne('base', 1, false)
-  await runOne('head', 1, false)
-  await runOne('head', 2, true)
-  await runOne('base', 2, true)
-} else {
+if (!comparable) {
   console.info(
     '[NitroBenchmark] Benchmark definitions changed; measuring a new head baseline only.'
   )
-  await runOne('head', 0, false, true)
-  await runOne('head', 1, false)
-  await runOne('head', 2, true)
+}
+const calibrationRevision = comparable ? 'base' : 'head'
+const calibrations: BenchmarkRunResult[] = []
+const baseRuns: BenchmarkRunResult[] = []
+const headRuns: BenchmarkRunResult[] = []
+// Discover the suite size from the first calibration. Every calibration process
+// exits before measuring base then head with the exact same operation counts.
+let count = 1
+for (let index = 0; index < count; index++) {
+  const calibration = await runCase(calibrationRevision, index)
+  if (index === 0) count = calibration.benchmarkCount!
+  const { id, iterations, chunkIterations } = calibration.metrics[0]!
+  const work = { id, iterations, chunkIterations }
+  calibrations.push(calibration)
+  if (comparable) baseRuns.push(await runCase('base', index, work))
+  headRuns.push(await runCase('head', index, work))
+}
+for (const [name, runs] of [
+  [`calibration-${calibrationRevision}`, calibrations],
+  ['base-1', baseRuns],
+  ['head-1', headRuns],
+] as const) {
+  if (runs.length === 0) continue
+  const result = combineIsolatedCases(runs)
+  await Bun.write(
+    path.join(outputDirectory, `${name}.json`),
+    `${JSON.stringify(result, null, 2)}\n`
+  )
 }

--- a/scripts/performance/validate-report.ts
+++ b/scripts/performance/validate-report.ts
@@ -358,58 +358,51 @@ for (const platform of ['android', 'ios'] as const) {
   builds.set(platform, build)
 }
 
-async function loadRawRuns(
+async function loadRawRun(
   platform: 'android' | 'ios',
   revision: 'base' | 'head',
   expectedSha: string
-): Promise<BenchmarkRunResult[]> {
+): Promise<BenchmarkRunResult> {
   const directory = path.join(artifactDirectory, 'raw', platform)
-  const filePattern = new RegExp(`^${revision}-[1-2]\\.json$`)
-  const files = (await readdir(directory))
-    .filter((file) => filePattern.test(file))
-    .sort()
-  if (files.length !== 2) {
-    throw new Error(`Expected two ${platform} ${revision} runs.`)
-  }
-  return Promise.all(
-    files.map(async (file) => {
-      const run = validateBenchmarkRun(
-        await readBoundedJson(path.join(directory, file))
-      )
-      const sequence = Number(file.match(/-(\d)\.json$/)![1])
-      if (
-        run.configuration.runId !== `${platform}-${revision}-${sequence}` ||
-        run.configuration.reverse !== (sequence === 2) ||
-        run.configuration.platform !== platform ||
-        run.configuration.architecture !== builds.get(platform)!.architecture ||
-        run.configuration.toolchain !== builds.get(platform)!.toolchain ||
-        run.configuration.benchmarkIndex !== undefined ||
-        run.metrics.length !== run.benchmarkCount ||
-        run.configuration.commitSha !== expectedSha ||
-        run.configuration.suiteHash !==
-          (revision === 'base' ? report.baseSuiteHash : report.headSuiteHash) ||
-        run.configuration.calibration !== undefined ||
-        run.runner.targetBatchDurationMs !== 150 ||
-        run.runner.warmupCount !== 5 ||
-        run.runner.sampleCount !== 20 ||
-        run.metrics.some(
-          (metric) =>
-            metric.samplesNsPerOp.length !== 20 ||
-            !METRIC_ID_PATTERN.test(metric.id)
-        )
-      ) {
-        throw new Error(`${platform} ${revision} run metadata is invalid.`)
-      }
-      return run
-    })
+  const filePattern = new RegExp(`^${revision}-[0-9]+\\.json$`)
+  const files = (await readdir(directory)).filter((file) =>
+    filePattern.test(file)
   )
+  if (files.length !== 1 || files[0] !== `${revision}-1.json`) {
+    throw new Error(`Expected one ${platform} ${revision} run.`)
+  }
+  const run = validateBenchmarkRun(
+    await readBoundedJson(path.join(directory, files[0]!))
+  )
+  if (
+    run.configuration.runId !== `${platform}-${revision}-1` ||
+    run.configuration.reverse !== false ||
+    run.configuration.platform !== platform ||
+    run.configuration.architecture !== builds.get(platform)!.architecture ||
+    run.configuration.toolchain !== builds.get(platform)!.toolchain ||
+    run.configuration.benchmarkIndex !== undefined ||
+    run.metrics.length !== run.benchmarkCount ||
+    run.configuration.commitSha !== expectedSha ||
+    run.configuration.suiteHash !==
+      (revision === 'base' ? report.baseSuiteHash : report.headSuiteHash) ||
+    run.configuration.calibration !== undefined ||
+    run.runner.targetBatchDurationMs !== 150 ||
+    run.runner.warmupCount !== 5 ||
+    run.runner.sampleCount !== 20 ||
+    run.metrics.some(
+      (metric) =>
+        metric.samplesNsPerOp.length !== 20 ||
+        !METRIC_ID_PATTERN.test(metric.id)
+    )
+  ) {
+    throw new Error(`${platform} ${revision} run metadata is invalid.`)
+  }
+  return run
 }
 
 const rebuiltComparisons = await Promise.all(
   (['android', 'ios'] as const).map(async (platform) => {
-    const headRuns = await loadRawRuns(platform, 'head', report.headSha)
-    // This also checks the two baseline processes share work and runtime settings.
-    compareRuns([headRuns[0]!], [headRuns[1]!])
+    const headRuns = [await loadRawRun(platform, 'head', report.headSha)]
     const comparable = report.baseSuiteHash === report.headSuiteHash
     const baseFiles = (
       await readdir(path.join(artifactDirectory, 'raw', platform))
@@ -419,7 +412,7 @@ const rebuiltComparisons = await Promise.all(
         'Changed suites must not upload incomparable base measurements.'
       )
     const baseRuns = comparable
-      ? await loadRawRuns(platform, 'base', report.baseSha)
+      ? [await loadRawRun(platform, 'base', report.baseSha)]
       : []
     const comparison = comparable
       ? compareRuns(baseRuns, headRuns)


### PR DESCRIPTION
For a given benchmark, base and head currently run minutes apart across four complete suite passes. Install the two Release apps side by side and measure each case as calibration → base → head before moving to the next case. This reduces a 46-case comparison from 230 fresh app processes to 138 while keeping identical operation counts, five warmups, and twenty samples per measurement.

Base retains its app ID; head uses `.head` through Gradle and Xcode build settings. Same-SHA checks reuse the exact same binary for both roles. Changed suites retain head-only baselines. The controller owns one case loop. Raw per-process JSON, artifact provenance, and measurement-only reruns remain available. Reporting accepts one pair and explicitly does not claim between-launch repeatability or statistical confidence.

### CI results

[The PR workflow passed](https://github.com/margelo/nitro/actions/runs/34109611020). Compared with the [previous cleanup run](https://github.com/margelo/nitro/actions/runs/34053470720):

| Measurement job | Previous | This PR | Typical base/head separation |
| --- | ---: | ---: | ---: |
| Android | 27m08s | 16m17s | 5.7 minutes → 7 seconds |
| iOS | 37m16s | 25m47s | 7.0 minutes → 9 seconds |

The entire workflow took 38m09s, versus 49m10s previously. These are observations from separate hosted runners, not a controlled estimate of repeatable speedup. All 46 calibration/base/head triples on each platform had matching benchmark IDs and work counts, and all 138 process timestamps followed the intended order.

**Accuracy remains limited, especially on iOS.** This PR does not change the measured function implementations, yet 2/46 Android cases and 23/46 iOS cases showed changes above 5%; the largest iOS difference was about 42%. Some buffer/callback workloads still drift within a process. Closer pairing is not enough to make a 3% regression gate trustworthy.

The separate [exact-same-binary A/A diagnostic](https://github.com/margelo/nitro/actions/runs/34110792874) also passed. The saved base/head app artifacts were verified byte-for-byte identical on both platforms, and every calibration/base/head triple preserved matching work and case order.

| A/A diagnostic | Median absolute difference across cases | Cases differing by more than 5% | Largest absolute difference |
| --- | ---: | ---: | ---: |
| Android | 0.79% | 3/46 | 12.3% |
| iOS | 10.22% | 33/46 | 33.9% |

These are descriptive results from one diagnostic run, not calibrated error rates. They demonstrate that this iOS environment remains unsuitable for treating small observed differences as regressions. The change saves time and brings comparisons closer together; it does not solve iOS measurement reliability. Results remain report-only. [Download the A/A raw JSON](https://github.com/margelo/nitro/actions/runs/34110792874/artifacts/10016246823).

[Download the PR's raw JSON artifact](https://github.com/margelo/nitro/actions/runs/34109611020/artifacts/10015081593). The new trusted validator rebuilt Markdown and Bencher JSON locally from that artifact against GitHub's actual run, PR, and artifact metadata. No local publication was performed.

### Validation and rollout

74 tooling tests passed, including real controller/receiver fixtures for Android and iOS, app identity and process ordering, A/A reuse, changed suites, malformed results, and artifact packaging. Tooling/app typechecks, app lint, actionlint, shellcheck, and diff checks passed. The original PR run at `77c4d5c3` passed all checks, including both native Release builds and measurements. Both downloaded CI artifacts also passed the measured revision’s trusted report validator against GitHub metadata.

Originally stacked on #1609. The results above measure `77c4d5c3`, before the later rebase to `816875fa` and merge. The benchmark app and measurement controller are unchanged by that rebase. Its [replacement CI run](https://github.com/margelo/nitro/actions/runs/34113809527) is still running; the superseded run was cancelled before executing jobs. At the time of the measured PR run, main's reporter skipped this internal PR, so the new report was validated locally without adding a temporary publishing path.
