### PR TITLE
ci: Post performance reports as Nitro Modules Bot

### DIFF
--- a/.github/PERFORMANCE.md
+++ b/.github/PERFORMANCE.md
@@ -78,6 +78,39 @@ a changed base SHA naturally selects a different start point.
 The Bencher action and downloaded CLI version are both pinned. Both publishers
 verify the reviewed Linux CLI SHA-256 before the step receiving the API key.
 
+## Nitro Modules Bot
+
+The paired PR comparison can post as a dedicated GitHub App named **Nitro Modules Bot**, using [`docs/static/img/nos.png`](../docs/static/img/nos.png)
+as its avatar. The app needs no hosted service or webhook receiver; Actions
+creates a short-lived installation token just before posting the comment.
+
+To configure it on `margelo/nitro`:
+
+1. Register a GitHub App named `Nitro Modules Bot` with homepage
+   `https://nitro.margelo.com`. Disable webhooks and grant only the repository
+   permission **Pull requests: Read & write** (Metadata read access is automatic).
+   Keep installation restricted to the owning account when the app belongs to
+   `margelo`.
+2. Upload the NOS image under the app's Display information and install the app
+   on only `margelo/nitro`.
+3. Generate an app private key and save its PEM contents in the repository's
+   Actions secret `NITRO_PERFORMANCE_APP_PRIVATE_KEY`. Keep the key out of git.
+4. Set the repository Actions variable `NITRO_PERFORMANCE_APP_CLIENT_ID` to the
+   app's Client ID. Set this last, after the key and installation are ready.
+
+Both publishing paths use the app's actual slug to recognize their own comments.
+They request only Pull requests write permission for the current repository, and
+the token action revokes the token at the end of the job. Build jobs and fork PR
+jobs never receive the app key. Bencher publishing retains its existing token.
+Update the same-repository publisher's reporting commit pin when changing the
+reporter. Fork reporting changes take effect after reaching the default branch.
+
+Without the Client ID variable, comments continue as `github-actions[bot]`.
+Removing that variable switches back to the default identity. Configured app
+authentication failures fail the posting job rather than silently switching authors.
+The first run after switching identities creates a new comment; subsequent runs
+update that bot's comment. Earlier comments keep their original author and avatar.
+
 ## Promoting performance verdicts to a gate
 
 This initial workflow always passes `--mode advisory`; merging it does **not**

--- a/.github/workflows/performance-report.yml
+++ b/.github/workflows/performance-report.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout trusted reporting code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
@@ -59,10 +61,20 @@ jobs:
             --trusted-workflow-event "$GITHUB_EVENT_PATH" \
             "${TRUSTED_PR_ARGUMENTS[@]}"
 
+      - name: Create Nitro Modules Bot token
+        id: performance-bot-token
+        if: steps.download.outcome == 'success' && vars.NITRO_PERFORMANCE_APP_CLIENT_ID != '' && github.event.workflow_run.event == 'pull_request'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ vars.NITRO_PERFORMANCE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.NITRO_PERFORMANCE_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+
       - name: Post paired comparison to the PR
         if: steps.download.outcome == 'success'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.performance-bot-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GITHUB_APP_SLUG: ${{ steps.performance-bot-token.outputs.app-slug }}
         run: bun scripts/performance/github-report.ts --directory validated-report
 
       - name: Install Bencher CLI

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -228,7 +228,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: margelo/nitro
-          ref: f5857e95af6c07a67a6604c44ecbfc6bc365e234
+          ref: a27931665204e9af801abc7f09a359da737d37d9
           persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
@@ -253,9 +253,18 @@ jobs:
             --expected-repository "$GITHUB_REPOSITORY" \
             --trusted-workflow-event trusted-workflow-event.json \
             --trusted-pull-request trusted-pull-request.json
+      - name: Create Nitro Modules Bot token
+        id: performance-bot-token
+        if: vars.NITRO_PERFORMANCE_APP_CLIENT_ID != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ vars.NITRO_PERFORMANCE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.NITRO_PERFORMANCE_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
       - name: Post paired comparison to the PR
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.performance-bot-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GITHUB_APP_SLUG: ${{ steps.performance-bot-token.outputs.app-slug }}
         run: bun scripts/performance/github-report.ts --directory validated-report
       - name: Install pinned Bencher CLI
         if: vars.NITRO_BENCHER_ENABLED == 'true'

--- a/scripts/performance/github-report.test.ts
+++ b/scripts/performance/github-report.test.ts
@@ -39,7 +39,45 @@ describe('paired performance PR comment', () => {
     ])
   })
 
-  test('updates only the existing paired comparison bot comment', async () => {
+  test.each(['github-actions[bot]', 'nitro-modules-bot[bot]'])(
+    'updates only the existing paired comparison from %s',
+    async (botLogin) => {
+      const writes: unknown[] = []
+      const status = await postPerformanceComment(
+        report,
+        async (endpoint, method = 'GET', body) => {
+          if (method !== 'GET') {
+            writes.push({ endpoint, method, body })
+            return {}
+          }
+          if (endpoint.includes('/pulls/')) return pullRequest
+          return [
+            {
+              id: 1,
+              body: `${marker}\nother bot's report`,
+              user: { login: 'another-app[bot]', type: 'Bot' },
+            },
+            {
+              id: 2,
+              body: `${marker}\nold report`,
+              user: { login: botLogin, type: 'Bot' },
+            },
+          ]
+        },
+        botLogin
+      )
+      expect(status).toBe('updated')
+      expect(writes).toEqual([
+        {
+          endpoint: '/repos/margelo/nitro/issues/comments/2',
+          method: 'PATCH',
+          body: { body: `${marker}\n${report.markdown}` },
+        },
+      ])
+    }
+  )
+
+  test('creates a new custom bot comment when migrating from GitHub Actions', async () => {
     const writes: unknown[] = []
     const status = await postPerformanceComment(
       report,
@@ -51,21 +89,42 @@ describe('paired performance PR comment', () => {
         if (endpoint.includes('/pulls/')) return pullRequest
         return [
           {
-            id: 2,
+            id: 1,
             body: `${marker}\nold report`,
             user: { login: 'github-actions[bot]', type: 'Bot' },
           },
+          {
+            id: 2,
+            body: marker,
+            user: { login: 'nitro-modules-bot[bot]', type: 'User' },
+          },
         ]
-      }
+      },
+      'nitro-modules-bot[bot]'
     )
-    expect(status).toBe('updated')
+    expect(status).toBe('created')
     expect(writes).toEqual([
       {
-        endpoint: '/repos/margelo/nitro/issues/comments/2',
-        method: 'PATCH',
+        endpoint: '/repos/margelo/nitro/issues/123/comments',
+        method: 'POST',
         body: { body: `${marker}\n${report.markdown}` },
       },
     ])
+  })
+
+  test('rejects a human author before making requests', async () => {
+    let requests = 0
+    await expect(
+      postPerformanceComment(
+        report,
+        async () => {
+          requests++
+          return {}
+        },
+        'mrousavy'
+      )
+    ).rejects.toThrow('Performance comment author must be a GitHub bot login.')
+    expect(requests).toBe(0)
   })
 
   test('does not post stale results after a PR advances', async () => {

--- a/scripts/performance/github-report.ts
+++ b/scripts/performance/github-report.ts
@@ -21,8 +21,12 @@ type GitHubRequest = (
 
 export async function postPerformanceComment(
   report: PullRequestReport,
-  request: GitHubRequest
+  request: GitHubRequest,
+  botLogin = 'github-actions[bot]'
 ): Promise<'created' | 'updated' | 'stale'> {
+  if (!/^[a-zA-Z0-9-]+\[bot\]$/.test(botLogin)) {
+    throw new Error('Performance comment author must be a GitHub bot login.')
+  }
   if (
     !/^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/.test(report.repository) ||
     !Number.isSafeInteger(report.pullRequestNumber) ||
@@ -58,7 +62,7 @@ export async function postPerformanceComment(
     }[]
     const existing = comments.find(
       (comment) =>
-        comment.user.login === 'github-actions[bot]' &&
+        comment.user.login === botLogin &&
         comment.user.type === 'Bot' &&
         comment.body.startsWith(COMMENT_MARKER)
     )
@@ -112,7 +116,10 @@ if (import.meta.main) {
           throw new Error(`GitHub report request failed: ${response.status}.`)
         }
         return response.json()
-      }
+      },
+      process.env.GITHUB_APP_SLUG
+        ? `${process.env.GITHUB_APP_SLUG}[bot]`
+        : 'github-actions[bot]'
     )
     console.info(`Paired performance PR comment: ${status}.`)
   }


### PR DESCRIPTION
Performance comparison comments currently appear as `github-actions[bot]`. Both publishing paths now use the Nitro Modules Bot GitHub App when configured, and identify existing comments by the app's actual bot login so subsequent reports update the correct comment.

The app token is scoped to this repository with Pull requests write permission and is created only in the trusted reporting jobs. Without the Client ID variable, publishing retains the existing GitHub Actions identity. Switching identities creates a new comment and preserves earlier comments with their original author. Bencher authentication is unchanged.

The same-repository reporter remains pinned to an immutable commit, updated here to include support for the custom author. Setup and credential rotation configuration are documented in `.github/PERFORMANCE.md`.

Validation: all 57 performance-tool tests pass; performance-tool TypeScript checks pass with the missing Bun types installed in a temporary directory; formatting and actionlint workflow checks pass (ShellCheck disabled because of existing unrelated SC2129 style warnings). The app key and installation were verified by creating a repository-scoped token, reading the PR API, and revoking the temporary token. Repository credentials are configured; the workflow change still needs merging.
