### PR TITLE
ci: try Blacksmith runners for performance benchmarks

### DIFF
--- a/.github/PERFORMANCE.md
+++ b/.github/PERFORMANCE.md
@@ -90,7 +90,14 @@ consume its new manifest. Merge the complete producer/publisher stack before rel
 there is no permanent old-schema reporting path. Existing raw app results may
 contain extra summary fields, which the raw parser ignores.
 
-## Android host requirements
+## CI runners
+
+Platform builds and measurements use Blacksmith: `blacksmith-4vcpu-ubuntu-2404`
+for Android and `blacksmith-6vcpu-macos-26` for iOS. Raw result device descriptions
+identify the requested runner tier. Preparation,
+collection and trusted publishing remain on GitHub-hosted runners. Changing
+runner hardware requires checking same-code variation again; absolute timings
+from different hosts are not evidence of a Nitro performance change.
 
 The API 36 x86_64 emulator requires KVM. CI checks `/dev/kvm`, verifies acceleration
 before boot and uses `-accel on`; it must not silently use software CPU emulation.

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -96,7 +96,7 @@ jobs:
   build-android:
     needs: prepare
     if: needs.prepare.outputs.relevant == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 40
     outputs:
       artifact_id: ${{ steps.upload.outputs.artifact-id }}
@@ -150,7 +150,7 @@ jobs:
 
   measure-android:
     needs: [prepare, build-android]
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 75
     outputs:
       artifact_id: ${{ steps.upload.outputs.artifact-id }}
@@ -213,7 +213,7 @@ jobs:
             --base-sha "$BASE_SHA" --head-sha "$HEAD_SHA"
             --output-directory performance-android
             --device-id "$(adb get-serialno)"
-            --device "Pixel 7 emulator / KVM" --os-version "Android 16 / API 36"
+            --device "Pixel 7 emulator / KVM / Blacksmith 4 vCPU" --os-version "Android 16 / API 36"
             --architecture x86_64 --toolchain "$(jq -r .toolchain apps/build.json)"
       - name: Upload Android results
         id: upload
@@ -228,7 +228,7 @@ jobs:
   build-ios:
     needs: prepare
     if: needs.prepare.outputs.relevant == 'true'
-    runs-on: macos-26
+    runs-on: blacksmith-6vcpu-macos-26
     timeout-minutes: 60
     outputs:
       artifact_id: ${{ steps.upload.outputs.artifact-id }}
@@ -281,7 +281,7 @@ jobs:
 
   measure-ios:
     needs: [prepare, build-ios]
-    runs-on: macos-26
+    runs-on: blacksmith-6vcpu-macos-26
     timeout-minutes: 90
     outputs:
       artifact_id: ${{ steps.upload.outputs.artifact-id }}
@@ -328,7 +328,7 @@ jobs:
             --build-metadata apps/build.json \
             --base-sha "$BASE_SHA" --head-sha "$HEAD_SHA" \
             --output-directory performance-ios --device-id "$DEVICE_ID" \
-            --device 'iPhone 17 Pro simulator' --os-version 'iOS 26.5' \
+            --device 'iPhone 17 Pro simulator / Blacksmith 6 vCPU' --os-version 'iOS 26.5' \
             --architecture arm64 --toolchain "$(jq -r .toolchain apps/build.json)"
       - name: Delete simulator
         if: always() && env.DEVICE_ID != ''


### PR DESCRIPTION
Try Blacksmith for the performance workflow's Android and iOS builds and measurements, to measure whether its runners improve CI duration and reduce same-code timing variation.

- Android uses `blacksmith-4vcpu-ubuntu-2404`; iOS uses `blacksmith-6vcpu-macos-26` (Apple Silicon).
- Keep API 36 / KVM, Xcode 26.5, the benchmark suite, calibration, sampling and per-case BASE → HEAD order unchanged. Both revisions still run on the same measurement host.
- Include the requested Blacksmith tier in raw result device descriptions. Preparation, collection and trusted reporting keep their existing GitHub runners.

[Blacksmith documents macOS 26 and x64 Linux nested virtualization support](https://docs.blacksmith.sh/blacksmith-runners/overview).

Validation: all 77 performance-tool tests pass; actionlint and shellcheck pass with Blacksmith's custom runner labels allowed. The [trial run, attempt 2](https://github.com/margelo/nitro/actions/runs/34117178949/attempts/2) passed all build, measurement and collection jobs. [Trusted reporting succeeded](https://github.com/margelo/nitro/actions/runs/34119683156), and [Nitro Modules Bot posted the comparison](https://github.com/margelo/nitro/pull/1614#issuecomment-5570320070).

| Job | Previous GitHub run (#1612) | Blacksmith trial |
| --- | ---: | ---: |
| Build Android | 10m01s | 5m18s |
| Build iOS | 11m03s | 4m29s |
| Measure Android | 16m17s | 14m43s |
| Measure iOS | 25m47s | 14m03s |

These are observed job durations, not a controlled hardware speedup estimate; cache and image state can differ. Both revisions were built and measured on Blacksmith, with required Android KVM and Xcode 26.5. Benchmark suite hash remains `f34d9c1f3a289bdc8f9257a57ba955d72f2ca30cb632c9fcd9a554d964674b55`.

The PR changes no Nitro implementation or benchmark code. It compares separately built base/head apps with different application IDs, not byte-identical apps. All 46 cases per platform completed with matching base/head operation and chunk counts.

| Same-code base/head differences | Android | iOS |
| --- | ---: | ---: |
| Median absolute change across cases | 1.18% | 1.09% |
| Cases with an absolute change of at least 5% | 6/46 | 7/46 |
| Largest absolute change | 60.03% | 14.33% |

The iOS observations are encouraging compared with the earlier GitHub same-binary diagnostic (median absolute change 10.22%, 33/46 cases at least 5%), but this one run does not establish reliable detection of small regressions. Android still has a large outlier: C++ `simpleFunc()` reports +60.03%, with its head samples slowing approximately 92% between the first and last five. iOS's largest corresponding within-process drift was about 6.7%. No samples were discarded or thresholds adjusted.

[Raw JSON and calibration/measurement records](https://github.com/margelo/nitro/actions/runs/34117178949/artifacts/10017659602) are attached to the successful CI run and linked from the bot comment. Existing compiler/React Native warnings remain, including the explicit-module compiler-selection warning addressed separately by #1610.

Attempt 1 was cancelled before platform jobs started, then retried after the Blacksmith installation was granted access to Nitro. The successful result is attempt 2 at `16367b7b5e3019a7489484c58c010c2893482c63`.
