### PR TITLE
perf: remove fixed benchmark startup sleep

### DIFF
--- a/apps/benchmark/src/benchmarks/BenchmarkApp.tsx
+++ b/apps/benchmark/src/benchmarks/BenchmarkApp.tsx
@@ -45,11 +45,10 @@ function isRunConfiguration(
   )
 }
 
-async function waitForRuntimeToSettle(): Promise<void> {
+async function waitForInitialFrames(): Promise<void> {
   await new Promise<void>((resolve) => {
     requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
   })
-  await new Promise<void>((resolve) => setTimeout(resolve, 1_000))
 }
 
 async function readConfiguration(): Promise<BenchmarkRunConfiguration> {
@@ -79,7 +78,7 @@ async function run(): Promise<BenchmarkRunResult> {
   const configuration = await readConfiguration()
   const environment = getBenchmarkEnvironment()
   assertReleaseBenchmarkEnvironment(environment)
-  await waitForRuntimeToSettle()
+  await waitForInitialFrames()
 
   const startedAt = new Date().toISOString()
   const start = performance.now()


### PR DESCRIPTION
Every benchmark process waits one second after its initial animation frames, without checking any readiness condition. Remove that fixed sleep and name the remaining two-frame handoff accurately. Fresh processes, warmups, operation counts, and cleanup are unchanged.

For the current 46-case paired suite this removes 138 seconds of intentional waiting per platform. In a local optimized Release simulator diagnostic, all 12 processes completed successfully; removing the sleep saved 0.96–1.32 seconds per comparison across a JavaScript control, C++ callback, and Swift buffer copy. This is a limited execution check, not proof of unchanged measurement accuracy.

Validation: 77 performance-tool tests, tool and benchmark TypeScript checks, scoped formatting, and `git diff --check`. CI provides the full-platform execution check. A suite change produces a head-only baseline under the existing workflow policy.
