### PR TITLE
perf: avoid unnecessary benchmark cleanup pauses

### DIFF
--- a/.github/PERFORMANCE.md
+++ b/.github/PERFORMANCE.md
@@ -23,7 +23,10 @@ measure and short enough to fit the job budget. Roughly 150 ms per batch is the
 initial sizing target, not a pass/fail bound or a claim of steady performance.
 Retune deliberately using representative runs; a slow head must execute all of
 the same work. Allocation-heavy cases sum bounded timed chunks with explicit
-cleanup outside timing. Raw `iterations`, `chunkIterations` and ordered
+cleanup outside timing. The eight primitive-only control, method and numeric
+property cases skip per-batch GC and native frame waits. iOS buffer copies keep
+bounded Hermes GC but skip frame waits: collecting their wrappers releases the
+owned native storage. Other allocating cases retain GC and native yields. Raw `iterations`, `chunkIterations` and ordered
 `samplesNsPerOp` describe the work. Slow samples are retained.
 
 ## Reading results

--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -72,9 +72,14 @@ Adding a case requires an explicit count. Revisit the counts when changing the
 case or device, using raw durations from representative runs; changes produce a
 new suite hash. The counts remain fixed during CI, even if a revision is slower.
 
+The eight primitive-only control, method and numeric property cases skip
+per-batch GC and frame waits. They still run in fresh processes with the same
+warmup and sample counts.
+
 Allocation-heavy cases split a sample into bounded chunks, collecting garbage
-after each chunk and yielding for native cleanup at most every four chunks,
-outside the timer. Kotlin buffer-copy and Promise cases also collect Java's heap
+after each chunk, outside the timer. iOS buffer copies use synchronous GC
+without frame waits; their wrappers release the owned native storage. Other
+allocating cases also yield for native cleanup after at most four chunks. Kotlin buffer-copy and Promise cases also collect Java's heap
 between chunks through a synchronous, benchmark-only TurboModule helper; Hermes
 GC alone cannot reclaim Java-backed direct buffers. Cleanup is excluded from
 timing. Each sample divides its accumulated timed duration by

--- a/apps/benchmark/src/benchmarks/batch.ts
+++ b/apps/benchmark/src/benchmarks/batch.ts
@@ -12,8 +12,8 @@ export const benchmarkRuntime: BenchmarkRuntime = {
     if (gc == null) throw new Error('Benchmark runtime requires Hermes gc().')
     gc()
   },
-  // RCTTiming immediately re-enqueues zero-delay timers. A positive delay goes
-  // through its next-frame path, allowing the native run loop/pools to drain.
+  // Bridgeless RN schedules this through a native frame. Returning to its
+  // run loop lets deferred native cleanup (including autorelease pools) run.
   yieldToRuntime: () => new Promise((resolve) => setTimeout(resolve, 1)),
 }
 
@@ -32,8 +32,10 @@ export async function executeBatch(
   let durationMs = 0
   let checksum = 0
   let chunksSinceYield = 0
-  runtime.collectGarbage()
-  definition.collectNativeGarbage?.()
+  if (definition.cleanup !== 'none') {
+    runtime.collectGarbage()
+    definition.collectNativeGarbage?.()
+  }
   for (
     let remaining = iterations;
     remaining > 0;
@@ -59,8 +61,10 @@ export async function executeBatch(
     }
     durationMs += elapsed
     checksum += result
+    if (definition.cleanup === 'none') continue
     runtime.collectGarbage()
     definition.collectNativeGarbage?.()
+    if (definition.cleanup === 'gc') continue
     // Drain native autorelease pools/cleaners after at most four bounded chunks.
     // A native timer yield can cost a frame; do not pay it for every tiny chunk.
     chunksSinceYield++

--- a/apps/benchmark/src/benchmarks/suite.ts
+++ b/apps/benchmark/src/benchmarks/suite.ts
@@ -93,6 +93,7 @@ function createObjectBenchmarks(
       family: 'primitive',
       implementation,
       kind: 'sync',
+      cleanup: 'none',
       expectedChecksum: sumFromOne,
       run(iterations) {
         let checksum = 0
@@ -109,6 +110,7 @@ function createObjectBenchmarks(
       family: 'primitive',
       implementation,
       kind: 'sync',
+      cleanup: 'none',
       expectedChecksum: addNumbersChecksum,
       run(iterations) {
         let checksum = 0
@@ -124,6 +126,7 @@ function createObjectBenchmarks(
       family: 'property',
       implementation,
       kind: 'sync',
+      cleanup: 'none',
       expectedChecksum: sumFromZero,
       run(iterations) {
         let checksum = 0
@@ -424,6 +427,9 @@ function createBufferBenchmark(
     family: 'array-buffer',
     implementation,
     kind: 'sync',
+    // iOS copies release their owned storage when Hermes collects the wrapper.
+    // Keep Android's existing policy, including JVM-backed Kotlin copies.
+    cleanup: operation === 'copy' && Platform.OS === 'ios' ? 'gc' : undefined,
     // Bounce does not copy the payload; its chunk bound is independent of size.
     maxChunkIterations:
       operation === 'bounce'
@@ -462,6 +468,7 @@ export function createBenchmarkSuite(): BenchmarkDefinition[] {
       family: 'control',
       implementation: 'javascript',
       kind: 'sync',
+      cleanup: 'none',
       expectedChecksum: addNumbersChecksum,
       run(iterations) {
         let checksum = 0
@@ -477,6 +484,7 @@ export function createBenchmarkSuite(): BenchmarkDefinition[] {
       family: 'control',
       implementation: 'turbo-module',
       kind: 'sync',
+      cleanup: 'none',
       expectedChecksum: addNumbersChecksum,
       run(iterations) {
         let checksum = 0

--- a/apps/benchmark/src/benchmarks/types.ts
+++ b/apps/benchmark/src/benchmarks/types.ts
@@ -24,6 +24,9 @@ interface BenchmarkDefinitionBase {
   version: number
   family: BenchmarkFamily
   implementation: BenchmarkImplementation
+  /** Default: GC and native yields. Primitive-only cases need none;
+   * synchronous native ownership can use GC without frame waits. */
+  cleanup?: 'none' | 'gc'
   /** Bound live allocations, not the total operations in a measured sample. */
   maxChunkIterations?: number
   /** Additional native-heap cleanup after Hermes GC, outside measured time. */

--- a/scripts/performance/runner.test.ts
+++ b/scripts/performance/runner.test.ts
@@ -1,9 +1,6 @@
 import { afterEach, describe, expect, spyOn, test } from 'bun:test'
 import { runBenchmarkDefinitions } from '../../apps/benchmark/src/benchmarks/runner'
-import {
-  benchmarkRuntime,
-  executeBatch,
-} from '../../apps/benchmark/src/benchmarks/batch'
+import { executeBatch } from '../../apps/benchmark/src/benchmarks/batch'
 import { getBenchmarkIterations } from '../../apps/benchmark/src/benchmarks/iterations'
 import type { BenchmarkDefinition } from '../../apps/benchmark/src/benchmarks/types'
 
@@ -28,14 +25,68 @@ function definition(expectedChecksum: (iterations: number) => number) {
 }
 
 describe('benchmark runner', () => {
-  test('uses a positive-delay native yield, not the immediate timer fast path', async () => {
-    const timer = spyOn(globalThis, 'setTimeout')
-    try {
-      await benchmarkRuntime.yieldToRuntime()
-      expect(timer.mock.calls[0]?.[1]).toBe(1)
-    } finally {
-      timer.mockRestore()
-    }
+  test('primitive-only cases perform their full work without cleanup pauses', async () => {
+    let now = 0
+    const calls: number[] = []
+    spyOn(performance, 'now').mockImplementation(() => now)
+    const [metric] = await runBenchmarkDefinitions(
+      [
+        {
+          ...definition((n) => n * 2),
+          cleanup: 'none',
+          run(n) {
+            calls.push(n)
+            now += n * 0.00002
+            return n * 2
+          },
+        },
+      ],
+      { warmupCount: 5, sampleCount: 20, reverse: false },
+      'ios',
+      {
+        collectGarbage() {
+          throw new Error('Unexpected GC')
+        },
+        async yieldToRuntime() {
+          throw new Error('Unexpected native yield')
+        },
+      }
+    )
+    expect(calls).toEqual(Array(25).fill(iterations))
+    expect(metric?.samplesNsPerOp).toHaveLength(20)
+    expect(metric?.checksum).toBe(25 * iterations * 2)
+  })
+
+  test('GC-only cases retain bounded collections without native frame waits', async () => {
+    let now = 0
+    let collections = 0
+    const chunks: number[] = []
+    spyOn(performance, 'now').mockImplementation(() => now)
+    const result = await executeBatch(
+      {
+        ...definition((n) => n * 2),
+        cleanup: 'gc',
+        maxChunkIterations: 50,
+        run(n) {
+          chunks.push(n)
+          now += n
+          return n * 2
+        },
+      },
+      120,
+      {
+        collectGarbage() {
+          collections++
+          now += 1000
+        },
+        async yieldToRuntime() {
+          throw new Error('Unexpected native yield')
+        },
+      }
+    )
+    expect(chunks).toEqual([50, 50, 20])
+    expect(collections).toBe(4)
+    expect(result).toEqual({ durationMs: 120, checksum: 240 })
   })
 
   test('samples batches with a fake clock', async () => {


### PR DESCRIPTION
Stacked on #1617.

The runner forces GC and waits for native frames even for primitive-only loops. Skip both for the eight JavaScript/TurboModule controls, C++/Swift/Kotlin primitive methods, and numeric property cases. The four iOS buffer-copy cases retain bounded synchronous Hermes GC but omit frame waits: their copied storage is released by the native buffer owner when its JS wrapper is collected. Other allocating cases, including Android copies, retain their current cleanup.

Fresh-process isolation, five warmups, twenty recorded samples, fixed operation counts, chunk bounds, and checksum validation remain unchanged. The default cleanup remains conservative; the case definition selects `none` or `gc` only for the paths validated here. The native timer comment now describes the actual bridgeless frame route.

Local Release validation ran all twelve affected iOS cases with both policies, twice in opposite order: **48 fresh processes, all successful**, with externally sampled process RSS. This used the larger initial counts from f41f8cde0; #1617 subsequently resized counts for the GitHub runners on main. These timings describe the heavier diagnostic workload, not a prediction for the final CI duration. Average results for the buffer-copy processes:

| Case | Previous duration | GC only | Previous peak RSS | GC-only peak RSS |
|---|---:|---:|---:|---:|
| C++ copy 4 KiB | 7.43 s | 5.34 s | 633 MiB | 641 MiB |
| C++ copy 1 MiB | 10.39 s | 5.39 s | 178 MiB | 178 MiB |
| Swift copy 4 KiB | 7.98 s | 6.36 s | 662 MiB | 654 MiB |
| Swift copy 1 MiB | 14.08 s | 7.24 s | 180 MiB | 180 MiB |

The eight primitive-only cases saved 0.49–0.75 seconds per process with comparable peak RSS around 164 MiB. These are local process-duration observations, not claims of improved Nitro operation performance or statistical confidence. Existing runtime bookkeeping growth and timing drift in small-buffer cases remain; the new policy did not eliminate them. Android allocating cases were not profiled and are unchanged.

Validation: 73 performance-tool tests, benchmark/tool TypeScript checks, benchmark lint, and diff checks. Tests verify full workloads with no cleanup, bounded GC without frame waits, retained default cleanup, checksum/timing boundaries, and fresh process sequencing. The initial pilot overlapped local receiver tests and was discarded; the 48 runs above were repeated in isolation. CI builds and executes the final source on both platforms.

Like #1617, the new raw schema requires its trusted publisher changes to reach main before a report comment can be posted. CI retains the raw artifacts during review.

Final CI at a2f098489: [run 34132511579](https://github.com/margelo/nitro/actions/runs/34132511579) passed both builds, both measurement jobs and aggregation; lint, TypeScript and Nitrogen checks also passed. The measurement jobs took 7m05s on Android and 9m57s on iOS. These are head-only baselines because the suite changed, not a timing estimate for a full base/head comparison. All 46 cases per platform returned twenty finite samples and the checked-in iteration counts. The median batch durations were 148.9 ms on Android and 120.1 ms on iOS. Existing drift remains visible in several cases.

The [raw JSON artifact](https://github.com/margelo/nitro/actions/runs/34132511579/artifacts/10023199185) also passed this stack's trusted report validator locally using GitHub run, PR and immutable artifact metadata. The default-branch publishing run rejected raw schema 2 as expected; it needs #1617 merged before publishing these results.
