### PR TITLE
perf: report benchmark changes by ID

### DIFF
--- a/.github/PERFORMANCE.md
+++ b/.github/PERFORMANCE.md
@@ -1,17 +1,17 @@
 # Release performance CI
 
 `Nitro Performance` builds the dedicated `apps/benchmark` Release/Hermes app.
-Each platform installs base and head side by side on the same machine. For each
-benchmark it measures base, then head immediately, before moving to the next
-benchmark. There is one AB pair, with five warmup batches and twenty measured
+Each platform installs base and head side by side on the same machine. It
+alternates base and head in each app's suite order, then finishes any remaining
+cases in the longer suite. With the same case order, each function runs back to back. There is one AB pair, with five warmup batches and twenty measured
 batches per process. Each case gets a fresh app process; installation, startup,
 transport and process restarts are outside timing. There is no automatic third
 pair. Manual reruns are retained as identifiable workflow attempts.
 
 Each case uses checked-in operation counts from
 [`iterations.ts`](../apps/benchmark/src/benchmarks/iterations.ts), separately for
-Android and iOS. Both revisions execute identical counts and chunk sizes; the
-comparison rejects unequal work. The initial counts are rounded to two significant digits from the measured
+Android and iOS. Each revision uses its own checked-in counts and chunk sizes.
+Timings are divided by the operation count before comparison. The initial counts are rounded to two significant digits from the measured
 medians in [GitHub run 34125332141, attempt 1](https://github.com/margelo/nitro/actions/runs/34125332141/attempts/1),
 using `150,000,000 ns / median ns per operation`.
 CI does not calibrate or adjust counts from observed speed. A new case requires
@@ -21,8 +21,8 @@ Review counts when changing the case or testbed. Use the raw batch duration
 (`ns/op * iterations / 1e6`) to check whether batches remain long enough to
 measure and short enough to fit the job budget. Roughly 150 ms per batch is the
 initial sizing target, not a pass/fail bound or a claim of steady performance.
-Retune deliberately using representative runs; a slow head must execute all of
-the same work. Allocation-heavy cases sum bounded timed chunks with explicit
+Retune deliberately using representative runs; a slow head still executes all
+its configured work. Allocation-heavy cases sum bounded timed chunks with explicit
 cleanup outside timing. The eight primitive-only control, method and numeric
 property cases skip per-batch GC and native frame waits. iOS buffer copies keep
 bounded Hermes GC but skip frame waits: collecting their wrappers releases the
@@ -34,8 +34,8 @@ owned native storage. Other allocating cases retain GC and native yields. Raw `i
 The main score is the median (p50) of batch averages in ns/op, not individual-call
 tail latency. The report shows every observed change of at least 5%, including
 Promise cases. This is a presentation threshold, not a calibrated regression
-budget. Expand the report for all metrics, individual process medians, matched
-pair changes, and sample MAD relative to p50. Matching pooled medians do not prove
+budget. Expand the report for the remaining metrics; the raw JSON retains all
+samples. Matching pooled medians do not prove
 equal performance. One pair cannot establish repeatability between launches or justify confidence
 intervals. Repeat measurement jobs or same-revision runs to investigate variation.
 
@@ -44,16 +44,20 @@ failures still fail CI. Turning observed differences into a regression gate need
 empirical validation on unchanged commits and intentional slowdowns on each
 unchanged suite/testbed. No Promise case is permanently exempt. Scheduled/manual
 runs with the same base and head SHA measure baseline variation explicitly.
-Changed benchmark definitions run one head-only measurement per case as a new baseline,
-without executing the old base app or publishing an invented paired baseline.
-This also handles the first rollout of a new runner protocol.
+Reports match results by benchmark ID, regardless of suite hashes, case order,
+versions, iteration counts or runner settings. New cases show their head timing
+as **⭐️ New**; removed cases retain their base timing with **❌ Removed** after.
+Changes to a benchmark or measurement method can affect its reported difference;
+the PR author interprets those changes. Suite hashes identify source code in
+artifacts, rather than deciding which results may be compared.
 
 ## Saved apps and measurement reruns
 
 The workflow separates preparation, platform builds, platform measurements and
 collection. Each measurement job downloads the immutable app artifact ID produced
-by its build job; base and head still run together on one machine. A changed suite
-builds only head. An identical base/head SHA reuses the same binary for both sides.
+by its build job; base and head still run together on one machine. Both revisions
+are built even when benchmark definitions change. An identical base/head SHA
+reuses the same binary for both sides.
 Otherwise each revision is built from its own checkout with the same build script.
 Base uses `com.margelo.nitrobenchmark`; head uses `com.margelo.nitrobenchmark.head`.
 Android keeps its Java namespace and fully qualified activity name unchanged.
@@ -70,7 +74,7 @@ The app artifact includes base/head SHAs, suite hashes, Release configuration,
 architecture and toolchain metadata. iOS apps are tar archives to preserve
 permissions and symlinks. Gradle's basic cache is the sole Android cache owner;
 Gradle still checks source/task inputs, while exact app reuse is by artifact ID.
-There is no new iOS compiler cache. App reuse avoids build work on manual reruns. With 46 cases, a comparable suite
+There is no new iOS compiler cache. App reuse avoids build work on manual reruns. With 46 cases in each revision, a run
 uses 92 fresh processes (46 base + 46 head).
 Closer comparisons reduce time separation, but fixed base-first order can still
 introduce bias; same-revision runs are needed to assess that on each testbed.

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -134,7 +134,7 @@ jobs:
           cp head/apps/benchmark/android/app/build/outputs/apk/release/app-release.apk apps/head.apk
           if [[ "$(jq -r .baseSha apps/build.json)" == "$(jq -r .headSha apps/build.json)" ]]; then
             cp apps/head.apk apps/base.apk
-          elif [[ "$(jq -r .baseSuiteHash apps/build.json)" == "$(jq -r .headSuiteHash apps/build.json)" ]]; then
+          else
             bash head/scripts/performance/build-android.sh "$GITHUB_WORKSPACE/base"
             cp base/apps/benchmark/android/app/build/outputs/apk/release/app-release.apk apps/base.apk
           fi
@@ -265,7 +265,7 @@ jobs:
           tar -czf apps/head.app.tar.gz -C head/apps/benchmark/ios/build-benchmark/Build/Products/Release-iphonesimulator NitroBenchmark.app
           if [[ "$(jq -r .baseSha apps/build.json)" == "$(jq -r .headSha apps/build.json)" ]]; then
             cp apps/head.app.tar.gz apps/base.app.tar.gz
-          elif [[ "$(jq -r .baseSuiteHash apps/build.json)" == "$(jq -r .headSuiteHash apps/build.json)" ]]; then
+          else
             bash head/scripts/performance/build-ios.sh "$GITHUB_WORKSPACE/base"
             tar -czf apps/base.app.tar.gz -C base/apps/benchmark/ios/build-benchmark/Build/Products/Release-iphonesimulator NitroBenchmark.app
           fi

--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -52,7 +52,10 @@ and assembles their results. This releases Nitro's runtime-scoped JSI reference
 bookkeeping between cases; GC alone cannot clear that cache. Each process posts
 one result only after its timing is complete. Per-case raw results are kept beside
 the combined output in `base-1-cases/` and `head-1-cases/` directories.
-For each case, base and head run back to back. Identical SHAs reuse one installed binary. Startup, transport, and process restarts are not timed.
+Base and head launches alternate in each app's suite order; the report matches
+results by ID even when cases move, appear or disappear. With the same case order,
+each function runs back to back. Identical SHAs reuse one installed binary.
+Startup, transport, and process restarts are not timed.
 For iOS, use `--platform ios`, a simulator UDID for `--device-id`, and the built
 `NitroBenchmark.app` for `--base-app` and `--head-app`, with matching
 simulator/toolchain metadata.
@@ -65,12 +68,14 @@ Each metric has fixed Android/iOS counts in
 [`iterations.ts`](src/benchmarks/iterations.ts), seeded from the existing
 GitHub-runner results with roughly 150 ms of timed work per sample. There is no
 calibration process. Each measurement process performs five warmup batches and
-twenty samples. Both revisions share the checked-in count and chunk size for
+twenty samples. Each revision uses its own checked-in count and chunk size for
 each case. Slow samples are retained without shortening the work.
 
 Adding a case requires an explicit count. Revisit the counts when changing the
-case or device, using raw durations from representative runs; changes produce a
-new suite hash. The counts remain fixed during CI, even if a revision is slower.
+case or device, using raw durations from representative runs. The counts remain
+fixed during CI, even if a revision is slower. Changing a count or test definition
+does not disable comparisons; the report uses per-operation timings, and the PR
+author interprets any measurement changes.
 
 The eight primitive-only control, method and numeric property cases skip
 per-batch GC and frame waits. They still run in fresh processes with the same
@@ -97,9 +102,10 @@ the timed batch. Operation-induced allocations remain inside it.
 See [performance CI](../../.github/PERFORMANCE.md) for observed comparisons,
 process variability, raw artifacts, trusted reporting, and Bencher publishing.
 CI retains exact app artifacts for measurement-only reruns. It builds both
-revisions when comparable, reuses one binary for identical SHAs, and builds only
-head when definitions changed. Same-revision scheduled/manual runs show baseline
-variation. Performance remains report-only.
+revisions even when definitions change, and reuses one binary for identical SHAs.
+New and removed cases stay visible in the table without a percentage comparison.
+Same-revision scheduled/manual runs show baseline variation. Performance remains
+report-only.
 
 The example's former benchmark screen and TurboModule control have moved here.
 No public Nitro API changes are needed. App dependency versions initially match

--- a/scripts/performance/build-artifacts.test.ts
+++ b/scripts/performance/build-artifacts.test.ts
@@ -12,7 +12,7 @@ import os from 'node:os'
 import path from 'node:path'
 
 // Execute the real packaging/selection steps with tiny stand-ins for native
-// compilers. This checks missing-base handling and tar permissions/symlinks.
+// compilers. This checks both-revision builds and tar permissions/symlinks.
 for (const platform of ['android', 'ios'] as const) {
   test.each(['paired', 'same-sha', 'changed-suite'])(
     `${platform} app artifacts preserve exact build selection: %s`,
@@ -94,7 +94,7 @@ fi
         expect(
           (await Bun.file(path.join(root, 'builds')).text()).trim().split('\n')
         ).toEqual(
-          mode === 'paired'
+          mode !== 'same-sha'
             ? [
                 'head com.margelo.nitrobenchmark.head',
                 'base com.margelo.nitrobenchmark',
@@ -105,7 +105,7 @@ fi
           root,
           `apps/base.${platform === 'ios' ? 'app.tar.gz' : 'apk'}`
         )
-        expect(await Bun.file(base).exists()).toBe(mode !== 'changed-suite')
+        expect(await Bun.file(base).exists()).toBe(true)
         if (platform === 'ios') {
           const unpack = path.join(root, 'unpacked')
           await mkdir(unpack)

--- a/scripts/performance/comparison.test.ts
+++ b/scripts/performance/comparison.test.ts
@@ -94,20 +94,45 @@ describe('performance comparison', () => {
     })
   })
 
-  test('does not compare changed benchmark definitions', () => {
-    expect(
-      compareRuns(
-        [run(BASE_SHA, [100])],
-        [run(HEAD_SHA, [100], 'd'.repeat(64))]
-      ).suiteComparable
-    ).toBe(false)
-  })
-  test('rejects unequal work and missing samples even if timings look identical', () => {
+  test('compares normalized timings even when the benchmark or runner changes', () => {
     const base = run(BASE_SHA, [100, 100])
+    const head = run(HEAD_SHA, [100, 100, 100], 'd'.repeat(64))
+    head.runner.warmupCount = 10
+    head.metrics[0]!.iterations = 20_000
+    head.metrics[0]!.chunkIterations = 5_000
+    head.metrics[0]!.version++
+    expect(compareRuns([base], [head]).comparisons[0]?.deltaPercent).toBe(0)
+    head.metrics[0]!.samplesNsPerOp = [200, 200, 200]
+    expect(compareRuns([base], [head]).comparisons[0]?.deltaPercent).toBe(100)
+  })
+
+  test('matches reordered cases by ID and retains new and removed timings', () => {
+    const base = run(BASE_SHA, [100, 100])
+    const head = run(HEAD_SHA, [120, 120], 'd'.repeat(64))
+    base.metrics.push({ ...base.metrics[0]!, id: 'removed' })
+    head.metrics.unshift({ ...head.metrics[0]!, id: 'new' })
+    base.benchmarkCount = head.benchmarkCount = 2
+    const metrics = compareRuns([base], [head]).comparisons
+    expect(
+      metrics.map(({ id, baseMedianNsPerOp, headMedianNsPerOp }) => [
+        id,
+        baseMedianNsPerOp,
+        headMedianNsPerOp,
+      ])
+    ).toEqual([
+      ['new', null, 120],
+      ['nitro-cpp/primitive/add-numbers', 100, 120],
+      ['removed', 100, null],
+    ])
+    expect(metrics[0]?.deltaPercent).toBeNull()
+    expect(metrics[1]?.deltaPercent).toBeCloseTo(20)
+    expect(metrics[2]?.deltaPercent).toBeNull()
+    expect(metrics[0]?.pairChangesPercent).toEqual([])
+    expect(metrics[2]?.pairChangesPercent).toEqual([])
+  })
+
+  test('still rejects missing samples', () => {
     const head = run(HEAD_SHA, [100, 100])
-    head.metrics[0]!.iterations = 9_000
-    expect(() => compareRuns([base], [head])).toThrow('unequal work')
-    head.metrics[0]!.iterations = base.metrics[0]!.iterations
     head.metrics[0]!.samplesNsPerOp = []
     expect(() => validateBenchmarkRun(head)).toThrow('Sample count')
   })

--- a/scripts/performance/comparison.ts
+++ b/scripts/performance/comparison.ts
@@ -12,13 +12,13 @@ export const REPORTING_THRESHOLD_PERCENT = 5
 
 export interface MetricComparison {
   id: string
-  baseMedianNsPerOp: number
-  headMedianNsPerOp: number
-  deltaPercent: number
+  baseMedianNsPerOp: number | null
+  headMedianNsPerOp: number | null
+  deltaPercent: number | null
   baseProcessMedians: number[]
   headProcessMedians: number[]
-  baseMadPercent: number
-  headMadPercent: number
+  baseMadPercent: number | null
+  headMadPercent: number | null
   pairChangesPercent: number[]
 }
 
@@ -26,7 +26,6 @@ export interface PlatformComparison {
   platform: 'android' | 'ios'
   baseSha: string
   headSha: string
-  suiteComparable: boolean
   comparisons: MetricComparison[]
 }
 
@@ -51,7 +50,7 @@ export function compareRuns(
   if (baseRuns.length === 0 || baseRuns.length !== headRuns.length) {
     throw new Error('A matching base run is required for every head run.')
   }
-  const { platform, commitSha: baseSha, suiteHash } = baseRuns[0]!.configuration
+  const { platform, commitSha: baseSha } = baseRuns[0]!.configuration
   const headSha = headRuns[0]!.configuration.commitSha
   for (const [runs, sha] of [
     [baseRuns, baseSha],
@@ -78,58 +77,29 @@ export function compareRuns(
       if (run.configuration[key] !== first.configuration[key])
         throw new Error(`Process runs have different ${key} settings.`)
     }
-    if (
-      JSON.stringify(run.runner) !== JSON.stringify(first.runner) ||
-      JSON.stringify(run.environment) !== JSON.stringify(first.environment)
-    ) {
-      throw new Error('Process runs have different runtime settings.')
-    }
   }
-  const suiteComparable = [...baseRuns, ...headRuns].every(
-    (run) => run.configuration.suiteHash === suiteHash
-  )
   const comparison: PlatformComparison = {
     platform,
     baseSha,
     headSha,
-    suiteComparable,
     comparisons: [],
   }
-  if (!suiteComparable) return comparison
-
   const baseMetrics = indexMetrics(baseRuns)
   const headMetrics = indexMetrics(headRuns)
-  if (
-    baseMetrics.size !== headMetrics.size ||
-    [...baseMetrics.keys()].some((id) => !headMetrics.has(id))
-  ) {
-    throw new Error('Base and head expose different benchmark IDs.')
-  }
-  for (const id of [...baseMetrics.keys()].sort()) {
-    const base = baseMetrics.get(id)!
-    const head = headMetrics.get(id)!
+  const ids = new Set([...baseMetrics.keys(), ...headMetrics.keys()])
+  for (const id of [...ids].sort()) {
+    const base = baseMetrics.get(id) ?? []
+    const head = headMetrics.get(id) ?? []
     if (
-      base.length !== baseRuns.length ||
-      head.length !== headRuns.length ||
-      [...base, ...head].some((metric) => metric.version !== base[0]!.version)
+      (base.length !== 0 && base.length !== baseRuns.length) ||
+      (head.length !== 0 && head.length !== headRuns.length)
     ) {
-      throw new Error(`Benchmark ${id} is missing or has a different version.`)
-    }
-    if (
-      [...base, ...head].some(
-        (metric) =>
-          metric.iterations !== base[0]!.iterations ||
-          metric.chunkIterations !== base[0]!.chunkIterations
-      )
-    ) {
-      throw new Error(
-        `Benchmark ${id} executed unequal work between process runs.`
-      )
+      throw new Error(`Benchmark ${id} is missing from a repeated process run.`)
     }
     const baseSamples = base.flatMap((metric) => metric.samplesNsPerOp)
     const headSamples = head.flatMap((metric) => metric.samplesNsPerOp)
-    const baseMedian = median(baseSamples)
-    const headMedian = median(headSamples)
+    const baseMedian = base.length === 0 ? null : median(baseSamples)
+    const headMedian = head.length === 0 ? null : median(headSamples)
     const baseProcessMedians = base.map((metric) =>
       median(metric.samplesNsPerOp)
     )
@@ -140,14 +110,26 @@ export function compareRuns(
       id,
       baseMedianNsPerOp: baseMedian,
       headMedianNsPerOp: headMedian,
-      deltaPercent: (headMedian / baseMedian - 1) * 100,
+      deltaPercent:
+        baseMedian === null || headMedian === null
+          ? null
+          : (headMedian / baseMedian - 1) * 100,
       baseProcessMedians,
       headProcessMedians,
-      baseMadPercent: (medianAbsoluteDeviation(baseSamples) / baseMedian) * 100,
-      headMadPercent: (medianAbsoluteDeviation(headSamples) / headMedian) * 100,
-      pairChangesPercent: headProcessMedians.map(
-        (value, index) => (value / baseProcessMedians[index]! - 1) * 100
-      ),
+      baseMadPercent:
+        baseMedian === null
+          ? null
+          : (medianAbsoluteDeviation(baseSamples) / baseMedian) * 100,
+      headMadPercent:
+        headMedian === null
+          ? null
+          : (medianAbsoluteDeviation(headSamples) / headMedian) * 100,
+      pairChangesPercent:
+        baseMedian === null || headMedian === null
+          ? []
+          : headProcessMedians.map(
+              (value, index) => (value / baseProcessMedians[index]! - 1) * 100
+            ),
     })
   }
   return comparison

--- a/scripts/performance/publish.test.ts
+++ b/scripts/performance/publish.test.ts
@@ -86,14 +86,16 @@ describe('Bencher publications', () => {
       bencherArguments(main, 'ios', 'base', '/validated', 'nitro')
     ).toThrow()
   })
-  test('a changed suite records head without an invented paired baseline', () => {
+  test('a changed suite publishes both measured revisions', () => {
     const changed = { ...metadata, headSuiteHash: 'd'.repeat(64) }
     const publications = bencherPublications(changed, '/validated', 'nitro')
     expect(publications.map((entry) => entry.revision)).toEqual([
+      'base',
+      'base',
       'head',
       'head',
     ])
-    expect(publications.flatMap((entry) => entry.command)).not.toContain(
+    expect(publications.flatMap((entry) => entry.command)).toContain(
       '--start-point'
     )
   })

--- a/scripts/performance/publish.ts
+++ b/scripts/performance/publish.ts
@@ -17,8 +17,7 @@ export function bencherArguments(
 ): string[] {
   const baselineBranch = `baseline-${metadata.baseSha}`
   const isBase = revision === 'base'
-  const comparable = metadata.baseSuiteHash === metadata.headSuiteHash
-  if (isBase && (metadata.pullRequestNumber == null || !comparable)) {
+  if (isBase && metadata.pullRequestNumber == null) {
     throw new Error('Only PR reports need a paired baseline upload.')
   }
   const command = [
@@ -41,7 +40,7 @@ export function bencherArguments(
     '--file',
     path.join(directory, `bencher-${isBase ? 'base-' : ''}${platform}.json`),
   ]
-  if (!isBase && metadata.pullRequestNumber != null && comparable) {
+  if (!isBase && metadata.pullRequestNumber != null) {
     command.push(
       '--start-point',
       baselineBranch,
@@ -58,8 +57,7 @@ export function bencherPublications(
   project: string
 ) {
   const revisions =
-    metadata.pullRequestNumber == null ||
-    metadata.baseSuiteHash !== metadata.headSuiteHash
+    metadata.pullRequestNumber == null
       ? (['head'] as const)
       : (['base', 'head'] as const)
   // Seed every testbed before creating the PR branch. Never reset that branch

--- a/scripts/performance/report-markdown.test.ts
+++ b/scripts/performance/report-markdown.test.ts
@@ -31,11 +31,8 @@ function metric(
     pairChangesPercent: pairs,
   }
 }
-function report(
-  metrics: MetricComparison[],
-  suiteComparable = true
-): PlatformComparison {
-  return { platform: 'ios', ...options, suiteComparable, comparisons: metrics }
+function report(metrics: MetricComparison[]): PlatformComparison {
+  return { platform: 'ios', ...options, comparisons: metrics }
 }
 
 test('restores the original table, emphasis, colors, disclosure, and footer', () => {
@@ -147,9 +144,7 @@ test.each([
   expect(text.match(/<code>addNumbers\(\)<\/code>/g)).toHaveLength(1)
   expect(text).not.toMatch(/unchanged|equal performance|decisive|calibrat/)
   if (visible) {
-    expect(collapsed).toContain(
-      `Every benchmark reached the ${REPORTING_THRESHOLD_PERCENT}% reporting threshold.`
-    )
+    expect(collapsed).toContain('All benchmarks are shown above.')
   } else {
     expect(main).toContain(
       `No observed change reached the ${REPORTING_THRESHOLD_PERCENT}% reporting threshold.`
@@ -201,15 +196,35 @@ test('keeps iOS before Android and preserves names, escaping, and time units', (
   expect(text).toContain('<code>a-&lt;b&gt;&amp;&quot;&#39;()</code>')
 })
 
-test('same revision and changed suites are explicit', () => {
-  const changedSuite = renderPerformanceReportMarkdown(
-    [report([], false)],
+test('new and removed cases stay visible with no invented percentage change', () => {
+  const text = renderPerformanceReportMarkdown(
+    [
+      report([
+        {
+          ...metric('javascript/control/new-case', 0),
+          baseMedianNsPerOp: null,
+          deltaPercent: null,
+        },
+        {
+          ...metric('javascript/control/removed-case', 0),
+          headMedianNsPerOp: null,
+          deltaPercent: null,
+        },
+      ]),
+    ],
     options
   )
-  expect(changedSuite).toContain(
-    '> Benchmark definitions changed in this PR. Results require a new baseline and are not compared.'
-  )
-  expect(changedSuite).not.toContain('<table>')
+  const [main] = text.split('<details>')
+  expect(main).toContain('<code>newCase()</code>')
+  expect(main).toContain('<td align="right">—</td>')
+  expect(main).toContain('<td align="right">⭐️ New (100.0 ns)</td>')
+  expect(main).toContain('<code>removedCase()</code>')
+  expect(main).toContain('<td align="right">100.0 ns</td>')
+  expect(main).toContain('<td align="right">❌ Removed</td>')
+  expect(main).not.toMatch(/slower|faster|baseline|definitions changed/)
+})
+
+test('same-revision runs remain explicit', () => {
   expect(
     renderPerformanceReportMarkdown([], {
       ...options,

--- a/scripts/performance/report-markdown.ts
+++ b/scripts/performance/report-markdown.ts
@@ -90,6 +90,7 @@ function directionalChange(deltaPercent: number): string {
 }
 
 function difference(metric: MetricComparison): string {
+  if (metric.deltaPercent === null) return '—'
   if (metric.deltaPercent > 0)
     return `🔴 ${directionalChange(metric.deltaPercent)}`
   if (metric.deltaPercent < 0)
@@ -104,8 +105,11 @@ function measurement(
   const before = metric.baseMedianNsPerOp
   const after = metric.headMedianNsPerOp
   const value = revision === 'base' ? before : after
-  const isFaster = revision === 'base' ? before < after : after < before
+  if (value === null) return revision === 'base' ? '—' : '❌ Removed'
   const formatted = formatNumber(value)
+  if (before === null) return `⭐️ New (${formatted})`
+  const isFaster =
+    after !== null && (revision === 'base' ? before < after : after < before)
   return isFaster ? `<strong>${formatted}</strong>` : formatted
 }
 
@@ -171,17 +175,15 @@ export function renderPerformanceReportMarkdown(
     b.platform.localeCompare(a.platform)
   )) {
     lines.push('', `### ${platformName(platform.platform)}`, '')
-    if (!platform.suiteComparable) {
-      lines.push(
-        '> Benchmark definitions changed in this PR. Results require a new baseline and are not compared.'
-      )
-      continue
-    }
     const changed = platform.comparisons.filter(
-      (metric) => Math.abs(metric.deltaPercent) >= REPORTING_THRESHOLD_PERCENT
+      (metric) =>
+        metric.deltaPercent === null ||
+        Math.abs(metric.deltaPercent) >= REPORTING_THRESHOLD_PERCENT
     )
     const other = platform.comparisons.filter(
-      (metric) => Math.abs(metric.deltaPercent) < REPORTING_THRESHOLD_PERCENT
+      (metric) =>
+        metric.deltaPercent !== null &&
+        Math.abs(metric.deltaPercent) < REPORTING_THRESHOLD_PERCENT
     )
     lines.push(
       changed.length === 0
@@ -191,7 +193,7 @@ export function renderPerformanceReportMarkdown(
       '<details>',
       '  <summary>All Benchmarks</summary>',
       other.length === 0
-        ? `  <p>Every benchmark reached the ${REPORTING_THRESHOLD_PERCENT}% reporting threshold.</p>`
+        ? '  <p>All benchmarks are shown above.</p>'
         : renderMetricTable(other, platform.platform, 2),
       '</details>'
     )

--- a/scripts/performance/report-validation.test.ts
+++ b/scripts/performance/report-validation.test.ts
@@ -290,48 +290,73 @@ describe('trusted performance report validation', () => {
       await rm(root, { recursive: true, force: true })
     }
   })
-  test('changed suites accept a head-only baseline; comparable suites require base', async () => {
+  test('changed suites compare shared IDs and report new and removed cases', async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-performance-'))
     try {
       const fixture = await createFixture(root)
-      for (const platform of ['android', 'ios']) {
-        await rm(path.join(fixture.artifact, 'raw', platform, 'base-1.json'))
-      }
-      expect((await validate(fixture)).exitCode).not.toBe(0)
       const file = path.join(fixture.artifact, 'performance-report.json')
-      const manifest = JSON.parse(await readFile(file, 'utf8'))
-      manifest.baseSuiteHash = 'd'.repeat(64)
-      for (const platform of ['android', 'ios']) {
-        const buildFile = path.join(
-          fixture.artifact,
-          'raw',
-          platform,
-          'build.json'
-        )
-        const build = await Bun.file(buildFile).json()
-        build.baseSuiteHash = manifest.baseSuiteHash
-        await writeJson(buildFile, build)
-      }
+      const manifest = await Bun.file(file).json()
+      manifest.headSuiteHash = 'd'.repeat(64)
       await writeJson(file, manifest)
-      expect((await validate(fixture)).exitCode).toBe(0)
-      expect(
-        await readFile(
-          path.join(fixture.output, 'performance-summary.md'),
-          'utf8'
-        )
-      ).toContain('require a new baseline')
+      for (const platform of ['android', 'ios']) {
+        const directory = path.join(fixture.artifact, 'raw', platform)
+        const buildFile = path.join(directory, 'build.json')
+        const build = await Bun.file(buildFile).json()
+        build.headSuiteHash = manifest.headSuiteHash
+        await writeJson(buildFile, build)
+        const baseFile = path.join(directory, 'base-1.json')
+        const base = await Bun.file(baseFile).json()
+        base.metrics.push({
+          ...base.metrics[0],
+          id: 'nitro-cpp/primitive/removed-case',
+        })
+        base.benchmarkCount = 2
+        await writeJson(baseFile, base)
+        const headFile = path.join(directory, 'head-1.json')
+        const head = await Bun.file(headFile).json()
+        head.configuration.suiteHash = manifest.headSuiteHash
+        head.runner = { warmupCount: 10, sampleCount: 10 }
+        head.metrics[0].samplesNsPerOp = Array(10).fill(120)
+        head.metrics[0].iterations *= 2
+        head.metrics[0].version++
+        head.metrics.unshift({
+          ...head.metrics[0],
+          id: 'nitro-cpp/primitive/new-case',
+        })
+        head.benchmarkCount = 2
+        await writeJson(headFile, head)
+      }
+      expect(await validate(fixture)).toEqual({ exitCode: 0, error: '' })
+      const markdown = await Bun.file(
+        path.join(fixture.output, 'performance-summary.md')
+      ).text()
+      expect(markdown).toContain('🔴 +20% slower')
+      expect(markdown).toContain('⭐️ New (120.0 ns)')
+      expect(markdown).toContain('❌ Removed')
+      expect(markdown).not.toContain('require a new baseline')
       expect(
         await Bun.file(
           path.join(fixture.output, 'bencher-base-ios.json')
         ).exists()
-      ).toBe(false)
+      ).toBe(true)
+
+      // Suite changes cannot excuse a missing or duplicated process artifact.
+      const baseFile = path.join(fixture.artifact, 'raw/ios/base-1.json')
+      const base = await Bun.file(baseFile).json()
+      await rm(baseFile)
+      expect((await validate(fixture)).error).toContain(
+        'Expected one ios base run'
+      )
+      await writeJson(baseFile, base)
       await writeJson(
         path.join(fixture.artifact, 'raw/ios/head-2.json'),
         await Bun.file(
           path.join(fixture.artifact, 'raw/ios/head-1.json')
         ).json()
       )
-      expect((await validate(fixture)).error).toContain('Expected one')
+      expect((await validate(fixture)).error).toContain(
+        'Expected one ios head run'
+      )
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/scripts/performance/run-sequence.test.ts
+++ b/scripts/performance/run-sequence.test.ts
@@ -3,6 +3,7 @@ import { chmod, mkdir, mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { calculateSuiteHash } from './suite-hash'
+import { compareRuns } from './comparison'
 
 // Exercise the real controller/receiver with a tiny process standing in for
 // simctl's app. Runner tests separately exercise fixed work across different execution speeds.
@@ -10,15 +11,30 @@ test.each([
   ['ios', 'paired', false],
   ['ios', 'paired', true],
   ['ios', 'changed-suite', true],
+  ['ios', 'added-case', true],
+  ['ios', 'removed-case', true],
   ['ios', 'same-sha', true],
   ['android', 'paired', true],
   ['android', 'same-sha', true],
   ['android', 'changed-suite', true],
+  ['android', 'added-case', true],
+  ['android', 'removed-case', true],
   ['ios', 'invalid-result', true],
 ] as const)(
   '%s per-case comparisons: %s, saved apps = %s',
   async (platform, mode, savedApps) => {
-    const changedSuite = mode === 'changed-suite'
+    const changedSuite = [
+      'changed-suite',
+      'added-case',
+      'removed-case',
+    ].includes(mode)
+    const baseIds = ['javascript/control/first', 'javascript/control/second']
+    const headIds =
+      mode === 'added-case'
+        ? [baseIds[1]!, 'javascript/control/new', baseIds[0]!]
+        : mode === 'removed-case'
+          ? [baseIds[1]!]
+          : baseIds
     const sameBinary = mode === 'same-sha'
     const headSha = sameBinary ? 'a'.repeat(40) : 'b'.repeat(40)
     const directory = await mkdtemp(path.join(os.tmpdir(), 'nitro-sequence-'))
@@ -29,10 +45,11 @@ test.each([
         `
       import { appendFile } from 'node:fs/promises'
       const configuration = await (await fetch('http://127.0.0.1:8173/config')).json()
-      if (process.env.CHANGED_SUITE === 'true' && configuration.commitSha.startsWith('a')) throw new Error('Old base must not receive the new protocol.')
-      const index = configuration.reverse ? 1 - configuration.benchmarkIndex : configuration.benchmarkIndex
-      const id = ['javascript/control/first', 'javascript/control/second'][index]
-      const work = { id, iterations: [1000, 500][index], chunkIterations: [250, 100][index] }
+      const ids = JSON.parse(process.env[configuration.runId.includes('-head-') ? 'HEAD_IDS' : 'BASE_IDS'])
+      const index = configuration.reverse ? ids.length - 1 - configuration.benchmarkIndex : configuration.benchmarkIndex
+      const id = ids[index]
+      if (id == null) throw new Error("Requested case outside this app's suite")
+      const work = { id, iterations: id.endsWith('/first') ? 1000 : 500, chunkIterations: id.endsWith('/first') ? 250 : 100 }
       const appId = process.argv[2]
       const expectedId = process.env.SAME_BINARY === 'true' || configuration.runId.includes('-head-') ? 'com.margelo.nitrobenchmark.head' : 'com.margelo.nitrobenchmark'
       if (appId !== expectedId) throw new Error('Launched the wrong app: ' + appId)
@@ -40,7 +57,7 @@ test.each([
       const count = 20
       const response = await fetch('http://127.0.0.1:8173/result', {
         method: 'POST', body: JSON.stringify({
-          schemaVersion: 2, suiteVersion: 1, benchmarkCount: 2, configuration,
+          schemaVersion: 2, suiteVersion: 1, benchmarkCount: ids.length, configuration,
           environment: { reactNativeVersion: '0.85.3', hermes: true, dev: false, nitroBuildType: 'release' },
           runner: { warmupCount: 5, sampleCount: count },
           startedAt: new Date().toISOString(), durationMs: 100,
@@ -149,7 +166,8 @@ test.each([
             GITHUB_RUN_ID: '123',
             GITHUB_RUN_ATTEMPT: '2',
             BUILD_ARTIFACT_ID: '456',
-            CHANGED_SUITE: String(changedSuite),
+            BASE_IDS: JSON.stringify(baseIds),
+            HEAD_IDS: JSON.stringify(headIds),
           },
           stdout: 'pipe',
           stderr: 'pipe',
@@ -191,7 +209,7 @@ test.each([
       }).toEqual({ exitCode: 0, error: '' })
       const installs = commands.filter((args) => args.includes('install'))
       expect(installs.map((args) => args.at(-1))).toEqual(
-        sameBinary || changedSuite
+        sameBinary
           ? [path.join(directory, 'head.app')]
           : [path.join(directory, 'head.app'), path.join(directory, 'base.app')]
       )
@@ -232,7 +250,7 @@ test.each([
         ).toEqual({ buildArtifactId: 456, runAttempt: 2 })
       }
       expect(new Set(processes.map((entry) => entry.pid)).size).toBe(
-        changedSuite ? 2 : 4
+        baseIds.length + headIds.length
       )
       expect(
         processes.map((entry) => [
@@ -240,36 +258,57 @@ test.each([
           entry.configuration.runId,
         ])
       ).toEqual(
-        [0, 1].flatMap((index) =>
-          changedSuite
-            ? [[index, `${platform}-head-1`]]
-            : [
-                [index, `${platform}-base-1`],
-                [index, `${platform}-head-1`],
+        mode === 'added-case'
+          ? [
+              [0, `${platform}-base-1`],
+              [0, `${platform}-head-1`],
+              [1, `${platform}-base-1`],
+              [1, `${platform}-head-1`],
+              [2, `${platform}-head-1`],
+            ]
+          : mode === 'removed-case'
+            ? [
+                [0, `${platform}-base-1`],
+                [0, `${platform}-head-1`],
+                [1, `${platform}-base-1`],
               ]
-        )
+            : [
+                [0, `${platform}-base-1`],
+                [0, `${platform}-head-1`],
+                [1, `${platform}-base-1`],
+                [1, `${platform}-head-1`],
+              ]
       )
       expect(
         (await readdir(output)).some((name) => name.startsWith('calibration'))
       ).toBe(false)
-      for (const file of changedSuite ? ['head-1'] : ['base-1', 'head-1']) {
-        const run = JSON.parse(
-          await readFile(path.join(output, `${file}.json`), 'utf8')
-        )
-        const metrics = run.metrics.sort(
-          (a: { id: string }, b: { id: string }) => a.id.localeCompare(b.id)
-        )
+      const base = await Bun.file(path.join(output, 'base-1.json')).json()
+      const head = await Bun.file(path.join(output, 'head-1.json')).json()
+      expect(base.metrics.map((metric: { id: string }) => metric.id)).toEqual(
+        baseIds
+      )
+      expect(head.metrics.map((metric: { id: string }) => metric.id)).toEqual(
+        headIds
+      )
+      const comparisons = compareRuns([base], [head]).comparisons
+      expect(
+        comparisons.find((metric) => metric.id === baseIds[1])?.deltaPercent
+      ).toBe(0)
+      if (mode === 'added-case') {
         expect(
-          metrics.map(
-            (metric: { iterations: number; chunkIterations: number }) => [
-              metric.iterations,
-              metric.chunkIterations,
-            ]
-          )
-        ).toEqual([
-          [1000, 250],
-          [500, 100],
-        ])
+          comparisons.find((metric) => metric.id === 'javascript/control/new')
+            ?.baseMedianNsPerOp
+        ).toBeNull()
+        // The first case moved to index 2, but still compares against base index 0.
+        expect(
+          comparisons.find((metric) => metric.id === baseIds[0])?.deltaPercent
+        ).toBe(0)
+      }
+      if (mode === 'removed-case') {
+        expect(
+          comparisons.find((metric) => metric.id === baseIds[0])
+            ?.headMedianNsPerOp
+        ).toBeNull()
       }
     } finally {
       await rm(directory, { recursive: true, force: true })

--- a/scripts/performance/run-sequence.ts
+++ b/scripts/performance/run-sequence.ts
@@ -75,12 +75,11 @@ await Bun.write(
   `${JSON.stringify({ baseSuiteHash, headSuiteHash }, null, 2)}\n`
 )
 
-const comparable = baseSuiteHash === headSuiteHash
 const sameBinary = baseSha === headSha
 const headId = 'com.margelo.nitrobenchmark.head'
 const baseId = sameBinary ? headId : 'com.margelo.nitrobenchmark'
 await installApp(platform, deviceId, headApp, headId)
-if (comparable && !sameBinary) {
+if (!sameBinary) {
   await installApp(platform, deviceId, baseApp, baseId)
 }
 
@@ -109,21 +108,23 @@ async function runCase(
   )
 }
 
-if (!comparable) {
-  console.info(
-    '[NitroBenchmark] Benchmark definitions changed; measuring a new head baseline only.'
-  )
-}
 const baseRuns: BenchmarkRunResult[] = []
 const headRuns: BenchmarkRunResult[] = []
-// Discover the suite size from the first measurement. Each launch is a fresh
-// process; finish base then head for this case before moving to the next one.
-let count = 1
-for (let index = 0; index < count; index++) {
-  if (comparable) baseRuns.push(await runCase('base', index))
-  const head = await runCase('head', index)
-  headRuns.push(head)
-  if (index === 0) count = head.benchmarkCount!
+// Each revision reports its own suite size. Alternate fresh processes while
+// both have cases left; the report matches their results by ID, not position.
+let baseCount = 1
+let headCount = 1
+for (let index = 0; index < Math.max(baseCount, headCount); index++) {
+  if (index < baseCount) {
+    const base = await runCase('base', index)
+    baseRuns.push(base)
+    if (index === 0) baseCount = base.benchmarkCount!
+  }
+  if (index < headCount) {
+    const head = await runCase('head', index)
+    headRuns.push(head)
+    if (index === 0) headCount = head.benchmarkCount!
+  }
 }
 for (const [name, runs] of [
   ['base-1', baseRuns],

--- a/scripts/performance/validate-report.ts
+++ b/scripts/performance/validate-report.ts
@@ -385,13 +385,7 @@ async function loadRawRun(
     run.configuration.commitSha !== expectedSha ||
     run.configuration.suiteHash !==
       (revision === 'base' ? report.baseSuiteHash : report.headSuiteHash) ||
-    run.runner.warmupCount !== 5 ||
-    run.runner.sampleCount !== 20 ||
-    run.metrics.some(
-      (metric) =>
-        metric.samplesNsPerOp.length !== 20 ||
-        !METRIC_ID_PATTERN.test(metric.id)
-    )
+    run.metrics.some((metric) => !METRIC_ID_PATTERN.test(metric.id))
   ) {
     throw new Error(`${platform} ${revision} run metadata is invalid.`)
   }
@@ -401,26 +395,8 @@ async function loadRawRun(
 const rebuiltComparisons = await Promise.all(
   (['android', 'ios'] as const).map(async (platform) => {
     const headRuns = [await loadRawRun(platform, 'head', report.headSha)]
-    const comparable = report.baseSuiteHash === report.headSuiteHash
-    const baseFiles = (
-      await readdir(path.join(artifactDirectory, 'raw', platform))
-    ).filter((file) => /^base-/.test(file))
-    if (!comparable && baseFiles.length !== 0)
-      throw new Error(
-        'Changed suites must not upload incomparable base measurements.'
-      )
-    const baseRuns = comparable
-      ? [await loadRawRun(platform, 'base', report.baseSha)]
-      : []
-    const comparison = comparable
-      ? compareRuns(baseRuns, headRuns)
-      : {
-          platform,
-          baseSha: report.baseSha,
-          headSha: report.headSha,
-          suiteComparable: false,
-          comparisons: [],
-        }
+    const baseRuns = [await loadRawRun(platform, 'base', report.baseSha)]
+    const comparison = compareRuns(baseRuns, headRuns)
     return { comparison, baseRuns, headRuns }
   })
 )


### PR DESCRIPTION
Follows the merged #1616–#1618 cleanup.

Editing any benchmark source currently disables every comparison and builds/runs only head. Always build and measure both revisions, then match results by benchmark ID. The original Before/After table remains: new cases show `—` before and `⭐️ New (timing)` after; removed cases retain their before timing and show `❌ Removed` after. Both stay visible without a percentage change.

Shared IDs are compared using their existing ns/op samples, even when test versions, iteration/chunk counts or runner settings change. Timings are already divided by the operation count. The PR author interprets changes to the workload or measurement method; the reporter adds no compatibility/version policy. Suite hashes remain provenance only. Bencher receives both measured revisions for PRs.

The controller alternates fresh base/head processes in each app's suite order and finishes the longer suite. With unchanged ordering, the same function runs back to back; additions/removals/reordering may shift the matching function's position, but the report always matches by ID. This uses the existing app protocol and adds no discovery launches. Identical SHAs still reuse one binary.

Validation: 86 performance-tool tests and TypeScript checks passed. Integration coverage builds both app artifacts for changed suites, runs different-length/reordered suites on both platform controllers with fresh processes, and rebuilds the trusted report with new/removed cases and changed counts. Existing report-layout snapshot passes. Malformed samples, duplicate/missing process artifacts, incorrect commit/testbed identity, stale PRs and artifact provenance remain checked.

Publishing uses code on main. The raw JSON schema is unchanged; this PR changes comparison policy and table handling. Its reporting behavior takes effect after merge, and CI retains raw measurements for review.

End-to-end CI at d923f9dff passed: [run 34149469608](https://github.com/margelo/nitro/actions/runs/34149469608). Both platforms built and measured BASE and HEAD, returning all 46 cases per revision with twenty valid samples. Measurement jobs took 6m42s on Android and 7m01s on iOS. The separate publishing workflow also passed and [posted the bot comment](https://github.com/margelo/nitro/pull/1622#issuecomment-5574263786) in the restored format. The [raw JSON artifact](https://github.com/margelo/nitro/actions/runs/34149469608/artifacts/10029120471) passed this PR's trusted validator locally with GitHub run/PR/artifact metadata. Added, removed and reordered cases are covered by the integration fixtures; the current real suite has the same IDs on both revisions.
