### PR TITLE
ci: render performance reports in PR workflows

### DIFF
--- a/.github/PERFORMANCE.md
+++ b/.github/PERFORMANCE.md
@@ -87,24 +87,37 @@ workflow run and attempt provenance, original build metadata and measurement art
 The PR comment links its exact immutable artifact ID; downloads require GitHub
 access. An agent can inspect the JSON instead of scraping the rendered table.
 
+The `nitro-performance` job checks out HEAD and generates the Markdown report and
+Bencher Metric Format (BMF) files using that revision's parser and renderer. It
+shows the report in the job summary and uploads `performance-publication-<attempt>`
+containing `performance-summary.md`, `metadata.json`, and `bencher-*.json`.
+The raw artifact is uploaded first so the rendered comment can link its exact ID.
+Renderer and raw-schema changes can therefore be reviewed in PR CI before merging.
+
 One default-branch `Publish Nitro Performance` workflow handles internal PRs,
-forks and main runs. It downloads the exact artifact from the triggering attempt,
-validates bounded JSON against GitHub's run and current PR metadata, and computes
-the comparison, Markdown and Bencher values from raw samples. It never installs
-or executes PR code or app artifacts. Docs-only and cancelled runs skip
-publication. Markdown/MDX-only edits also skip measurements inside package/app directories. Relevant failures remain failures. Stale PR results are skipped.
+forks and main runs. It selects the exact publication artifact for the triggering
+attempt, checks its repository, run, revisions and current PR against GitHub,
+and posts its Markdown unchanged. It reads no raw samples and never installs or
+executes PR code or artifact scripts. Comment content is produced by PR code;
+provenance checks establish its source, not the correctness of its measurements.
+Docs-only and cancelled runs skip publication. Markdown/MDX-only edits also skip
+measurements inside package/app directories. Relevant failures remain failures.
+Stale PR results are skipped. User comments are never edited.
 
-The trusted publisher uses `BENCHER_KEY` as an Actions secret. Its CLI version and
-binary digest are pinned. Bencher receives median latency values without invented
-bounds; its JSON adapter requires only `value`. PR publications seed both measured
-platform baselines at `baseline-<base SHA>` before recording the head at
-`pr-<number>`. Main runs record main history. Bencher receives history only: it does not post a second GitHub comment or create alert-driven checks. The trusted renderer owns the one PR comment. User comments are never edited.
+The publication envelope is independent of raw app schema versions. Keep its
+filenames and identity fields stable when changing benchmarks or report rendering.
+Changes to the trusted upload code itself still take effect after merge; ordinary
+report changes do not. Raw app results currently use schema version 2.
 
-Raw app results use schema version 2: fixed work counts replace the calibration
-protocol and the runner no longer reports a duration target. The producer and
-trusted parser must be merged together before the default-branch reporter can
-publish these results. During review, CI still retains the raw artifacts; the
-old reporter rejects the new schema instead of misinterpreting it.
+The trusted workflow also performs the final Bencher upload with `BENCHER_KEY`;
+that secret never reaches HEAD code. Its CLI version and binary digest are pinned.
+Bencher's JSON adapter validates the already-generated BMF files. The comment is
+posted first so an invalid BMF file cannot prevent the report from appearing.
+Bencher receives median latency values without invented bounds. PR publications
+seed both measured platform baselines at `baseline-<base SHA>` before recording
+the head at `pr-<number>`. Only main-branch runs record main history. Bencher
+receives history only: it does not post a second comment or create alert-driven
+checks.
 
 ## CI runners
 
@@ -148,7 +161,7 @@ To configure it on `margelo/nitro`:
 The trusted publisher uses the app's actual slug to recognize their own comments.
 They request only Pull requests write permission for the current repository, and
 the token action revokes the token at the end of the job. Build and measurement jobs never receive the app key. Bencher publishing retains its existing token.
-Reporting changes take effect after reaching the default branch.
+Bot authentication and upload changes take effect after reaching the default branch; report rendering runs from HEAD.
 
 Without the Client ID variable, comments continue as `github-actions[bot]`.
 Removing that variable switches back to the default identity. Configured app

--- a/.github/workflows/performance-report.yml
+++ b/.github/workflows/performance-report.yml
@@ -14,7 +14,7 @@ jobs:
   publish:
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout trusted reporting code
+      - name: Checkout trusted publishing code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
@@ -38,7 +38,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Validate untrusted report
+      - name: Validate publication provenance
         id: validate
         if: steps.download.outcome == 'success'
         env:
@@ -47,7 +47,7 @@ jobs:
           EVENT_NAME=$(jq -r '.workflow_run.event' "$GITHUB_EVENT_PATH")
           TRUSTED_PR_ARGUMENTS=()
           if [[ "$EVENT_NAME" == 'pull_request' ]]; then
-            PR_NUMBER=$(jq -r '.pullRequestNumber' untrusted-artifact/performance-report.json)
+            PR_NUMBER=$(jq -r '.pullRequestNumber' untrusted-artifact/metadata.json)
             if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
               echo 'Invalid pull request number in performance artifact.' >&2
               exit 1
@@ -60,8 +60,6 @@ jobs:
             --output-directory validated-report \
             --expected-repository "$GITHUB_REPOSITORY" \
             --trusted-workflow-event "$GITHUB_EVENT_PATH" \
-            --artifact-id "${{ steps.select.outputs.artifact_id }}" \
-            --trusted-artifacts trusted-artifacts.json \
             "${TRUSTED_PR_ARGUMENTS[@]}"
 
       - name: Create Nitro Modules Bot token
@@ -96,4 +94,4 @@ jobs:
         env:
           BENCHER_API_KEY: ${{ secrets.BENCHER_KEY }}
           BENCHER_PROJECT: nitro
-        run: bun scripts/performance/publish.ts --directory validated-report
+        run: bun scripts/performance/publish.ts --directory validated-report --data-directory untrusted-artifact

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -398,9 +398,23 @@ jobs:
             --base-sha "${{ needs.prepare.outputs.base_sha }}" \
             --head-sha "${{ needs.prepare.outputs.head_sha }}"
       - name: Upload aggregate report
+        id: raw-report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: performance-report-${{ github.run_attempt }}
           path: performance-report
+          if-no-files-found: error
+          retention-days: 30
+      - name: Render performance report from HEAD
+        run: |
+          bun scripts/performance/generate-report.ts \
+            --artifact-directory performance-report \
+            --output-directory performance-publication \
+            --artifact-id "${{ steps.raw-report.outputs.artifact-id }}"
+      - name: Upload rendered publication
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: performance-publication-${{ github.run_attempt }}
+          path: performance-publication
           if-no-files-found: error
           retention-days: 30

--- a/scripts/performance/generate-report.test.ts
+++ b/scripts/performance/generate-report.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import type { BenchmarkRunResult } from '../../apps/benchmark/src/benchmarks/types'
+
+const REPOSITORY = 'margelo/nitro'
+const BASE_SHA = 'a'.repeat(40)
+const HEAD_SHA = 'b'.repeat(40)
+const SUITE_HASH = 'c'.repeat(64)
+
+function run(
+  platform: 'android' | 'ios',
+  revision: 'base' | 'head'
+): BenchmarkRunResult {
+  const center = revision === 'base' ? 100 : 120
+  const samples = Array.from(
+    { length: 20 },
+    (_, index) => center - 1 + (index % 3)
+  )
+  return {
+    schemaVersion: 2,
+    suiteVersion: 1,
+    benchmarkCount: 1,
+    configuration: {
+      runId: `${platform}-${revision}-1`,
+      reverse: false,
+      commitSha: revision === 'base' ? BASE_SHA : HEAD_SHA,
+      suiteHash: SUITE_HASH,
+      platform,
+      device: 'fixed simulator',
+      osVersion: 'fixed OS',
+      architecture: platform === 'ios' ? 'arm64' : 'x86_64',
+      toolchain: 'fixed toolchain',
+    },
+    environment: {
+      reactNativeVersion: '0.85.3',
+      hermes: true,
+      dev: false,
+      nitroBuildType: 'release',
+    },
+    runner: {
+      warmupCount: 5,
+      sampleCount: 20,
+    },
+    startedAt: '2026-09-04T00:00:00.000Z',
+    durationMs: 4_000,
+    metrics: [
+      {
+        id: 'nitro-cpp/primitive/add-numbers',
+        version: 1,
+        family: 'primitive',
+        implementation: 'nitro-cpp',
+        iterations: 10_000,
+        chunkIterations: 10_000,
+        samplesNsPerOp: samples,
+        checksum: 42,
+      },
+    ],
+  }
+}
+
+async function writeJson(file: string, value: unknown): Promise<void> {
+  await Bun.write(file, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+async function createFixture(root: string): Promise<{
+  artifact: string
+  output: string
+}> {
+  const artifact = path.join(root, 'artifact')
+  const output = path.join(root, 'output')
+  for (const platform of ['android', 'ios'] as const) {
+    const directory = path.join(artifact, 'raw', platform)
+    await mkdir(directory, { recursive: true })
+    await writeJson(path.join(directory, 'measurement.json'), {
+      buildArtifactId: platform === 'android' ? 1 : 3,
+      runAttempt: 1,
+    })
+    await writeJson(path.join(directory, 'build.json'), {
+      platform,
+      baseSha: BASE_SHA,
+      headSha: HEAD_SHA,
+      baseSuiteHash: SUITE_HASH,
+      headSuiteHash: SUITE_HASH,
+      architecture: platform === 'ios' ? 'arm64' : 'x86_64',
+      toolchain: 'fixed toolchain',
+      configuration: 'Release',
+      workflowRunId: 123456789,
+      runAttempt: 1,
+    })
+    for (const revision of ['base', 'head'] as const) {
+      await writeJson(
+        path.join(directory, `${revision}-1.json`),
+        run(platform, revision)
+      )
+    }
+  }
+
+  await writeJson(path.join(artifact, 'performance-report.json'), {
+    schemaVersion: 2,
+    eventName: 'pull_request',
+    repository: REPOSITORY,
+    pullRequestNumber: 123,
+    baseSha: BASE_SHA,
+    headSha: HEAD_SHA,
+    baseSuiteHash: SUITE_HASH,
+    headSuiteHash: SUITE_HASH,
+    workflowRunId: 123456789,
+    runAttempt: 1,
+    artifacts: {
+      android: {
+        buildId: 1,
+        buildAttempt: 1,
+        measurementId: 2,
+        measurementAttempt: 1,
+      },
+      ios: {
+        buildId: 3,
+        buildAttempt: 1,
+        measurementId: 4,
+        measurementAttempt: 1,
+      },
+    },
+  })
+
+  return { artifact, output }
+}
+
+async function generate(fixture: Awaited<ReturnType<typeof createFixture>>) {
+  const child = Bun.spawn(
+    [
+      'bun',
+      path.join(import.meta.dir, 'generate-report.ts'),
+      '--artifact-directory',
+      fixture.artifact,
+      '--output-directory',
+      fixture.output,
+      '--artifact-id',
+      '987',
+    ],
+    {
+      stderr: 'pipe',
+      stdout: 'pipe',
+      env: {
+        ...process.env,
+        GITHUB_STEP_SUMMARY: path.join(fixture.output, 'job-summary.md'),
+      },
+    }
+  )
+  const error = new Response(child.stderr).text()
+  const output = new Response(child.stdout).text()
+  const [exitCode, errorMessage, outputMessage] = await Promise.all([
+    child.exited,
+    error,
+    output,
+  ])
+  return { exitCode, error: `${errorMessage}${outputMessage}` }
+}
+
+describe('HEAD report generation', () => {
+  test('generates Markdown and BMF from raw samples', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-performance-'))
+    try {
+      const fixture = await createFixture(root)
+      expect((await generate(fixture)).exitCode).toBe(0)
+      const markdown = await readFile(
+        path.join(fixture.output, 'performance-summary.md'),
+        'utf8'
+      )
+      expect(
+        await Bun.file(path.join(fixture.output, 'job-summary.md')).text()
+      ).toBe(markdown)
+      expect(markdown).toContain('/artifacts/987')
+      expect(markdown).toContain('## Performance Report')
+      expect(markdown).toContain('### iOS')
+      expect(markdown).toContain('### Android')
+      expect(markdown).toContain(
+        '<strong>C++</strong> <code>addNumbers()</code>'
+      )
+      expect(markdown).toContain('<summary>All Benchmarks</summary>')
+      expect(markdown).toContain(
+        `Benchmarking Code Diff [\`${BASE_SHA.slice(0, 8)}\`...\`${HEAD_SHA.slice(0, 8)}\`](https://github.com/margelo/nitro/compare/${BASE_SHA}..${HEAD_SHA}) ([view raw output](https://github.com/margelo/nitro/actions/runs/123456789))`
+      )
+      const bmf = JSON.parse(
+        await readFile(path.join(fixture.output, 'bencher-ios.json'), 'utf8')
+      )
+      expect(bmf['nitro-cpp/primitive/add-numbers'].latency.value).toBe(120)
+      const baseBmf = JSON.parse(
+        await readFile(
+          path.join(fixture.output, 'bencher-base-ios.json'),
+          'utf8'
+        )
+      )
+      expect(baseBmf['nitro-cpp/primitive/add-numbers'].latency.value).toBe(100)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test.each(['raw-sha', 'raw-order', 'raw-count', 'raw-id', 'raw-mode'])(
+    'rejects mismatched or malformed raw provenance: %s',
+    async (kind) => {
+      const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-performance-'))
+      try {
+        const fixture = await createFixture(root)
+        const raw = path.join(fixture.artifact, 'raw/ios/head-1.json')
+        const file = raw
+        const value = JSON.parse(await readFile(file, 'utf8'))
+        if (kind === 'raw-sha') value.configuration.commitSha = BASE_SHA
+        if (kind === 'raw-order') value.configuration.reverse = true
+        if (kind === 'raw-count') value.metrics[0].samplesNsPerOp.pop()
+        if (kind === 'raw-id') value.metrics[0].id = '<script>alert(1)</script>'
+        if (kind === 'raw-mode') value.environment.dev = true
+        await writeJson(file, value)
+        expect((await generate(fixture)).exitCode).not.toBe(0)
+      } finally {
+        await rm(root, { recursive: true, force: true })
+      }
+    }
+  )
+  test('changed suites compare shared IDs and report new and removed cases', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-performance-'))
+    try {
+      const fixture = await createFixture(root)
+      const file = path.join(fixture.artifact, 'performance-report.json')
+      const manifest = await Bun.file(file).json()
+      manifest.headSuiteHash = 'd'.repeat(64)
+      await writeJson(file, manifest)
+      for (const platform of ['android', 'ios']) {
+        const directory = path.join(fixture.artifact, 'raw', platform)
+        const buildFile = path.join(directory, 'build.json')
+        const build = await Bun.file(buildFile).json()
+        build.headSuiteHash = manifest.headSuiteHash
+        await writeJson(buildFile, build)
+        const baseFile = path.join(directory, 'base-1.json')
+        const base = await Bun.file(baseFile).json()
+        base.metrics.push({
+          ...base.metrics[0],
+          id: 'nitro-cpp/primitive/removed-case',
+        })
+        base.benchmarkCount = 2
+        await writeJson(baseFile, base)
+        const headFile = path.join(directory, 'head-1.json')
+        const head = await Bun.file(headFile).json()
+        head.configuration.suiteHash = manifest.headSuiteHash
+        head.runner = { warmupCount: 10, sampleCount: 10 }
+        head.metrics[0].samplesNsPerOp = Array(10).fill(120)
+        head.metrics[0].iterations *= 2
+        head.metrics[0].version++
+        head.metrics.unshift({
+          ...head.metrics[0],
+          id: 'nitro-cpp/primitive/new-case',
+        })
+        head.benchmarkCount = 2
+        await writeJson(headFile, head)
+      }
+      expect(await generate(fixture)).toEqual({ exitCode: 0, error: '' })
+      const markdown = await Bun.file(
+        path.join(fixture.output, 'performance-summary.md')
+      ).text()
+      expect(markdown).toContain('🔴 +20% slower')
+      expect(markdown).toContain('⭐️ New (120.0 ns)')
+      expect(markdown).toContain('❌ Removed')
+      expect(markdown).not.toContain('require a new baseline')
+      expect(
+        await Bun.file(
+          path.join(fixture.output, 'bencher-base-ios.json')
+        ).exists()
+      ).toBe(true)
+
+      // Suite changes cannot excuse a missing or duplicated process artifact.
+      const baseFile = path.join(fixture.artifact, 'raw/ios/base-1.json')
+      const base = await Bun.file(baseFile).json()
+      await rm(baseFile)
+      expect((await generate(fixture)).error).toContain(
+        'Expected one ios base run'
+      )
+      await writeJson(baseFile, base)
+      await writeJson(
+        path.join(fixture.artifact, 'raw/ios/head-2.json'),
+        await Bun.file(
+          path.join(fixture.artifact, 'raw/ios/head-1.json')
+        ).json()
+      )
+      expect((await generate(fixture)).error).toContain(
+        'Expected one ios head run'
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})
+
+test('rerunning Android retains the exact earlier iOS measurements and app builds', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-attempts-'))
+  try {
+    const fixture = await createFixture(root)
+    const manifestFile = path.join(fixture.artifact, 'performance-report.json')
+    const manifest = await Bun.file(manifestFile).json()
+    manifest.runAttempt = 2
+    manifest.artifacts.android.measurementId = 5
+    manifest.artifacts.android.measurementAttempt = 2
+    await writeJson(
+      path.join(fixture.artifact, 'raw/android/measurement.json'),
+      { buildArtifactId: 1, runAttempt: 2 }
+    )
+    await writeJson(manifestFile, manifest)
+    expect(await generate(fixture)).toEqual({ exitCode: 0, error: '' })
+    const markdown = await Bun.file(
+      path.join(fixture.output, 'performance-summary.md')
+    ).text()
+    expect(markdown).toContain('Android: [measurements, attempt 2]')
+    expect(markdown).toContain('iOS: [measurements, attempt 1]')
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/scripts/performance/generate-report.ts
+++ b/scripts/performance/generate-report.ts
@@ -1,0 +1,149 @@
+import type { PerformanceReport, ReportMetadata } from './report'
+import type { BuildMetadata } from './build-metadata'
+import type { BenchmarkRunResult } from '../../apps/benchmark/src/benchmarks/types'
+import { appendFile, mkdir, readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { parseArguments, requiredArgument } from './args'
+import { compareRuns, toBencherMetricFormat } from './comparison'
+import { renderPerformanceReportMarkdown } from './report-markdown'
+import { validateBenchmarkRun } from './schema'
+
+const METRIC_ID_PATTERN = /^[a-z0-9][a-z0-9/._-]{0,199}$/
+const argumentsMap = parseArguments(Bun.argv.slice(2))
+const artifactDirectory = requiredArgument(argumentsMap, 'artifact-directory')
+const outputDirectory = requiredArgument(argumentsMap, 'output-directory')
+const report: PerformanceReport = JSON.parse(
+  await readFile(
+    path.join(artifactDirectory, 'performance-report.json'),
+    'utf8'
+  )
+)
+const workflowRunUrl = `https://github.com/${report.repository}/actions/runs/${report.workflowRunId}`
+const builds = new Map<string, BuildMetadata>()
+for (const platform of ['android', 'ios'] as const) {
+  const ids = report.artifacts[platform]
+  const build: BuildMetadata = await Bun.file(
+    path.join(artifactDirectory, 'raw', platform, 'build.json')
+  ).json()
+  if (
+    build.platform !== platform ||
+    build.baseSha !== report.baseSha ||
+    build.headSha !== report.headSha ||
+    build.baseSuiteHash !== report.baseSuiteHash ||
+    build.headSuiteHash !== report.headSuiteHash ||
+    build.workflowRunId !== report.workflowRunId ||
+    build.runAttempt !== ids.buildAttempt ||
+    build.configuration !== 'Release' ||
+    ids.buildAttempt > ids.measurementAttempt ||
+    ids.measurementAttempt > report.runAttempt
+  ) {
+    throw new Error(
+      `${platform} app build metadata does not match this report.`
+    )
+  }
+  const measurement = await Bun.file(
+    path.join(artifactDirectory, 'raw', platform, 'measurement.json')
+  ).json()
+  if (
+    measurement.buildArtifactId !== ids.buildId ||
+    measurement.runAttempt !== ids.measurementAttempt
+  ) {
+    throw new Error(
+      `${platform} measurement provenance does not match this report.`
+    )
+  }
+  builds.set(platform, build)
+}
+
+async function loadRawRun(
+  platform: 'android' | 'ios',
+  revision: 'base' | 'head',
+  expectedSha: string
+): Promise<BenchmarkRunResult> {
+  const directory = path.join(artifactDirectory, 'raw', platform)
+  const filePattern = new RegExp(`^${revision}-[0-9]+\\.json$`)
+  const files = (await readdir(directory)).filter((file) =>
+    filePattern.test(file)
+  )
+  if (files.length !== 1 || files[0] !== `${revision}-1.json`) {
+    throw new Error(`Expected one ${platform} ${revision} run.`)
+  }
+  const run = validateBenchmarkRun(
+    JSON.parse(await readFile(path.join(directory, files[0]!), 'utf8'))
+  )
+  if (
+    run.configuration.runId !== `${platform}-${revision}-1` ||
+    run.configuration.reverse !== false ||
+    run.configuration.platform !== platform ||
+    run.configuration.architecture !== builds.get(platform)!.architecture ||
+    run.configuration.toolchain !== builds.get(platform)!.toolchain ||
+    run.configuration.benchmarkIndex !== undefined ||
+    run.metrics.length !== run.benchmarkCount ||
+    run.configuration.commitSha !== expectedSha ||
+    run.configuration.suiteHash !==
+      (revision === 'base' ? report.baseSuiteHash : report.headSuiteHash) ||
+    run.metrics.some((metric) => !METRIC_ID_PATTERN.test(metric.id))
+  ) {
+    throw new Error(`${platform} ${revision} run metadata is invalid.`)
+  }
+  return run
+}
+
+const comparisons = await Promise.all(
+  (['android', 'ios'] as const).map(async (platform) => {
+    const headRuns = [await loadRawRun(platform, 'head', report.headSha)]
+    const baseRuns = [await loadRawRun(platform, 'base', report.baseSha)]
+    const comparison = compareRuns(baseRuns, headRuns)
+    return { comparison, baseRuns, headRuns }
+  })
+)
+
+await mkdir(outputDirectory, { recursive: true })
+const markdown = renderPerformanceReportMarkdown(
+  comparisons.map(({ comparison }) => comparison),
+  {
+    repository: report.repository,
+    baseSha: report.baseSha,
+    headSha: report.headSha,
+    workflowRunUrl,
+    artifactId: Number(requiredArgument(argumentsMap, 'artifact-id')),
+    runAttempt: report.runAttempt,
+    artifacts: report.artifacts,
+  }
+)
+await Bun.write(path.join(outputDirectory, 'performance-summary.md'), markdown)
+
+await Bun.write(
+  path.join(outputDirectory, 'metadata.json'),
+  `${JSON.stringify(
+    {
+      repository: report.repository,
+      eventName: report.eventName,
+      pullRequestNumber: report.pullRequestNumber,
+      baseSha: report.baseSha,
+      headSha: report.headSha,
+      workflowRunId: report.workflowRunId,
+      runAttempt: report.runAttempt,
+      platforms: comparisons.map(({ comparison }) => comparison.platform),
+    } satisfies ReportMetadata,
+    null,
+    2
+  )}\n`
+)
+
+for (const { comparison, baseRuns, headRuns } of comparisons) {
+  for (const [suffix, runs] of [
+    [`base-${comparison.platform}`, baseRuns],
+    [comparison.platform, headRuns],
+  ] as const) {
+    if (runs.length === 0) continue
+    await Bun.write(
+      path.join(outputDirectory, `bencher-${suffix}.json`),
+      `${JSON.stringify(toBencherMetricFormat(runs), null, 2)}\n`
+    )
+  }
+}
+
+if (process.env.GITHUB_STEP_SUMMARY != null) {
+  await appendFile(process.env.GITHUB_STEP_SUMMARY, markdown)
+}

--- a/scripts/performance/github-report.ts
+++ b/scripts/performance/github-report.ts
@@ -2,7 +2,6 @@ import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { parseArguments, requiredArgument } from './args'
 import type { ReportMetadata } from './report'
-import { isSafeSha } from './schema'
 
 const COMMENT_MARKER = '<!-- nitro-performance-paired-comparison -->'
 
@@ -32,15 +31,15 @@ export async function postPerformanceComment(
     !/^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/.test(report.repository) ||
     !Number.isSafeInteger(report.pullRequestNumber) ||
     report.pullRequestNumber < 1 ||
-    !isSafeSha(report.baseSha) ||
-    !isSafeSha(report.headSha) ||
+    !/^[0-9a-f]{40}$/.test(report.baseSha) ||
+    !/^[0-9a-f]{40}$/.test(report.headSha) ||
     report.markdown.length > 60_000
   ) {
     throw new Error('Invalid validated PR report metadata or size.')
   }
 
   const root = `/repos/${report.repository}`
-  // A PR may have advanced while validation or Bencher publishing was running.
+  // A PR may have advanced while publication was being prepared.
   const pullRequest = (await request(
     `${root}/pulls/${report.pullRequestNumber}`
   )) as { state: string; base: { sha: string }; head: { sha: string } }

--- a/scripts/performance/publish.test.ts
+++ b/scripts/performance/publish.test.ts
@@ -1,5 +1,8 @@
 import type { ReportMetadata } from './report'
 import { describe, expect, test } from 'bun:test'
+import { chmod, mkdtemp, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
 import { bencherArguments, bencherPublications } from './publish'
 
 const metadata: ReportMetadata = {
@@ -8,8 +11,8 @@ const metadata: ReportMetadata = {
   pullRequestNumber: 123,
   baseSha: 'a'.repeat(40),
   headSha: 'b'.repeat(40),
-  baseSuiteHash: 'c'.repeat(64),
-  headSuiteHash: 'c'.repeat(64),
+  workflowRunId: 123,
+  runAttempt: 1,
   platforms: ['android', 'ios'],
 }
 
@@ -86,17 +89,76 @@ describe('Bencher publications', () => {
       bencherArguments(main, 'ios', 'base', '/validated', 'nitro')
     ).toThrow()
   })
-  test('a changed suite publishes both measured revisions', () => {
-    const changed = { ...metadata, headSuiteHash: 'd'.repeat(64) }
-    const publications = bencherPublications(changed, '/validated', 'nitro')
-    expect(publications.map((entry) => entry.revision)).toEqual([
-      'base',
-      'base',
-      'head',
-      'head',
-    ])
-    expect(publications.flatMap((entry) => entry.command)).toContain(
-      '--start-point'
+})
+
+test('uploads pre-rendered Bencher data through fixed arguments, without executing artifact code', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-bencher-'))
+  try {
+    const directory = path.join(root, 'validated')
+    const data = path.join(root, 'artifact')
+    const bmf = { 'case-from-head': { latency: { value: 123 } } }
+    await Bun.write(
+      path.join(directory, 'metadata.json'),
+      JSON.stringify(metadata)
     )
-  })
+    for (const name of ['base-android', 'base-ios', 'android', 'ios']) {
+      await Bun.write(
+        path.join(data, `bencher-${name}.json`),
+        JSON.stringify(bmf)
+      )
+    }
+    await Bun.write(
+      path.join(data, 'publish.ts'),
+      'throw new Error("Artifact code executed")'
+    )
+    const executable = path.join(root, 'bin', 'bencher')
+    await Bun.write(
+      executable,
+      `#!${process.execPath}
+import { appendFile } from 'node:fs/promises'
+const args = Bun.argv.slice(2)
+const file = args[args.indexOf('--file') + 1]
+await appendFile(process.env.CAPTURE, JSON.stringify({ args, data: await Bun.file(file).json() }) + '\\n')
+`
+    )
+    await chmod(executable, 0o755)
+    const capture = path.join(root, 'uploads.jsonl')
+    const child = Bun.spawn(
+      [
+        'bun',
+        path.join(import.meta.dir, 'publish.ts'),
+        '--directory',
+        directory,
+        '--data-directory',
+        data,
+      ],
+      {
+        env: {
+          ...process.env,
+          PATH: `${path.join(root, 'bin')}:${process.env.PATH}`,
+          BENCHER_PROJECT: 'nitro',
+          BENCHER_API_KEY: 'test-only',
+          CAPTURE: capture,
+        },
+        stdout: 'pipe',
+        stderr: 'pipe',
+      }
+    )
+    const stderr = new Response(child.stderr).text()
+    expect(await child.exited).toBe(0)
+    expect(await stderr).toBe('')
+    const uploads = (await Bun.file(capture).text())
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line))
+    expect(uploads).toHaveLength(4)
+    for (const upload of uploads) {
+      expect(upload.data).toEqual(bmf)
+      expect(upload.args).not.toContain('test-only')
+      expect(option(upload.args, '--project')).toBe('nitro')
+      expect(option(upload.args, '--file')).toStartWith(directory)
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
 })

--- a/scripts/performance/publish.ts
+++ b/scripts/performance/publish.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises'
+import { readFile, lstat } from 'node:fs/promises'
 import path from 'node:path'
 import { parseArguments, requiredArgument } from './args'
 import type { ReportMetadata } from './report'
@@ -88,11 +88,25 @@ if (import.meta.main) {
   const metadata: ReportMetadata = JSON.parse(
     await readFile(path.join(directory, 'metadata.json'), 'utf8')
   )
+  const dataDirectory = requiredArgument(argumentsMap, 'data-directory')
   for (const { platform, revision, command } of bencherPublications(
     metadata,
     directory,
     project
   )) {
+    // Read only fixed data filenames. The JSON adapter validates Bencher's format;
+    // this uploader has no dependency on the app's raw measurement schema.
+    const filename = `bencher-${revision === 'base' ? 'base-' : ''}${platform}.json`
+    const source = path.join(dataDirectory, filename)
+    const information = await lstat(source)
+    if (
+      !information.isFile() ||
+      information.size === 0 ||
+      information.size > 5 * 1024 * 1024
+    ) {
+      throw new Error(`Invalid Bencher data size for ${platform} ${revision}.`)
+    }
+    await Bun.write(path.join(directory, filename), await readFile(source))
     // The Bencher key is environment-only, never an argument or log message.
     const child = Bun.spawn(command, {
       env: { ...Bun.env, BENCHER_API_KEY: apiKey },

--- a/scripts/performance/report-validation.test.ts
+++ b/scripts/performance/report-validation.test.ts
@@ -1,399 +1,189 @@
-import { describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { expect, test } from 'bun:test'
+import { mkdtemp, rm, symlink } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import type { BenchmarkRunResult } from '../../apps/benchmark/src/benchmarks/types'
 
-const REPOSITORY = 'margelo/nitro'
-const FORK_REPOSITORY = 'contributor/nitro'
-const BASE_SHA = 'a'.repeat(40)
-const HEAD_SHA = 'b'.repeat(40)
-const SUITE_HASH = 'c'.repeat(64)
-
-function run(
-  platform: 'android' | 'ios',
-  revision: 'base' | 'head'
-): BenchmarkRunResult {
-  const center = revision === 'base' ? 100 : 120
-  const samples = Array.from(
-    { length: 20 },
-    (_, index) => center - 1 + (index % 3)
-  )
-  return {
-    schemaVersion: 2,
-    suiteVersion: 1,
-    benchmarkCount: 1,
-    configuration: {
-      runId: `${platform}-${revision}-1`,
-      reverse: false,
-      commitSha: revision === 'base' ? BASE_SHA : HEAD_SHA,
-      suiteHash: SUITE_HASH,
-      platform,
-      device: 'fixed simulator',
-      osVersion: 'fixed OS',
-      architecture: platform === 'ios' ? 'arm64' : 'x86_64',
-      toolchain: 'fixed toolchain',
-    },
-    environment: {
-      reactNativeVersion: '0.85.3',
-      hermes: true,
-      dev: false,
-      nitroBuildType: 'release',
-    },
-    runner: {
-      warmupCount: 5,
-      sampleCount: 20,
-    },
-    startedAt: '2026-09-04T00:00:00.000Z',
-    durationMs: 4_000,
-    metrics: [
-      {
-        id: 'nitro-cpp/primitive/add-numbers',
-        version: 1,
-        family: 'primitive',
-        implementation: 'nitro-cpp',
-        iterations: 10_000,
-        chunkIterations: 10_000,
-        samplesNsPerOp: samples,
-        checksum: 42,
-      },
-    ],
+async function fixture() {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-publication-'))
+  const metadata = {
+    repository: 'margelo/nitro',
+    eventName: 'pull_request',
+    pullRequestNumber: 123,
+    baseSha: 'a'.repeat(40),
+    headSha: 'b'.repeat(40),
+    workflowRunId: 123456,
+    runAttempt: 2,
+    platforms: ['android', 'ios'],
   }
-}
-
-async function writeJson(file: string, value: unknown): Promise<void> {
-  await Bun.write(file, `${JSON.stringify(value, null, 2)}\n`)
-}
-
-async function createFixture(root: string): Promise<{
-  artifact: string
-  output: string
-  trustedEvent: string
-  trustedPullRequest: string
-  trustedArtifacts: string
-}> {
+  const event = {
+    repository: { full_name: metadata.repository },
+    workflow_run: {
+      id: metadata.workflowRunId,
+      run_attempt: metadata.runAttempt,
+      event: metadata.eventName,
+      head_sha: metadata.headSha,
+      head_branch: 'feature',
+      head_repository: { full_name: 'contributor/nitro' },
+    },
+  }
+  const pr = {
+    number: metadata.pullRequestNumber,
+    state: 'open',
+    base: { sha: metadata.baseSha, repo: { full_name: metadata.repository } },
+    head: { sha: metadata.headSha, repo: { full_name: 'contributor/nitro' } },
+  }
   const artifact = path.join(root, 'artifact')
   const output = path.join(root, 'output')
-  for (const platform of ['android', 'ios'] as const) {
-    const directory = path.join(artifact, 'raw', platform)
-    await mkdir(directory, { recursive: true })
-    await writeJson(path.join(directory, 'measurement.json'), {
-      buildArtifactId: platform === 'android' ? 1 : 3,
-      runAttempt: 1,
-    })
-    await writeJson(path.join(directory, 'build.json'), {
-      platform,
-      baseSha: BASE_SHA,
-      headSha: HEAD_SHA,
-      baseSuiteHash: SUITE_HASH,
-      headSuiteHash: SUITE_HASH,
-      architecture: platform === 'ios' ? 'arm64' : 'x86_64',
-      toolchain: 'fixed toolchain',
-      configuration: 'Release',
-      workflowRunId: 123456789,
-      runAttempt: 1,
-    })
-    for (const revision of ['base', 'head'] as const) {
-      await writeJson(
-        path.join(directory, `${revision}-1.json`),
-        run(platform, revision)
-      )
+  const markdown =
+    '## Report from HEAD\n\n<table><tr><td>🟢 faster</td></tr></table>\n\n`$(touch should-not-exist)`\n'
+  await Bun.write(path.join(artifact, 'performance-summary.md'), markdown)
+  async function validate() {
+    for (const [file, data] of [
+      [path.join(artifact, 'metadata.json'), metadata],
+      [path.join(root, 'event.json'), event],
+      [path.join(root, 'pr.json'), pr],
+    ] as const) {
+      await Bun.write(file, JSON.stringify(data))
     }
+    const child = Bun.spawn(
+      [
+        'bun',
+        path.join(import.meta.dir, 'validate-report.ts'),
+        '--artifact-directory',
+        artifact,
+        '--output-directory',
+        output,
+        '--expected-repository',
+        'margelo/nitro',
+        '--trusted-workflow-event',
+        path.join(root, 'event.json'),
+        '--trusted-pull-request',
+        path.join(root, 'pr.json'),
+      ],
+      {
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: { ...process.env, GITHUB_OUTPUT: path.join(root, 'outputs') },
+      }
+    )
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ])
+    return { exitCode, text: stdout + stderr }
   }
-
-  await writeJson(path.join(artifact, 'performance-report.json'), {
-    schemaVersion: 2,
-    eventName: 'pull_request',
-    repository: REPOSITORY,
-    pullRequestNumber: 123,
-    baseSha: BASE_SHA,
-    headSha: HEAD_SHA,
-    baseSuiteHash: SUITE_HASH,
-    headSuiteHash: SUITE_HASH,
-    workflowRunId: 123456789,
-    runAttempt: 1,
-    artifacts: {
-      android: {
-        buildId: 1,
-        buildAttempt: 1,
-        measurementId: 2,
-        measurementAttempt: 1,
-      },
-      ios: {
-        buildId: 3,
-        buildAttempt: 1,
-        measurementId: 4,
-        measurementAttempt: 1,
-      },
-    },
-  })
-
-  const trustedEvent = path.join(root, 'workflow-run.json')
-  await writeJson(trustedEvent, {
-    repository: { full_name: REPOSITORY },
-    workflow_run: {
-      id: 123456789,
-      run_attempt: 1,
-      html_url: 'https://github.com/margelo/nitro/actions/runs/123456789',
-      event: 'pull_request',
-      head_sha: HEAD_SHA,
-      head_repository: { full_name: FORK_REPOSITORY },
-    },
-  })
-  const trustedPullRequest = path.join(root, 'pull-request.json')
-  await writeJson(trustedPullRequest, {
-    number: 123,
-    state: 'open',
-    base: { sha: BASE_SHA, repo: { full_name: REPOSITORY } },
-    head: { sha: HEAD_SHA, repo: { full_name: FORK_REPOSITORY } },
-  })
-  const trustedArtifacts = path.join(root, 'trusted-artifacts.json')
-  await writeJson(trustedArtifacts, [
-    { id: 1, name: 'performance-apps-android-1', expired: false },
-    { id: 2, name: 'performance-android-1', expired: false },
-    { id: 3, name: 'performance-apps-ios-1', expired: false },
-    { id: 4, name: 'performance-ios-1', expired: false },
-  ])
   return {
+    root,
     artifact,
     output,
-    trustedEvent,
-    trustedPullRequest,
-    trustedArtifacts,
+    metadata,
+    event,
+    pr,
+    markdown,
+    validate,
+    [Symbol.asyncDispose]: () => rm(root, { recursive: true, force: true }),
   }
 }
 
-async function validate(fixture: Awaited<ReturnType<typeof createFixture>>) {
-  const process = Bun.spawn(
-    [
-      'bun',
-      path.join(import.meta.dir, 'validate-report.ts'),
-      '--artifact-directory',
-      fixture.artifact,
-      '--output-directory',
-      fixture.output,
-      '--expected-repository',
-      REPOSITORY,
-      '--trusted-workflow-event',
-      fixture.trustedEvent,
-      '--trusted-artifacts',
-      fixture.trustedArtifacts,
-      '--artifact-id',
-      '987',
-      '--trusted-pull-request',
-      fixture.trustedPullRequest,
-    ],
-    { stderr: 'pipe', stdout: 'pipe' }
+test('forwards HEAD Markdown unchanged without reading the raw schema or recomputing results', async () => {
+  await using f = await fixture()
+  // Future raw schemas and arbitrary artifact source code are never loaded by the publisher.
+  await Bun.write(
+    path.join(f.artifact, 'performance-report.json'),
+    '{"schemaVersion":999}'
   )
-  const error = new Response(process.stderr).text()
-  const output = new Response(process.stdout).text()
-  const [exitCode, errorMessage, outputMessage] = await Promise.all([
-    process.exited,
-    error,
-    output,
-  ])
-  return { exitCode, error: `${errorMessage}${outputMessage}` }
-}
-
-describe('trusted performance report validation', () => {
-  test('rebuilds Markdown and BMF from bounded raw samples', async () => {
-    const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-performance-'))
-    try {
-      const fixture = await createFixture(root)
-      expect((await validate(fixture)).exitCode).toBe(0)
-      const markdown = await readFile(
-        path.join(fixture.output, 'performance-summary.md'),
-        'utf8'
-      )
-      expect(markdown).toContain('## Performance Report')
-      expect(markdown).toContain('### iOS')
-      expect(markdown).toContain('### Android')
-      expect(markdown).toContain(
-        '<strong>C++</strong> <code>addNumbers()</code>'
-      )
-      expect(markdown).toContain('<summary>All Benchmarks</summary>')
-      expect(markdown).toContain(
-        `Benchmarking Code Diff [\`${BASE_SHA.slice(0, 8)}\`...\`${HEAD_SHA.slice(0, 8)}\`](https://github.com/margelo/nitro/compare/${BASE_SHA}..${HEAD_SHA}) ([view raw output](https://github.com/margelo/nitro/actions/runs/123456789))`
-      )
-      const bmf = JSON.parse(
-        await readFile(path.join(fixture.output, 'bencher-ios.json'), 'utf8')
-      )
-      expect(bmf['nitro-cpp/primitive/add-numbers'].latency.value).toBe(120)
-      const baseBmf = JSON.parse(
-        await readFile(
-          path.join(fixture.output, 'bencher-base-ios.json'),
-          'utf8'
-        )
-      )
-      expect(baseBmf['nitro-cpp/primitive/add-numbers'].latency.value).toBe(100)
-    } finally {
-      await rm(root, { recursive: true, force: true })
-    }
-  })
-
-  test('skips a PR that advanced after measurement', async () => {
-    const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-performance-'))
-    try {
-      const fixture = await createFixture(root)
-      const pullRequest = JSON.parse(
-        await readFile(fixture.trustedPullRequest, 'utf8')
-      )
-      pullRequest.head.sha = 'd'.repeat(40)
-      await writeJson(fixture.trustedPullRequest, pullRequest)
-      const result = await validate(fixture)
-      expect(result.exitCode).toBe(0)
-      expect(result.error).toContain('Skipping stale')
-    } finally {
-      await rm(root, { recursive: true, force: true })
-    }
-  })
-
-  test('rejects a forged workflow run URL', async () => {
-    const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-performance-'))
-    try {
-      const fixture = await createFixture(root)
-      const event = JSON.parse(await readFile(fixture.trustedEvent, 'utf8'))
-      event.workflow_run.html_url = 'https://example.com/forged'
-      await writeJson(fixture.trustedEvent, event)
-      const result = await validate(fixture)
-      expect(result.exitCode).not.toBe(0)
-    } finally {
-      await rm(root, { recursive: true, force: true })
-    }
-  })
-  test.each([
-    'attempt',
-    'repository',
-    'raw-sha',
-    'raw-order',
-    'raw-count',
-    'raw-id',
-    'raw-mode',
-  ])('rejects mismatched or malformed raw provenance: %s', async (kind) => {
-    const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-performance-'))
-    try {
-      const fixture = await createFixture(root)
-      const manifest = path.join(fixture.artifact, 'performance-report.json')
-      const raw = path.join(fixture.artifact, 'raw/ios/head-1.json')
-      const file = kind === 'attempt' || kind === 'repository' ? manifest : raw
-      const value = JSON.parse(await readFile(file, 'utf8'))
-      if (kind === 'attempt') value.runAttempt = 2
-      if (kind === 'repository') value.repository = 'other/repo'
-      if (kind === 'raw-sha') value.configuration.commitSha = BASE_SHA
-      if (kind === 'raw-order') value.configuration.reverse = true
-      if (kind === 'raw-count') value.metrics[0].samplesNsPerOp.pop()
-      if (kind === 'raw-id') value.metrics[0].id = '<script>alert(1)</script>'
-      if (kind === 'raw-mode') value.environment.dev = true
-      await writeJson(file, value)
-      expect((await validate(fixture)).exitCode).not.toBe(0)
-    } finally {
-      await rm(root, { recursive: true, force: true })
-    }
-  })
-  test('changed suites compare shared IDs and report new and removed cases', async () => {
-    const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-performance-'))
-    try {
-      const fixture = await createFixture(root)
-      const file = path.join(fixture.artifact, 'performance-report.json')
-      const manifest = await Bun.file(file).json()
-      manifest.headSuiteHash = 'd'.repeat(64)
-      await writeJson(file, manifest)
-      for (const platform of ['android', 'ios']) {
-        const directory = path.join(fixture.artifact, 'raw', platform)
-        const buildFile = path.join(directory, 'build.json')
-        const build = await Bun.file(buildFile).json()
-        build.headSuiteHash = manifest.headSuiteHash
-        await writeJson(buildFile, build)
-        const baseFile = path.join(directory, 'base-1.json')
-        const base = await Bun.file(baseFile).json()
-        base.metrics.push({
-          ...base.metrics[0],
-          id: 'nitro-cpp/primitive/removed-case',
-        })
-        base.benchmarkCount = 2
-        await writeJson(baseFile, base)
-        const headFile = path.join(directory, 'head-1.json')
-        const head = await Bun.file(headFile).json()
-        head.configuration.suiteHash = manifest.headSuiteHash
-        head.runner = { warmupCount: 10, sampleCount: 10 }
-        head.metrics[0].samplesNsPerOp = Array(10).fill(120)
-        head.metrics[0].iterations *= 2
-        head.metrics[0].version++
-        head.metrics.unshift({
-          ...head.metrics[0],
-          id: 'nitro-cpp/primitive/new-case',
-        })
-        head.benchmarkCount = 2
-        await writeJson(headFile, head)
-      }
-      expect(await validate(fixture)).toEqual({ exitCode: 0, error: '' })
-      const markdown = await Bun.file(
-        path.join(fixture.output, 'performance-summary.md')
-      ).text()
-      expect(markdown).toContain('🔴 +20% slower')
-      expect(markdown).toContain('⭐️ New (120.0 ns)')
-      expect(markdown).toContain('❌ Removed')
-      expect(markdown).not.toContain('require a new baseline')
-      expect(
-        await Bun.file(
-          path.join(fixture.output, 'bencher-base-ios.json')
-        ).exists()
-      ).toBe(true)
-
-      // Suite changes cannot excuse a missing or duplicated process artifact.
-      const baseFile = path.join(fixture.artifact, 'raw/ios/base-1.json')
-      const base = await Bun.file(baseFile).json()
-      await rm(baseFile)
-      expect((await validate(fixture)).error).toContain(
-        'Expected one ios base run'
-      )
-      await writeJson(baseFile, base)
-      await writeJson(
-        path.join(fixture.artifact, 'raw/ios/head-2.json'),
-        await Bun.file(
-          path.join(fixture.artifact, 'raw/ios/head-1.json')
-        ).json()
-      )
-      expect((await validate(fixture)).error).toContain(
-        'Expected one ios head run'
-      )
-    } finally {
-      await rm(root, { recursive: true, force: true })
-    }
-  })
+  await Bun.write(path.join(f.artifact, 'raw/ios/head-1.json'), 'not JSON')
+  await Bun.write(
+    path.join(f.artifact, 'report.ts'),
+    'throw new Error("PR code executed")'
+  )
+  expect((await f.validate()).exitCode).toBe(0)
+  expect(
+    await Bun.file(path.join(f.output, 'performance-summary.md')).text()
+  ).toBe(f.markdown)
+  expect(await Bun.file(path.join(f.output, 'metadata.json')).json()).toEqual(
+    f.metadata
+  )
 })
 
-test('rerunning Android retains the exact earlier iOS measurements and app builds', async () => {
-  const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-attempts-'))
-  try {
-    const fixture = await createFixture(root)
-    const manifestFile = path.join(fixture.artifact, 'performance-report.json')
-    const manifest = await Bun.file(manifestFile).json()
-    manifest.runAttempt = 2
-    manifest.artifacts.android.measurementId = 5
-    manifest.artifacts.android.measurementAttempt = 2
-    await writeJson(
-      path.join(fixture.artifact, 'raw/android/measurement.json'),
-      { buildArtifactId: 1, runAttempt: 2 }
+test.each([
+  'repository',
+  'event',
+  'run',
+  'attempt',
+  'head',
+  'pr',
+  'fork',
+  'base-repository',
+  'platform',
+  'duplicate-platform',
+])('rejects a publication with mismatched %s', async (kind) => {
+  await using f = await fixture()
+  if (kind === 'repository') f.metadata.repository = 'other/repo'
+  if (kind === 'event') f.metadata.eventName = 'push'
+  if (kind === 'run') f.metadata.workflowRunId++
+  if (kind === 'attempt') f.metadata.runAttempt++
+  if (kind === 'head') f.metadata.headSha = 'c'.repeat(40)
+  if (kind === 'pr') f.metadata.pullRequestNumber++
+  if (kind === 'fork') f.pr.head.repo.full_name = 'another/nitro'
+  if (kind === 'base-repository') f.pr.base.repo.full_name = 'other/repo'
+  if (kind === 'platform') f.metadata.platforms = ['../../injected']
+  if (kind === 'duplicate-platform') f.metadata.platforms = ['ios', 'ios']
+  expect((await f.validate()).exitCode).not.toBe(0)
+})
+
+test.each(['head', 'base', 'closed'])(
+  'skips stale PR results: %s',
+  async (change) => {
+    await using f = await fixture()
+    if (change === 'head') f.pr.head.sha = 'c'.repeat(40)
+    if (change === 'base') f.pr.base.sha = 'c'.repeat(40)
+    if (change === 'closed') f.pr.state = 'closed'
+    const result = await f.validate()
+    expect(result.exitCode).toBe(0)
+    expect(result.text).toContain('Skipping stale')
+    expect(await Bun.file(path.join(f.root, 'outputs')).text()).toContain(
+      'stale=true'
     )
-    await writeJson(manifestFile, manifest)
-    const event = await Bun.file(fixture.trustedEvent).json()
-    event.workflow_run.run_attempt = 2
-    await writeJson(fixture.trustedEvent, event)
-    const artifacts = await Bun.file(fixture.trustedArtifacts).json()
-    artifacts.push({ id: 5, name: 'performance-android-2', expired: false })
-    await writeJson(fixture.trustedArtifacts, artifacts)
-    expect(await validate(fixture)).toEqual({ exitCode: 0, error: '' })
-    const markdown = await Bun.file(
-      path.join(fixture.output, 'performance-summary.md')
-    ).text()
-    expect(markdown).toContain('Android: [measurements, attempt 2]')
-    expect(markdown).toContain('iOS: [measurements, attempt 1]')
-    // An unrelated artifact cannot substitute for the retained iOS attempt.
-    manifest.artifacts.ios.measurementId = 5
-    await writeJson(manifestFile, manifest)
-    expect((await validate(fixture)).exitCode).not.toBe(0)
-  } finally {
-    await rm(root, { recursive: true, force: true })
+    expect(
+      await Bun.file(path.join(f.output, 'performance-summary.md')).exists()
+    ).toBe(false)
   }
+)
+
+test.each(['', 'x'.repeat(60_001)])(
+  'rejects empty or oversized comments',
+  async (markdown) => {
+    await using f = await fixture()
+    await Bun.write(path.join(f.artifact, 'performance-summary.md'), markdown)
+    expect((await f.validate()).exitCode).not.toBe(0)
+  }
+)
+
+test.each(['push', 'schedule', 'workflow_dispatch'])(
+  'allows %s history only from main in this repository',
+  async (eventName) => {
+    await using f = await fixture()
+    f.metadata.eventName = f.event.workflow_run.event = eventName
+    Object.assign(f.metadata, { pullRequestNumber: null })
+    f.event.workflow_run.head_branch = 'main'
+    f.event.workflow_run.head_repository.full_name = 'margelo/nitro'
+    expect((await f.validate()).exitCode).toBe(0)
+    f.event.workflow_run.head_branch = 'feature'
+    expect((await f.validate()).exitCode).not.toBe(0)
+    f.event.workflow_run.head_branch = 'main'
+    f.event.workflow_run.head_repository.full_name = 'contributor/nitro'
+    expect((await f.validate()).exitCode).not.toBe(0)
+  }
+)
+
+test('rejects a symlink instead of posting a file outside the publication', async () => {
+  await using f = await fixture()
+  const report = path.join(f.artifact, 'performance-summary.md')
+  await rm(report)
+  const outside = path.join(f.root, 'outside.md')
+  await Bun.write(outside, 'Must not be posted')
+  await symlink(outside, report)
+  expect((await f.validate()).exitCode).not.toBe(0)
 })

--- a/scripts/performance/report.ts
+++ b/scripts/performance/report.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import { readFile } from 'node:fs/promises'
 import { parseArguments, requiredArgument } from './args'
 
-/** The artifact contains raw runs plus provenance. Only trusted code derives a report. */
+/** Raw measurements and provenance, retained separately from the rendered publication. */
 export interface PerformanceReport {
   schemaVersion: 2
   eventName: 'pull_request' | 'push' | 'schedule' | 'workflow_dispatch'
@@ -24,9 +24,16 @@ export interface PlatformArtifacts {
   measurementAttempt: number
 }
 
-export interface ReportMetadata extends Omit<
+/** Stable publication envelope. It does not depend on the raw benchmark schema. */
+export interface ReportMetadata extends Pick<
   PerformanceReport,
-  'schemaVersion' | 'workflowRunId' | 'runAttempt' | 'artifacts'
+  | 'eventName'
+  | 'repository'
+  | 'pullRequestNumber'
+  | 'baseSha'
+  | 'headSha'
+  | 'workflowRunId'
+  | 'runAttempt'
 > {
   platforms: ('android' | 'ios')[]
 }

--- a/scripts/performance/select-report.test.ts
+++ b/scripts/performance/select-report.test.ts
@@ -23,10 +23,13 @@ test('a relevant build failure or missing results remains a failure', () => {
 test('selects the immutable artifact for the triggering attempt only', () => {
   const artifacts = [1, 2].map((id) => ({
     id,
-    name: `performance-report-${id}`,
+    name: `performance-publication-${id}`,
     expired: false,
   }))
-  expect(selectReportArtifact('success', 2, artifacts, [])).toBe(2)
+  const rawArtifact = { id: 99, name: 'performance-report-2', expired: false }
+  expect(
+    selectReportArtifact('success', 2, [...artifacts, rawArtifact], [])
+  ).toBe(2)
   expect(() => selectReportArtifact('success', 3, artifacts, [])).toThrow()
   expect(() =>
     selectReportArtifact('success', 2, [...artifacts, artifacts[1]!], [])

--- a/scripts/performance/select-report.ts
+++ b/scripts/performance/select-report.ts
@@ -21,7 +21,7 @@ export function selectReportArtifact(
     throw new Error(
       `Performance workflow ${conclusion}; no measurements published.`
     )
-  const name = `performance-report-${attempt}`
+  const name = `performance-publication-${attempt}`
   const matches = artifacts.filter(
     (artifact) => artifact.name === name && !artifact.expired
   )
@@ -69,10 +69,6 @@ if (import.meta.main) {
   ])
   if (artifactResponse.total_count > 100 || jobResponse.total_count > 100)
     throw new Error('Performance run exceeds the artifact/job lookup limit.')
-  await Bun.write(
-    'trusted-artifacts.json',
-    JSON.stringify(artifactResponse.artifacts)
-  )
   const id = selectReportArtifact(
     run.conclusion,
     run.run_attempt,

--- a/scripts/performance/validate-report.ts
+++ b/scripts/performance/validate-report.ts
@@ -1,291 +1,77 @@
-import type { PerformanceReport, PlatformArtifacts } from './report'
-import type { Artifact } from './select-report'
-import { appendFile, mkdir, readdir, readFile, stat } from 'node:fs/promises'
+import type { ReportMetadata } from './report'
+import { appendFile, mkdir, readFile, lstat } from 'node:fs/promises'
 import path from 'node:path'
 import { parseArguments, requiredArgument } from './args'
-import { compareRuns, toBencherMetricFormat } from './comparison'
-import { renderPerformanceReportMarkdown } from './report-markdown'
-import { isSafeSha, validateBenchmarkRun } from './schema'
-import type { BenchmarkRunResult } from '../../apps/benchmark/src/benchmarks/types'
 
-const MAX_FILE_BYTES = 5 * 1024 * 1024
-const METRIC_ID_PATTERN = /^[a-z0-9][a-z0-9/._-]{0,199}$/
-
-interface TrustedWorkflowRunEvent {
-  repository: { full_name: string }
-  workflow_run: {
-    id: number
-    run_attempt: number
-    html_url: string
-    event: 'pull_request' | 'push' | 'schedule' | 'workflow_dispatch'
-    head_sha: string
-    head_repository: { full_name: string }
-  }
-}
-
-interface TrustedPullRequest {
-  number: number
-  state: string
-  base: { sha: string; repo: { full_name: string } }
-  head: { sha: string; repo: { full_name: string } }
-}
-
-function object(value: unknown, name: string): Record<string, unknown> {
-  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error(`${name} must be an object.`)
-  }
-  return value as Record<string, unknown>
-}
-
-function boundedString(value: unknown, name: string): string {
-  if (typeof value !== 'string' || value.length === 0 || value.length > 256) {
-    throw new Error(`${name} must be a bounded string.`)
-  }
-  return value
-}
-
-function finiteNumber(value: unknown, name: string): number {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new Error(`${name} must be finite.`)
-  }
-  return value
-}
-
-async function readBoundedJson(file: string): Promise<unknown> {
-  const information = await stat(file)
-  if (information.size <= 0 || information.size > MAX_FILE_BYTES) {
+async function readBoundedFile(
+  file: string,
+  maxBytes: number
+): Promise<string> {
+  const information = await lstat(file)
+  if (
+    !information.isFile() ||
+    information.size === 0 ||
+    information.size > maxBytes
+  ) {
     throw new Error(`${file} has an invalid size.`)
   }
-  return JSON.parse(await readFile(file, 'utf8'))
+  return readFile(file, 'utf8')
 }
 
-function validateTrustedWorkflowRunEvent(
-  value: unknown
-): TrustedWorkflowRunEvent {
-  const event = object(value, 'workflow_run event')
-  const repository = object(event.repository, 'event.repository')
-  const workflowRun = object(event.workflow_run, 'event.workflow_run')
-  const headRepository = object(
-    workflowRun.head_repository,
-    'event.workflow_run.head_repository'
-  )
-  const eventName = workflowRun.event
-  const id = finiteNumber(workflowRun.id, 'event.workflow_run.id')
-  if (
-    eventName !== 'pull_request' &&
-    eventName !== 'push' &&
-    eventName !== 'schedule' &&
-    eventName !== 'workflow_dispatch'
-  ) {
-    throw new Error('Trusted workflow run has an unsupported event.')
-  }
-  const headSha = boundedString(
-    workflowRun.head_sha,
-    'event.workflow_run.head_sha'
-  )
-  if (!Number.isSafeInteger(id) || id < 1 || !isSafeSha(headSha)) {
-    throw new Error('Trusted workflow run identity is invalid.')
-  }
-  return {
-    repository: {
-      full_name: boundedString(repository.full_name, 'repository.full_name'),
-    },
-    workflow_run: {
-      id,
-      run_attempt: finiteNumber(
-        workflowRun.run_attempt,
-        'workflow_run.run_attempt'
-      ),
-      html_url: boundedString(
-        workflowRun.html_url,
-        'event.workflow_run.html_url'
-      ),
-      event: eventName,
-      head_sha: headSha,
-      head_repository: {
-        full_name: boundedString(
-          headRepository.full_name,
-          'event.workflow_run.head_repository.full_name'
-        ),
-      },
-    },
-  }
-}
-
-function validateTrustedPullRequest(value: unknown): TrustedPullRequest {
-  const pullRequest = object(value, 'trusted pull request')
-  const base = object(pullRequest.base, 'pull_request.base')
-  const head = object(pullRequest.head, 'pull_request.head')
-  const baseRepository = object(base.repo, 'pull_request.base.repo')
-  const headRepository = object(head.repo, 'pull_request.head.repo')
-  const number = finiteNumber(pullRequest.number, 'pull_request.number')
-  const baseSha = boundedString(base.sha, 'pull_request.base.sha')
-  const headSha = boundedString(head.sha, 'pull_request.head.sha')
-  if (
-    !Number.isInteger(number) ||
-    number < 1 ||
-    !isSafeSha(baseSha) ||
-    !isSafeSha(headSha)
-  ) {
-    throw new Error('Trusted pull request metadata is invalid.')
-  }
-  return {
-    number,
-    state: boundedString(pullRequest.state, 'pull_request.state'),
-    base: {
-      sha: baseSha,
-      repo: {
-        full_name: boundedString(
-          baseRepository.full_name,
-          'pull_request.base.repo.full_name'
-        ),
-      },
-    },
-    head: {
-      sha: headSha,
-      repo: {
-        full_name: boundedString(
-          headRepository.full_name,
-          'pull_request.head.repo.full_name'
-        ),
-      },
-    },
-  }
-}
-
-function validateReport(value: unknown): PerformanceReport {
-  const report = object(value, 'report')
-  if (report.schemaVersion !== 2) {
-    throw new Error('Invalid performance report.')
-  }
-  const pullRequestNumber =
-    report.pullRequestNumber === null
-      ? null
-      : finiteNumber(report.pullRequestNumber, 'report.pullRequestNumber')
-  if (
-    pullRequestNumber !== null &&
-    (!Number.isInteger(pullRequestNumber) || pullRequestNumber < 1)
-  ) {
-    throw new Error('Invalid report pull request number.')
-  }
-  const eventName = report.eventName
-  if (
-    eventName !== 'pull_request' &&
-    eventName !== 'push' &&
-    eventName !== 'schedule' &&
-    eventName !== 'workflow_dispatch'
-  ) {
-    throw new Error('Invalid report event name.')
-  }
-  const baseSha = boundedString(report.baseSha, 'report.baseSha')
-  const headSha = boundedString(report.headSha, 'report.headSha')
-  if (!isSafeSha(baseSha) || !isSafeSha(headSha)) {
-    throw new Error('Report SHAs are invalid.')
-  }
-  const baseSuiteHash = boundedString(
-    report.baseSuiteHash,
-    'report.baseSuiteHash'
-  )
-  const headSuiteHash = boundedString(
-    report.headSuiteHash,
-    'report.headSuiteHash'
-  )
-  if (
-    !/^[0-9a-f]{64}$/.test(baseSuiteHash) ||
-    !/^[0-9a-f]{64}$/.test(headSuiteHash)
-  )
-    throw new Error('Invalid report suite hashes.')
-  const artifactValues = object(report.artifacts, 'report.artifacts')
-  function artifacts(platform: 'android' | 'ios'): PlatformArtifacts {
-    const values = object(artifactValues[platform], `${platform} artifacts`)
-    const result = {} as PlatformArtifacts
-    for (const key of [
-      'buildId',
-      'buildAttempt',
-      'measurementId',
-      'measurementAttempt',
-    ] as const) {
-      const value = finiteNumber(values[key], `${platform}.${key}`)
-      if (!Number.isSafeInteger(value) || value < 1)
-        throw new Error('Invalid platform artifact provenance.')
-      result[key] = value
-    }
-    if (
-      result.buildAttempt > result.measurementAttempt ||
-      result.measurementAttempt > Number(report.runAttempt)
-    )
-      throw new Error('Platform artifacts come from a future attempt.')
-    return result
-  }
-  return {
-    artifacts: { android: artifacts('android'), ios: artifacts('ios') },
-    baseSuiteHash,
-    headSuiteHash,
-    schemaVersion: 2,
-    eventName,
-    repository: boundedString(report.repository, 'report.repository'),
-    pullRequestNumber,
-    baseSha,
-    headSha,
-    workflowRunId: finiteNumber(report.workflowRunId, 'report.workflowRunId'),
-    runAttempt: finiteNumber(report.runAttempt, 'report.runAttempt'),
-  }
-}
-
-const argumentsMap = parseArguments(Bun.argv.slice(2))
-const artifactDirectory = requiredArgument(argumentsMap, 'artifact-directory')
-const outputDirectory = requiredArgument(argumentsMap, 'output-directory')
-const expectedRepository = requiredArgument(argumentsMap, 'expected-repository')
-const trustedWorkflowEventPath = requiredArgument(
-  argumentsMap,
-  'trusted-workflow-event'
+const args = parseArguments(Bun.argv.slice(2))
+const directory = requiredArgument(args, 'artifact-directory')
+const output = requiredArgument(args, 'output-directory')
+const repository = requiredArgument(args, 'expected-repository')
+// These inputs come from GitHub, not from the downloaded artifact.
+const event = JSON.parse(
+  await readFile(requiredArgument(args, 'trusted-workflow-event'), 'utf8')
 )
-
-const trustedWorkflowEvent = validateTrustedWorkflowRunEvent(
-  await readBoundedJson(trustedWorkflowEventPath)
-)
-const report = validateReport(
-  await readBoundedJson(path.join(artifactDirectory, 'performance-report.json'))
+const run = event.workflow_run
+const metadata: ReportMetadata = JSON.parse(
+  await readBoundedFile(path.join(directory, 'metadata.json'), 64 * 1024)
 )
 if (
-  trustedWorkflowEvent.repository.full_name !== expectedRepository ||
-  trustedWorkflowEvent.workflow_run.event !== report.eventName ||
-  report.repository !== expectedRepository ||
-  report.headSha !== trustedWorkflowEvent.workflow_run.head_sha ||
-  report.workflowRunId !== trustedWorkflowEvent.workflow_run.id ||
-  report.runAttempt !== trustedWorkflowEvent.workflow_run.run_attempt
+  metadata.repository !== repository ||
+  event.repository.full_name !== repository ||
+  metadata.eventName !== run.event ||
+  metadata.workflowRunId !== run.id ||
+  metadata.runAttempt !== run.run_attempt ||
+  metadata.headSha !== run.head_sha ||
+  typeof metadata.baseSha !== 'string' ||
+  !/^[0-9a-f]{40}$/.test(metadata.baseSha) ||
+  !Array.isArray(metadata.platforms) ||
+  metadata.platforms.length === 0 ||
+  metadata.platforms.length > 2 ||
+  new Set(metadata.platforms).size !== metadata.platforms.length ||
+  metadata.platforms.some(
+    (platform) => platform !== 'android' && platform !== 'ios'
+  )
 ) {
   throw new Error(
-    'Artifact event metadata does not match the triggering workflow.'
+    'Publication metadata does not match the triggering workflow.'
   )
-}
-const workflowRunUrl = `https://github.com/${expectedRepository}/actions/runs/${trustedWorkflowEvent.workflow_run.id}`
-if (trustedWorkflowEvent.workflow_run.html_url !== workflowRunUrl) {
-  throw new Error('Trusted workflow run URL is invalid.')
 }
 
-if (report.eventName === 'pull_request') {
-  const trustedPullRequestPath = requiredArgument(
-    argumentsMap,
-    'trusted-pull-request'
-  )
-  const pullRequest = validateTrustedPullRequest(
-    await readBoundedJson(trustedPullRequestPath)
+if (run.event === 'pull_request') {
+  const pr = JSON.parse(
+    await readFile(requiredArgument(args, 'trusted-pull-request'), 'utf8')
   )
   if (
-    pullRequest.base.repo.full_name !== expectedRepository ||
-    pullRequest.head.repo.full_name !==
-      trustedWorkflowEvent.workflow_run.head_repository.full_name ||
-    report.pullRequestNumber !== pullRequest.number
+    metadata.pullRequestNumber === null ||
+    !Number.isSafeInteger(metadata.pullRequestNumber) ||
+    metadata.pullRequestNumber < 1 ||
+    metadata.pullRequestNumber !== pr.number ||
+    pr.base.repo.full_name !== repository ||
+    pr.head.repo.full_name !== run.head_repository.full_name
   ) {
     throw new Error(
-      'Artifact metadata does not match the trusted pull request.'
+      'Publication metadata does not match the trusted pull request.'
     )
   }
   if (
-    pullRequest.state !== 'open' ||
-    report.baseSha !== pullRequest.base.sha ||
-    report.headSha !== pullRequest.head.sha
+    pr.state !== 'open' ||
+    metadata.baseSha !== pr.base.sha ||
+    metadata.headSha !== pr.head.sha
   ) {
     console.info(
       'Skipping stale performance results: the pull request advanced or closed.'
@@ -294,158 +80,23 @@ if (report.eventName === 'pull_request') {
       await appendFile(process.env.GITHUB_OUTPUT, 'stale=true\n')
     process.exit(0)
   }
-} else {
-  if (report.pullRequestNumber !== null) {
-    throw new Error(
-      'Artifact metadata does not match the trusted workflow run.'
-    )
-  }
-}
-const builds = new Map<string, Record<string, unknown>>()
-const trustedArtifacts = (await readBoundedJson(
-  requiredArgument(argumentsMap, 'trusted-artifacts')
-)) as Artifact[]
-for (const platform of ['android', 'ios'] as const) {
-  const ids = report.artifacts[platform]
-  for (const [id, name] of [
-    [ids.buildId, `performance-apps-${platform}-${ids.buildAttempt}`],
-    [ids.measurementId, `performance-${platform}-${ids.measurementAttempt}`],
-  ] as const) {
-    if (
-      !trustedArtifacts.some(
-        (artifact) =>
-          artifact.id === id && artifact.name === name && !artifact.expired
-      )
-    ) {
-      throw new Error(
-        `${platform} references an artifact outside this workflow run or attempt.`
-      )
-    }
-  }
-  const build = object(
-    await readBoundedJson(
-      path.join(artifactDirectory, 'raw', platform, 'build.json')
-    ),
-    `${platform} build`
-  )
-  if (
-    build.platform !== platform ||
-    build.baseSha !== report.baseSha ||
-    build.headSha !== report.headSha ||
-    build.baseSuiteHash !== report.baseSuiteHash ||
-    build.headSuiteHash !== report.headSuiteHash ||
-    build.workflowRunId !== report.workflowRunId ||
-    build.runAttempt !== ids.buildAttempt ||
-    build.configuration !== 'Release'
-  ) {
-    throw new Error(
-      `${platform} app build metadata does not match this report.`
-    )
-  }
-  const measurement = object(
-    await readBoundedJson(
-      path.join(artifactDirectory, 'raw', platform, 'measurement.json')
-    ),
-    `${platform} measurement`
-  )
-  if (
-    measurement.buildArtifactId !== ids.buildId ||
-    measurement.runAttempt !== ids.measurementAttempt
-  )
-    throw new Error(
-      `${platform} measurement provenance does not match this report.`
-    )
-  builds.set(platform, build)
+} else if (
+  !['push', 'schedule', 'workflow_dispatch'].includes(run.event) ||
+  run.head_branch !== 'main' ||
+  run.head_repository.full_name !== repository ||
+  metadata.pullRequestNumber !== null
+) {
+  throw new Error('Only main runs may publish main performance history.')
 }
 
-async function loadRawRun(
-  platform: 'android' | 'ios',
-  revision: 'base' | 'head',
-  expectedSha: string
-): Promise<BenchmarkRunResult> {
-  const directory = path.join(artifactDirectory, 'raw', platform)
-  const filePattern = new RegExp(`^${revision}-[0-9]+\\.json$`)
-  const files = (await readdir(directory)).filter((file) =>
-    filePattern.test(file)
-  )
-  if (files.length !== 1 || files[0] !== `${revision}-1.json`) {
-    throw new Error(`Expected one ${platform} ${revision} run.`)
-  }
-  const run = validateBenchmarkRun(
-    await readBoundedJson(path.join(directory, files[0]!))
-  )
-  if (
-    run.configuration.runId !== `${platform}-${revision}-1` ||
-    run.configuration.reverse !== false ||
-    run.configuration.platform !== platform ||
-    run.configuration.architecture !== builds.get(platform)!.architecture ||
-    run.configuration.toolchain !== builds.get(platform)!.toolchain ||
-    run.configuration.benchmarkIndex !== undefined ||
-    run.metrics.length !== run.benchmarkCount ||
-    run.configuration.commitSha !== expectedSha ||
-    run.configuration.suiteHash !==
-      (revision === 'base' ? report.baseSuiteHash : report.headSuiteHash) ||
-    run.metrics.some((metric) => !METRIC_ID_PATTERN.test(metric.id))
-  ) {
-    throw new Error(`${platform} ${revision} run metadata is invalid.`)
-  }
-  return run
-}
-
-const rebuiltComparisons = await Promise.all(
-  (['android', 'ios'] as const).map(async (platform) => {
-    const headRuns = [await loadRawRun(platform, 'head', report.headSha)]
-    const baseRuns = [await loadRawRun(platform, 'base', report.baseSha)]
-    const comparison = compareRuns(baseRuns, headRuns)
-    return { comparison, baseRuns, headRuns }
-  })
+const markdown = await readBoundedFile(
+  path.join(directory, 'performance-summary.md'),
+  240_000
 )
-
-await mkdir(outputDirectory, { recursive: true })
-const markdown = renderPerformanceReportMarkdown(
-  rebuiltComparisons.map(({ comparison }) => comparison),
-  {
-    repository: expectedRepository,
-    baseSha: report.baseSha,
-    headSha: report.headSha,
-    workflowRunUrl,
-    artifactId: Number(requiredArgument(argumentsMap, 'artifact-id')),
-    runAttempt: report.runAttempt,
-    artifacts: report.artifacts,
-  }
-)
-await Bun.write(path.join(outputDirectory, 'performance-summary.md'), markdown)
-
-await Bun.write(
-  path.join(outputDirectory, 'metadata.json'),
-  `${JSON.stringify(
-    {
-      repository: report.repository,
-      eventName: report.eventName,
-      pullRequestNumber: report.pullRequestNumber,
-      baseSha: report.baseSha,
-      headSha: report.headSha,
-      baseSuiteHash: report.baseSuiteHash,
-      headSuiteHash: report.headSuiteHash,
-      workflowRunUrl,
-      platforms: rebuiltComparisons.map(
-        ({ comparison }) => comparison.platform
-      ),
-    },
-    null,
-    2
-  )}\n`
-)
-
-for (const { comparison, baseRuns, headRuns } of rebuiltComparisons) {
-  for (const [suffix, runs] of [
-    [`base-${comparison.platform}`, baseRuns],
-    [comparison.platform, headRuns],
-  ] as const) {
-    if (runs.length === 0) continue
-    await Bun.write(
-      path.join(outputDirectory, `bencher-${suffix}.json`),
-      `${JSON.stringify(toBencherMetricFormat(runs), null, 2)}\n`
-    )
-  }
+if (markdown.length > 60_000 || markdown.trim().length === 0) {
+  throw new Error('Performance comment is empty or exceeds GitHub limits.')
 }
+await mkdir(output, { recursive: true })
+await Bun.write(path.join(output, 'metadata.json'), JSON.stringify(metadata))
+// Markdown is data. Do not interpolate it into shell commands or execute any artifact files.
+await Bun.write(path.join(output, 'performance-summary.md'), markdown)

--- a/scripts/performance/workflow.test.ts
+++ b/scripts/performance/workflow.test.ts
@@ -45,7 +45,7 @@ test('Android performance CI requires KVM and cannot fall back to software emula
   expect(emulator?.['pre-emulator-launch-script']).toContain('-accel-check')
   expect(emulator?.['emulator-options']).toContain('-accel on')
   expect(emulator?.['emulator-options']).toContain('-no-snapshot')
-  expect(emulator?.['script']).toContain('/ KVM')
+  expect(emulator?.script).toContain('/ KVM')
 })
 
 test('one trusted publisher handles internal and fork reports without executing PR code', async () => {
@@ -72,6 +72,29 @@ test('one trusted publisher handles internal and fork reports without executing 
     /pull_request.head.sha|bun install|NITRO_BENCHER_ENABLED/
   )
   expect(source).toContain('secrets.BENCHER_KEY')
+  expect(source).not.toMatch(
+    /generate-report|report-markdown|comparison\.ts|trusted-artifacts|raw\//
+  )
+  const aggregate = entry.jobs['nitro-performance']
+  expect(
+    aggregate.steps.find((s: any) => s.name === 'Checkout report tooling').with
+      .ref
+  ).toBe('${{ needs.prepare.outputs.head_sha }}')
+  expect(JSON.stringify(aggregate)).not.toContain('secrets.')
+  const renderIndex = aggregate.steps.findIndex(
+    (s: any) => s.name === 'Render performance report from HEAD'
+  )
+  const rawUploadIndex = aggregate.steps.findIndex(
+    (s: any) => s.name === 'Upload aggregate report'
+  )
+  expect(renderIndex).toBeGreaterThan(rawUploadIndex)
+  expect(aggregate.steps[renderIndex].run).toContain('generate-report.ts')
+  expect(aggregate.steps[renderIndex].run).toContain(
+    '${{ steps.raw-report.outputs.artifact-id }}'
+  )
+  expect(aggregate.steps[renderIndex + 1].with.name).toBe(
+    'performance-publication-${{ github.run_attempt }}'
+  )
   const steps = publisher.jobs.publish.steps as any[]
   expect(
     steps.find((s) => s.name === 'Download performance report').with[


### PR DESCRIPTION
Performance report changes currently need to reach `main` before a PR can show them: the privileged publisher reparses raw samples and renders Markdown using its own checkout. A new raw schema can also prevent the comment from being posted.

Generate Markdown and Bencher Metric Format files in the existing HEAD aggregation job instead. Show the report in the CI summary and save it as `performance-publication-<attempt>`. Keep raw JSON in the existing artifact, with the same comment links and presentation.

The trusted workflow selects that attempt's publication, checks its run/repository/revisions/current PR, and posts the Markdown unchanged. It neither parses raw measurements nor executes artifact code. Bencher retains its secret and final upload in the trusted workflow; its standard JSON adapter consumes the already-generated values after the comment is posted. Comments are PR-produced output, not independently recomputed by the bot.

Validation: 102 performance-tool tests, TypeScript and ESLint pass. Tests cover altered run/PR/fork provenance, stale results, empty/oversized comments, future raw schemas, HEAD job summaries and the Bencher upload handoff. Replaying the real artifacts from [#1622's run](https://github.com/margelo/nitro/actions/runs/34149469608) produces byte-identical Markdown and forwards it unchanged.

This PR installs the new handoff on `main` once. During its own review, HEAD-rendered output is available in the CI summary/artifact; the existing default-branch publisher still uses its old path until merge. Subsequent renderer and raw-schema changes will use HEAD without another publisher change.


Final-commit CI: [34152160489](https://github.com/margelo/nitro/actions/runs/34152160489) passed on both platforms. The HEAD aggregation job generated the report summary and [publication artifact](https://github.com/margelo/nitro/actions/runs/34152160489/artifacts/10030028397), linking the [raw JSON artifact](https://github.com/margelo/nitro/actions/runs/34152160489/artifacts/10030027896). Downloading those artifacts and regenerating the publication locally produced identical files; the new trusted validator accepted the real GitHub provenance and forwarded identical Markdown.
