### PR TITLE
ci: update iOS jobs to Ruby 3.3.12

### DIFF
--- a/.github/workflows/build-ios-release.yml
+++ b/.github/workflows/build-ios-release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Ruby (bundle)
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
+          ruby-version: 3.3.12
           bundler-cache: true
           working-directory: apps/example
 

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Ruby (bundle)
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
+          ruby-version: 3.3.12
           bundler-cache: true
           working-directory: apps/example
 

--- a/.github/workflows/harness-ios.yml
+++ b/.github/workflows/harness-ios.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Setup Ruby (bundle)
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
+          ruby-version: 3.3.12
           bundler-cache: true
           working-directory: apps/example
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -249,7 +249,7 @@ jobs:
           bun-version: 1.3.14
       - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
-          ruby-version: 3.3.0
+          ruby-version: 3.3.12
           working-directory: head/apps/benchmark
       - name: Select Xcode 26.5
         run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer

--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Ruby (bundle)
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
+          ruby-version: 3.3.12
           bundler-cache: true
           working-directory: apps/example/ios
 


### PR DESCRIPTION
Updates all five CI Ruby selections to 3.3.12. The example build, Release, Harness and lockfile jobs currently select Ruby 2.7.2; performance CI selects 3.3.0. Using one supported patch release removes the outdated interpreter selections while preserving the existing Gemfile and Bundler constraints.

Ruby 3.3.12 includes security fixes: https://www.ruby-lang.org/en/news/2026/07/16/ruby-3-3-12-released/. The pinned performance `ruby/setup-ruby` revision already lists this release in its supported versions.

Validation: workflow syntax and expressions pass actionlint with existing unrelated shellcheck diagnostics and custom Blacksmith runner-label warnings excluded. Confirmed that these five version selections are the only changes. Built Ruby 3.3.12 locally and installed both repository Gemfiles with Bundler 2.3.22 in deployment mode: bundle checks and CocoaPods 1.16.2 passed with unchanged lockfiles. Before the refresh onto the publisher rollout on main, commit `8eea48168` passed both Debug build configurations, Release, TSan Harness and both performance app builds: https://github.com/margelo/nitro/actions/runs/34153047762 and https://github.com/margelo/nitro/actions/runs/34153047789. These results validate the previous revision; the refreshed revision receives new hosted checks.

