### PR TITLE
ci: group dependency updates across the example and benchmark

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
       - "/packages/react-native-nitro-test-external/android/"
       - "/packages/template/android/"
       - "/apps/example/android/"
+      - "/apps/benchmark/android/"
     schedule:
       interval: "daily"
     labels:
@@ -25,6 +26,23 @@ updates:
       agp:
         patterns:
           - "com.android.tools.build:gradle"
+      shared-android-dependencies:
+        group-by: dependency-name
+        patterns:
+          - "*"
+
+  - package-ecosystem: "bundler"
+    directories:
+      - "/apps/example/"
+      - "/apps/benchmark/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+    groups:
+      cocoapods:
+        patterns:
+          - "*"
 
   - package-ecosystem: "bun"
     directories:
@@ -43,11 +61,13 @@ updates:
 
   - package-ecosystem: "bun"
     directories:
+      - "/"
       - "/packages/react-native-nitro-modules/"
       - "/packages/react-native-nitro-test/"
       - "/packages/react-native-nitro-test-external/"
       - "/packages/template/"
       - "/apps/example/"
+      - "/apps/benchmark/"
     schedule:
       interval: "daily"
     labels:
@@ -68,6 +88,10 @@ updates:
       react:
         patterns:
           - "react"
+      shared-dependencies:
+        group-by: dependency-name
+        patterns:
+          - "*"
 
   - package-ecosystem: "bun"
     directories:


### PR DESCRIPTION
Dependabot currently updates the example app while missing the benchmark and root workspace. Shared versions can drift, as the React Native CLI already did.

Extend the existing React, React Native, CLI and Babel groups across the root and both apps. Add benchmark Gradle coverage and group remaining shared dependencies by name across directories, keeping each dependency's updates together without combining unrelated updates. Add one CocoaPods/Bundler group for both apps' matching Gemfiles.

Stacked on #1584, which aligns the existing CLI mismatch and checks shared app declarations in CI. This PR only changes Dependabot configuration.

Validation: the Dependabot JSON schema, configured directory coverage, toolchain group matching and diff checks pass. Dependabot begins using the configuration once it reaches `main`.
