### PR TITLE
ci: cache benchmark gems for both revisions

### DIFF
--- a/.github/PERFORMANCE.md
+++ b/.github/PERFORMANCE.md
@@ -74,6 +74,8 @@ The app artifact includes base/head SHAs, suite hashes, Release configuration,
 architecture and toolchain metadata. iOS apps are tar archives to preserve
 permissions and symlinks. Gradle's basic cache is the sole Android cache owner;
 Gradle still checks source/task inputs, while exact app reuse is by artifact ID.
+Ruby's setup action caches each checkout's benchmark gems using its own Gemfile.lock
+and Ruby version. Identical revisions skip base gem setup along with the base build.
 There is no new iOS compiler cache. App reuse avoids build work on manual reruns. With 46 cases in each revision, a run
 uses 92 fresh processes (46 base + 46 head).
 Closer comparisons reduce time separation, but fixed base-first order can still

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -247,10 +247,19 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
-      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+      - name: Set up Ruby and cache head gems
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: 3.3.12
+          bundler-cache: true
           working-directory: head/apps/benchmark
+      - name: Cache base gems
+        if: needs.prepare.outputs.base_sha != needs.prepare.outputs.head_sha
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: 3.3.12
+          bundler-cache: true
+          working-directory: base/apps/benchmark
       - name: Select Xcode 26.5
         run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
       - name: Build and package exact simulator apps

--- a/scripts/performance/build-ios.sh
+++ b/scripts/performance/build-ios.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 cd "${1:?Usage: build-ios.sh <checkout-root> [application-id]}"
 bun install --frozen-lockfile
 cd apps/benchmark
-bundle install
+bundle check || bundle install
 bun pods
 cd ios
 xcodebuild \


### PR DESCRIPTION
Performance CI currently installs benchmark gems from scratch in both checkouts. Enable `ruby/setup-ruby`'s Bundler cache separately for head and base, letting the action key each cache by its checkout path, Ruby version and Gemfile.lock. Identical revisions skip the base setup because they reuse the head app.

The build script now checks the installed bundle before falling back to installation, so CI reuses the action's dependencies and standalone local builds still install missing gems.

Stacked on #1624 for the Ruby 3.3.12 upgrade.

Validation:
- Built Ruby 3.3.12 locally and used the locked Bundler 2.3.22 to install both repository Gemfiles in deployment mode; `bundle check` and CocoaPods 1.16.2 passed without changing either lockfile.
- Verified separate checkout bundle paths retain different locked gem versions simultaneously (benchmark 0.4.1 versus 0.4.0 in temporary fixtures).
- Actionlint workflow syntax/expressions, ShellCheck, Bash syntax and `git diff --check` pass. Existing Blacksmith runner labels were excluded from actionlint; no new shellcheck diagnostics were introduced.

Hosted cache restore performance still needs a warm CI run; the first run can populate the caches.

Before the refresh onto the publisher rollout on main, commit `040b31c26` passed hosted validation: https://github.com/margelo/nitro/actions/runs/34153344045/job/101840132508. Both checkout caches uploaded successfully, both `bundle check` calls reused installed dependencies, and both simulator apps built successfully. These results validate the previous revision; the refreshed revision receives new hosted checks.

