### PR TITLE
ci: silence avoidable Android emulator warnings

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -204,8 +204,8 @@ jobs:
           # CPU acceleration is required, independently of software GPU rendering.
           disable-linux-hw-accel: false
           emulator-boot-timeout: 300
-          pre-emulator-launch-script: '"$ANDROID_HOME/emulator/emulator" -version; "$ANDROID_HOME/emulator/emulator" -accel-check'
-          emulator-options: -accel on -no-window -gpu swiftshader -no-snapshot -noaudio -no-boot-anim -camera-back none
+          pre-emulator-launch-script: '"$ANDROID_HOME/emulator/emulator" -accel-check'
+          emulator-options: -accel on -no-window -gpu swiftshader -no-snapshot -noaudio -no-boot-anim -no-metrics -camera-back none
           script: >-
             bun scripts/performance/run-sequence.ts
             --platform android --base-app apps/base.apk --head-app apps/head.apk


### PR DESCRIPTION
The Android benchmark emulator's version probe fails while loading `libpulse.so.0`, then its exit status is hidden by the following acceleration probe. Remove the redundant version command and retain `-accel-check`, the KVM permission checks, and mandatory hardware acceleration.

Pass `-no-metrics` explicitly to avoid the emulator's telemetry-consent warning. This disables emulator telemetry only; benchmark result collection is unchanged.

Pre-rebase validation (`dce342a62`): actionlint with the repository's Blacksmith runner labels (including ShellCheck), workflow tests (4 tests), and `git diff --check` pass. [CI preparation/tooling tests passed](https://github.com/margelo/nitro/actions/runs/34153401665/job/101840138759).

Rebased onto main's performance-publication artifact update. `git range-diff` confirms the patch is unchanged; actionlint and ShellCheck pass again. Fresh native CI validation is pending.
