### PR TITLE
ci: bound benchmark simulator setup and cleanup

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -305,33 +305,34 @@ jobs:
         with:
           artifact-ids: ${{ env.BUILD_ARTIFACT_ID }}
           path: apps
-      - name: Run paired iOS benchmarks
+      - name: Create and boot iOS simulator
+        timeout-minutes: 5
         run: |
           set -euo pipefail
-          mkdir -p apps/base apps/head
-          if [[ -f apps/base.app.tar.gz ]]; then tar -xzf apps/base.app.tar.gz -C apps/base; fi
-          tar -xzf apps/head.app.tar.gz -C apps/head
           DEVICE_ID=$(xcrun simctl create \
             'Nitro Performance' \
             'com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro' \
             'com.apple.CoreSimulator.SimRuntime.iOS-26-5')
           echo "DEVICE_ID=$DEVICE_ID" >> "$GITHUB_ENV"
           xcrun simctl boot "$DEVICE_ID"
-          DEVICE_ID="$DEVICE_ID" bun -e '
-            const child = Bun.spawn(["xcrun", "simctl", "bootstatus", process.env.DEVICE_ID, "-b"], {
-              stdout: "inherit", stderr: "inherit", timeout: 300_000, killSignal: "SIGKILL",
-            });
-            if (await child.exited !== 0) throw new Error("iOS simulator did not boot successfully within five minutes.");
-          '
+          xcrun simctl bootstatus "$DEVICE_ID" -b
+      - name: Run paired iOS benchmarks
+        run: |
+          set -euo pipefail
+          mkdir -p apps/base apps/head
+          if [[ -f apps/base.app.tar.gz ]]; then tar -xzf apps/base.app.tar.gz -C apps/base; fi
+          tar -xzf apps/head.app.tar.gz -C apps/head
           bun scripts/performance/run-sequence.ts \
             --platform ios --base-app apps/base/NitroBenchmark.app --head-app apps/head/NitroBenchmark.app \
             --build-metadata apps/build.json \
             --base-sha "$BASE_SHA" --head-sha "$HEAD_SHA" \
             --output-directory performance-ios --device-id "$DEVICE_ID" \
+            --fresh-ios-simulator true \
             --device 'iPhone 17 Pro simulator / Blacksmith 6 vCPU' --os-version 'iOS 26.5' \
             --architecture arm64 --toolchain "$(jq -r .toolchain apps/build.json)"
       - name: Delete simulator
         if: always() && env.DEVICE_ID != ''
+        timeout-minutes: 1
         run: |
           xcrun simctl shutdown "$DEVICE_ID" || true
           xcrun simctl delete "$DEVICE_ID" || true

--- a/scripts/performance/run-device.ts
+++ b/scripts/performance/run-device.ts
@@ -210,15 +210,19 @@ export async function installApp(
   platform: 'android' | 'ios',
   deviceId: string,
   app: string,
-  appId: string
+  appId: string,
+  options: { freshIosSimulator?: boolean } = {}
 ): Promise<void> {
   if (platform === 'android') {
     await command('adb', ['-s', deviceId, 'uninstall', appId], true)
     await command('adb', ['-s', deviceId, 'install', '-r', app])
     await command('adb', ['-s', deviceId, 'reverse', 'tcp:8173', 'tcp:8173'])
   } else {
-    await command('xcrun', ['simctl', 'terminate', deviceId, appId], true)
-    await command('xcrun', ['simctl', 'uninstall', deviceId, appId], true)
+    // Only a newly created simulator is known to have no previous app state.
+    if (!options.freshIosSimulator) {
+      await command('xcrun', ['simctl', 'terminate', deviceId, appId], true)
+      await command('xcrun', ['simctl', 'uninstall', deviceId, appId], true)
+    }
     await command('xcrun', ['simctl', 'install', deviceId, app])
   }
 }

--- a/scripts/performance/run-sequence.test.ts
+++ b/scripts/performance/run-sequence.test.ts
@@ -8,21 +8,23 @@ import { compareRuns } from './comparison'
 // Exercise the real controller/receiver with a tiny process standing in for
 // simctl's app. Runner tests separately exercise fixed work across different execution speeds.
 test.each([
-  ['ios', 'paired', false],
-  ['ios', 'paired', true],
-  ['ios', 'changed-suite', true],
-  ['ios', 'added-case', true],
-  ['ios', 'removed-case', true],
-  ['ios', 'same-sha', true],
-  ['android', 'paired', true],
-  ['android', 'same-sha', true],
-  ['android', 'changed-suite', true],
-  ['android', 'added-case', true],
-  ['android', 'removed-case', true],
-  ['ios', 'invalid-result', true],
+  ['ios', 'paired', false, false],
+  ['ios', 'paired', true, false],
+  ['ios', 'changed-suite', true, false],
+  ['ios', 'added-case', true, false],
+  ['ios', 'removed-case', true, false],
+  ['ios', 'same-sha', true, false],
+  ['android', 'paired', true, false],
+  ['android', 'same-sha', true, false],
+  ['android', 'changed-suite', true, false],
+  ['android', 'added-case', true, false],
+  ['android', 'removed-case', true, false],
+  ['ios', 'invalid-result', true, false],
+  ['ios', 'paired', true, true],
+  ['ios', 'same-sha', true, true],
 ] as const)(
-  '%s per-case comparisons: %s, saved apps = %s',
-  async (platform, mode, savedApps) => {
+  '%s per-case comparisons: %s, saved apps = %s, fresh simulator = %s',
+  async (platform, mode, savedApps, freshIosSimulator) => {
     const changedSuite = [
       'changed-suite',
       'added-case',
@@ -126,6 +128,7 @@ test.each([
           path.join(import.meta.dir, 'run-sequence.ts'),
           '--platform',
           platform,
+          ...(freshIosSimulator ? ['--fresh-ios-simulator', 'true'] : []),
           '--base-app',
           path.join(directory, 'base.app'),
           '--head-app',
@@ -213,6 +216,28 @@ test.each([
           ? [path.join(directory, 'head.app')]
           : [path.join(directory, 'head.app'), path.join(directory, 'base.app')]
       )
+      if (platform === 'ios') {
+        const preinstallCleanup = commands
+          .slice(
+            0,
+            commands.findIndex((args) => args.includes('launch'))
+          )
+          .filter((args) => ['terminate', 'uninstall'].includes(args[1]!))
+        expect(preinstallCleanup).toEqual(
+          freshIosSimulator
+            ? []
+            : (sameBinary
+                ? ['com.margelo.nitrobenchmark.head']
+                : [
+                    'com.margelo.nitrobenchmark.head',
+                    'com.margelo.nitrobenchmark',
+                  ]
+              ).flatMap((appId) => [
+                ['simctl', 'terminate', 'fixture', appId],
+                ['simctl', 'uninstall', 'fixture', appId],
+              ])
+        )
+      }
       const launches = commands.filter(
         (args) => args.includes('launch') || args.includes('start')
       )
@@ -315,4 +340,29 @@ test.each([
     }
   },
   20_000
+)
+
+test.each([
+  ['ios', 'yes'],
+  ['android', 'true'],
+])(
+  'reject an invalid fresh simulator assertion: %s, %s',
+  async (platform, fresh) => {
+    const child = Bun.spawn(
+      [
+        'bun',
+        path.join(import.meta.dir, 'run-sequence.ts'),
+        '--platform',
+        platform!,
+        '--fresh-ios-simulator',
+        fresh!,
+      ],
+      { stdout: 'pipe', stderr: 'pipe' }
+    )
+    const stderr = await new Response(child.stderr).text()
+    expect(await child.exited).not.toBe(0)
+    expect(stderr).toContain(
+      '--fresh-ios-simulator must be true or false, and requires iOS when true.'
+    )
+  }
 )

--- a/scripts/performance/run-sequence.ts
+++ b/scripts/performance/run-sequence.ts
@@ -13,6 +13,17 @@ if (platformArgument !== 'android' && platformArgument !== 'ios') {
   throw new Error('--platform must be android or ios.')
 }
 const platform = platformArgument
+const freshIosSimulator =
+  argumentsMap.get('fresh-ios-simulator')?.[0] ?? 'false'
+if (
+  !['true', 'false'].includes(freshIosSimulator) ||
+  (freshIosSimulator === 'true' && platform !== 'ios')
+) {
+  throw new Error(
+    '--fresh-ios-simulator must be true or false, and requires iOS when true.'
+  )
+}
+const installOptions = { freshIosSimulator: freshIosSimulator === 'true' }
 const baseApp = path.resolve(requiredArgument(argumentsMap, 'base-app'))
 const headApp = path.resolve(requiredArgument(argumentsMap, 'head-app'))
 const baseSha = requiredArgument(argumentsMap, 'base-sha')
@@ -78,9 +89,9 @@ await Bun.write(
 const sameBinary = baseSha === headSha
 const headId = 'com.margelo.nitrobenchmark.head'
 const baseId = sameBinary ? headId : 'com.margelo.nitrobenchmark'
-await installApp(platform, deviceId, headApp, headId)
+await installApp(platform, deviceId, headApp, headId, installOptions)
 if (!sameBinary) {
-  await installApp(platform, deviceId, baseApp, baseId)
+  await installApp(platform, deviceId, baseApp, baseId, installOptions)
 }
 
 async function runCase(

--- a/scripts/performance/workflow.test.ts
+++ b/scripts/performance/workflow.test.ts
@@ -3,6 +3,39 @@ import { readFile, mkdtemp, mkdir, rm } from 'node:fs/promises'
 import path from 'node:path'
 import os from 'node:os'
 
+test('iOS creation and boot share a setup deadline before fresh-simulator measurements', async () => {
+  const workflow = Bun.YAML.parse(
+    await readFile(
+      new URL('../../.github/workflows/performance.yml', import.meta.url),
+      'utf8'
+    )
+  ) as any
+  const steps = workflow.jobs['measure-ios'].steps as any[]
+  const setupIndex = steps.findIndex(
+    (step) => step.name === 'Create and boot iOS simulator'
+  )
+  const measurementIndex = steps.findIndex(
+    (step) => step.name === 'Run paired iOS benchmarks'
+  )
+  const setup = steps[setupIndex]
+  expect(setupIndex).toBeGreaterThanOrEqual(0)
+  expect(setupIndex).toBeLessThan(measurementIndex)
+  expect(setup['timeout-minutes']).toBe(5)
+  for (const command of ['create', 'boot', 'bootstatus']) {
+    expect(setup.run).toContain(`xcrun simctl ${command}`)
+  }
+  // Retain the new ID for always() cleanup even if boot or bootstatus times out.
+  expect(setup.run.indexOf('>> "$GITHUB_ENV"')).toBeLessThan(
+    setup.run.indexOf('xcrun simctl boot')
+  )
+  expect(steps[measurementIndex].if).toBeUndefined()
+  expect(steps[measurementIndex].run).toContain('--fresh-ios-simulator true')
+  const cleanup = steps.find((step) => step.name === 'Delete simulator')
+  expect(cleanup.if).toBe("always() && env.DEVICE_ID != ''")
+  expect(cleanup['timeout-minutes']).toBe(1)
+  expect(cleanup.run).toContain('xcrun simctl delete "$DEVICE_ID"')
+})
+
 test('Android performance CI requires KVM and cannot fall back to software emulation', async () => {
   const source = await readFile(
     new URL('../../.github/workflows/performance.yml', import.meta.url),


### PR DESCRIPTION
Simulator creation and `simctl boot` can currently hang before the five-minute `bootstatus` timer starts. Put all three commands in one setup step with a five-minute Actions deadline, and give final simulator cleanup a one-minute deadline. Export the device ID immediately after creation so cleanup can run when boot fails or times out.

After successful setup, explicitly mark the newly created CI simulator as fresh. Skip preinstall terminate/uninstall calls for apps that cannot yet exist. Reused simulators keep that cleanup by default; each benchmark case still launches and terminates its own process.

Validation on `c7576d288e314744bd3f52992924fe3a9cf74c2c`: all GitHub checks passed, including TypeScript, lint, Nitrogen on both platforms, both native builds and both device measurement jobs. [The iOS job](https://github.com/margelo/nitro/actions/runs/34154047323/job/101843586653) completed all 92 measurements, created/booted the simulator in 38 seconds and deleted it in four seconds. The two expected missing-app termination errors seen in unchanged runs are absent.

Local tests cover fresh/reused installations, paired and same-SHA runs, invalid freshness flags and per-case process isolation. Workflow checks verify that create/boot/bootstatus share the setup deadline and final cleanup has its own deadline; GitHub Actions enforces the timeouts. TypeScript, actionlint, ShellCheck and diff checks pass. Rebase patch equivalence was verified with `git range-diff`.

Timing review:

| Run | Entire iOS measurement job | Boot-ready to first app launch |
|---|---:|---:|
| [Current PR](https://github.com/margelo/nitro/actions/runs/34154047323/job/101843586653) | 7m00s | 6.61s |
| [Unchanged iOS controller, #1628](https://github.com/margelo/nitro/actions/runs/34154006746/job/101843657056) | 7m18s | 7.81s |
| [Unchanged iOS controller, #1629](https://github.com/margelo/nitro/actions/runs/34154016158/job/101844038990) | 7m01s | 8.46s |
| [PR before rebase](https://github.com/margelo/nitro/actions/runs/34153422173/job/101841318614) | Cancelled by rebase | 24.53s |

The current run and controls share the same base and iOS runner/toolchain. These are separate hosted runs, and app extraction moved to after boot in this PR. The latest run is slightly shorter, but startup variation prevents attributing a reliable overall speedup to the change. The demonstrated benefits are bounded setup/cleanup and removing unnecessary commands/errors. Leave open under the requested works-and-speeds-up-CI merge condition.
