### PR TITLE
ci: maintain native lockfiles for both apps

### DIFF
--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -11,6 +11,8 @@ on:
       - ".github/workflows/update-lockfiles.yml"
       - "package.json"
       - "**/package.json"
+      - "**/Gemfile"
+      - "**/Gemfile.lock"
 
 permissions:
   contents: write
@@ -41,18 +43,17 @@ jobs:
       - run: |
           bun install
 
-          cd apps/example
-          bundle install
-          bun pods
-          cd "$GITHUB_WORKSPACE"
+          for app in apps/example apps/benchmark; do
+            bun --cwd "$app" bundle-install
+            bun --cwd "$app" pods
+            git add "$app/Gemfile.lock" "$app/ios/Podfile.lock"
+          done
 
           cd docs
           bun install
           cd ..
 
           git add bun.lock
-          git add apps/example/ios/Podfile.lock
-          git add apps/example/Gemfile.lock
 
           git config --global user.name 'dependabot[bot]'
           git config --global user.email 'dependabot[bot]@users.noreply.github.com'

--- a/scripts/try-install-lockfiles.sh
+++ b/scripts/try-install-lockfiles.sh
@@ -11,12 +11,14 @@ cd "$(pwd)" || exit 0
   bun i
   bun run build
 
-  # Install example pods
-  bun example bundle-install
-  bun example pods
+  # Refresh both apps' Ruby and CocoaPods lockfiles
+  for app in apps/example apps/benchmark; do
+    bun --cwd "$app" bundle-install
+    bun --cwd "$app" pods
+    git add "$app/Gemfile.lock" "$app/ios/Podfile.lock"
+  done
 
-  # Add everything to git
-  git add **/*.lock
+  git add bun.lock
 } || true
 
 # No errors - whatever.


### PR DESCRIPTION
Stacked on #1626.

Dependency lock maintenance currently refreshes only the example app, and Gemfile-only updates do not trigger it. Refresh and stage both apps' Gemfile.lock and Podfile.lock files, and include Gemfile/Gemfile.lock changes in the pull-request paths.

Apply the same two-app loop to the release lockfile hook, with explicit lockfile staging and its existing best-effort behavior.

Validation: actionlint, ShellCheck, Bash syntax, and diff checks pass. Disposable fixtures exercised the actual workflow shell commands before publishing and the release hook: both apps' commands and all five staged lockfiles are correct; CI stops on an install failure while the release hook continues. App script paths and Gemfile triggers were also checked.

The live maintenance job runs only for `dependabot[bot]`, so it will skip this human-authored PR. Native dependency installation and bot publishing still need validation on a Dependabot PR.
