### PR TITLE
ci: keep completed performance reports visible as PRs advance

### DIFF
--- a/.github/PERFORMANCE.md
+++ b/.github/PERFORMANCE.md
@@ -96,13 +96,31 @@ Renderer and raw-schema changes can therefore be reviewed in PR CI before mergin
 
 One default-branch `Publish Nitro Performance` workflow handles internal PRs,
 forks and main runs. It selects the exact publication artifact for the triggering
-attempt, checks its repository, run, revisions and current PR against GitHub,
-and posts its Markdown unchanged. It reads no raw samples and never installs or
-executes PR code or artifact scripts. Comment content is produced by PR code;
+attempt, checks its repository, run, measured head SHA and PR source branch
+against GitHub, and posts its Markdown with a trusted measured-commit/run label.
+It reads no raw samples and never installs or executes PR code or artifact scripts. Comment content is produced by PR code;
 provenance checks establish its source, not the correctness of its measurements.
 Docs-only and cancelled runs skip publication. Markdown/MDX-only edits also skip
 measurements inside package/app directories. Relevant failures remain failures.
-Stale PR results are skipped. User comments are never edited.
+Completed reports remain useful when an open PR's head or base has advanced.
+They identify the measured commits and say when the PR has changed. A newer run
+that is still building does not hide the last completed result. Closed PRs are
+skipped, and user comments are never edited.
+
+A hidden marker on the bot comment identifies its source run and attempt. The
+publisher resolves that attempt through GitHub and checks that it completed
+successfully on the same source repository and branch. Higher run numbers win;
+within one run, higher attempts win. A late completion or rerun of an older run
+cannot replace a newer report. Retrying the same publication updates the same
+comment. Legacy comments use their existing run/attempt footer for the same lookup.
+Unrecognized or mismatched source claims cannot freeze future comments; lookup
+failures stop publication rather than risk replacing a newer result.
+
+Publishing is serialized per source repository and branch, including forks, so
+checking the marker and updating the comment cannot race with another publisher.
+`queue: max` retains up to 100 waiting publications instead of canceling the
+previous pending job. This ordering policy takes effect after the trusted
+publisher reaches `main`; HEAD run summaries are already available during review.
 
 The publication envelope is independent of raw app schema versions. Keep its
 filenames and identity fields stable when changing benchmarks or report rendering.
@@ -113,6 +131,8 @@ The trusted workflow also performs the final Bencher upload with `BENCHER_KEY`;
 that secret never reaches HEAD code. Its CLI version and binary digest are pinned.
 Bencher's JSON adapter validates the already-generated BMF files. The comment is
 posted first so an invalid BMF file cannot prevent the report from appearing.
+Bencher keeps its current-revision policy: advanced PR results can appear in the
+comment without being uploaded to history, and superseded reports skip history.
 Bencher receives median latency values without invented bounds. PR publications
 seed both measured platform baselines at `baseline-<base SHA>` before recording
 the head at `pr-<number>`. Only main-branch runs record main history. Bencher

--- a/.github/workflows/performance-report.yml
+++ b/.github/workflows/performance-report.yml
@@ -5,6 +5,12 @@ on:
     workflows: [Nitro Performance]
     types: [completed]
 
+# Serialize comment reads/writes for each PR source, including fork branches.
+# Preserve queued reports; a late older completion must not cancel a newer one.
+concurrency:
+  group: nitro-performance-publisher-${{ github.event.workflow_run.head_repository.id }}-${{ github.event.workflow_run.head_branch }}
+  queue: max
+
 permissions:
   actions: read
   contents: read
@@ -64,7 +70,7 @@ jobs:
 
       - name: Create Nitro Modules Bot token
         id: performance-bot-token
-        if: steps.download.outcome == 'success' && steps.validate.outputs.stale != 'true' && vars.NITRO_PERFORMANCE_APP_CLIENT_ID != '' && github.event.workflow_run.event == 'pull_request'
+        if: steps.download.outcome == 'success' && steps.validate.outputs.closed != 'true' && vars.NITRO_PERFORMANCE_APP_CLIENT_ID != '' && github.event.workflow_run.event == 'pull_request'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.NITRO_PERFORMANCE_APP_CLIENT_ID }}
@@ -72,25 +78,27 @@ jobs:
           permission-pull-requests: write
 
       - name: Post paired comparison to the PR
-        if: steps.download.outcome == 'success' && steps.validate.outputs.stale != 'true'
+        id: comment
+        if: steps.download.outcome == 'success' && steps.validate.outputs.closed != 'true'
         env:
           GITHUB_TOKEN: ${{ steps.performance-bot-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_APP_SLUG: ${{ steps.performance-bot-token.outputs.app-slug }}
         run: bun scripts/performance/github-report.ts --directory validated-report
 
       - name: Install Bencher CLI
-        if: steps.download.outcome == 'success' && steps.validate.outputs.stale != 'true'
+        if: steps.download.outcome == 'success' && steps.validate.outputs.closed != 'true' && steps.validate.outputs.stale != 'true' && steps.comment.outputs.publish_history != 'false'
         uses: bencherdev/bencher@8d75325c3bc59403a2186a056b472c4f49d42838 # v0.6.12
         with:
           version: '0.6.12'
 
       - name: Verify pinned Bencher binary
-        if: steps.download.outcome == 'success' && steps.validate.outputs.stale != 'true'
+        if: steps.download.outcome == 'success' && steps.validate.outputs.closed != 'true' && steps.validate.outputs.stale != 'true' && steps.comment.outputs.publish_history != 'false'
         run: |
           printf '%s  %s\n' 'c2d3a6a7fae654246134e5ced1408bdb9ba4e198b0ac3b903af17a06574a7e08' "$(command -v bencher)" | sha256sum --check -
 
       - name: Publish Bencher history
-        if: steps.download.outcome == 'success' && steps.validate.outputs.stale != 'true'
+        if: steps.download.outcome == 'success' && steps.validate.outputs.closed != 'true' && steps.validate.outputs.stale != 'true' && steps.comment.outputs.publish_history != 'false'
         env:
           BENCHER_API_KEY: ${{ secrets.BENCHER_KEY }}
           BENCHER_PROJECT: nitro

--- a/scripts/performance/github-report.test.ts
+++ b/scripts/performance/github-report.test.ts
@@ -6,134 +6,392 @@ const report = {
   pullRequestNumber: 123,
   baseSha: 'a'.repeat(40),
   headSha: 'b'.repeat(40),
+  workflowRunId: 123456,
+  workflowRunNumber: 50,
+  runAttempt: 2,
   markdown: '## Nitro performance\n\n| Benchmark | Base | Head |',
 }
 const pullRequest = {
   state: 'open',
   base: { sha: report.baseSha },
-  head: { sha: report.headSha },
+  head: {
+    sha: report.headSha,
+    ref: 'feature',
+    repo: { full_name: 'contributor/nitro' },
+  },
 }
 const marker = '<!-- nitro-performance-paired-comparison -->'
+const botLogin = 'github-actions[bot]'
+type Comment = {
+  id: number
+  body: string
+  user: { login: string; type: string }
+}
+
+function github(comments: Comment[] = []) {
+  const writes: { endpoint: string; method: string; body: string }[] = []
+  const requests: string[] = []
+  const fixture = {
+    comments,
+    writes,
+    requests,
+    pullRequest,
+    existingRun: {} as Record<string, unknown>,
+    async request(endpoint: string, method = 'GET', body?: { body: string }) {
+      requests.push(endpoint)
+      if (method !== 'GET') {
+        writes.push({ endpoint, method, body: body!.body })
+        if (method === 'PATCH') {
+          comments.find((c) => endpoint.endsWith(`/${c.id}`))!.body = body!.body
+        } else {
+          comments.push({
+            id: 999,
+            body: body!.body,
+            user: { login: botLogin, type: 'Bot' },
+          })
+        }
+        return {}
+      }
+      if (endpoint.includes('/pulls/')) return fixture.pullRequest
+      if (endpoint.includes('/actions/runs/')) {
+        const [, id, attempt] = /\/runs\/(\d+)\/attempts\/(\d+)$/.exec(
+          endpoint
+        )!
+        return {
+          id: Number(id),
+          run_attempt: Number(attempt),
+          run_number: Number(id) - 123406,
+          name: 'Nitro Performance',
+          status: 'completed',
+          conclusion: 'success',
+          head_branch: 'feature',
+          head_repository: { full_name: 'contributor/nitro' },
+          ...fixture.existingRun,
+        }
+      }
+      const page = Number(
+        new URL(`https://api.github.com${endpoint}`).searchParams.get('page')
+      )
+      return comments.slice((page - 1) * 100, page * 100)
+    },
+  }
+  return fixture
+}
+
+function previous(runNumber: number, attempt = 1, login = botLogin): Comment {
+  return {
+    id: 2,
+    body: `${marker}\n<!-- nitro-performance-source: ${123406 + runNumber}.${attempt} -->\nPrevious results`,
+    user: { login, type: 'Bot' },
+  }
+}
 
 describe('paired performance PR comment', () => {
-  test('creates a comment without modifying user comments', async () => {
-    const writes: unknown[] = []
-    const status = await postPerformanceComment(
-      report,
-      async (endpoint, method = 'GET', body) => {
-        if (method !== 'GET') {
-          writes.push({ endpoint, method, body })
-          return {}
-        }
-        if (endpoint.includes('/pulls/')) return pullRequest
-        return [{ id: 1, body: marker, user: { login: 'user', type: 'User' } }]
-      }
+  test('creates one report with the trusted measured commit and source attempt', async () => {
+    const userComment = {
+      id: 1,
+      body: marker,
+      user: { login: 'user', type: 'User' },
+    }
+    const api = github([userComment])
+    expect(await postPerformanceComment(report, api.request)).toEqual({
+      status: 'created',
+      current: true,
+    })
+    expect(api.writes).toHaveLength(1)
+    expect(api.writes[0]).toMatchObject({
+      endpoint: '/repos/margelo/nitro/issues/123/comments',
+      method: 'POST',
+    })
+    expect(api.writes[0]!.body).toContain(
+      '<!-- nitro-performance-source: 123456.2 -->'
     )
-    expect(status).toBe('created')
-    expect(writes).toEqual([
-      {
-        endpoint: '/repos/margelo/nitro/issues/123/comments',
-        method: 'POST',
-        body: { body: `${marker}\n${report.markdown}` },
-      },
-    ])
+    expect(api.writes[0]!.body).toContain(`/commit/${report.headSha}`)
+    expect(api.writes[0]!.body).toContain(`/commit/${report.baseSha}`)
+    expect(api.writes[0]!.body).toContain('/actions/runs/123456/attempts/2')
+    expect(api.writes[0]!.body).toEndWith(report.markdown)
+    expect(api.comments[0]).toEqual(userComment)
   })
 
   test.each(['github-actions[bot]', 'nitro-modules-bot[bot]'])(
-    'updates only the existing paired comparison from %s',
-    async (botLogin) => {
-      const writes: unknown[] = []
-      const status = await postPerformanceComment(
-        report,
-        async (endpoint, method = 'GET', body) => {
-          if (method !== 'GET') {
-            writes.push({ endpoint, method, body })
-            return {}
-          }
-          if (endpoint.includes('/pulls/')) return pullRequest
-          return [
-            {
-              id: 1,
-              body: `${marker}\nother bot's report`,
-              user: { login: 'another-app[bot]', type: 'Bot' },
-            },
-            {
-              id: 2,
-              body: `${marker}\nold report`,
-              user: { login: botLogin, type: 'Bot' },
-            },
-          ]
-        },
-        botLogin
-      )
-      expect(status).toBe('updated')
-      expect(writes).toEqual([
-        {
-          endpoint: '/repos/margelo/nitro/issues/comments/2',
-          method: 'PATCH',
-          body: { body: `${marker}\n${report.markdown}` },
-        },
-      ])
+    'updates only its existing report as %s',
+    async (login) => {
+      const otherBot = previous(900, 1, 'another-app[bot]')
+      otherBot.id = 1
+      const api = github([otherBot, previous(49, 1, login)])
+      expect(
+        (await postPerformanceComment(report, api.request, login)).status
+      ).toBe('updated')
+      expect(api.writes[0]).toMatchObject({
+        endpoint: '/repos/margelo/nitro/issues/comments/2',
+        method: 'PATCH',
+      })
+      expect(api.comments[0]).toEqual(otherBot)
     }
   )
 
-  test('creates a new custom bot comment when migrating from GitHub Actions', async () => {
-    const writes: unknown[] = []
-    const status = await postPerformanceComment(
-      report,
-      async (endpoint, method = 'GET', body) => {
-        if (method !== 'GET') {
-          writes.push({ endpoint, method, body })
-          return {}
-        }
-        if (endpoint.includes('/pulls/')) return pullRequest
-        return [
-          {
-            id: 1,
-            body: `${marker}\nold report`,
-            user: { login: 'github-actions[bot]', type: 'Bot' },
-          },
-          {
-            id: 2,
-            body: marker,
-            user: { login: 'nitro-modules-bot[bot]', type: 'User' },
-          },
-        ]
-      },
-      'nitro-modules-bot[bot]'
-    )
-    expect(status).toBe('created')
-    expect(writes).toEqual([
+  test('keeps the existing author when migrating to a custom bot', async () => {
+    const old = previous(49)
+    const api = github([
+      old,
       {
-        endpoint: '/repos/margelo/nitro/issues/123/comments',
-        method: 'POST',
-        body: { body: `${marker}\n${report.markdown}` },
+        id: 3,
+        body: marker,
+        user: { login: 'nitro-modules-bot[bot]', type: 'User' },
       },
     ])
+    expect(
+      (
+        await postPerformanceComment(
+          report,
+          api.request,
+          'nitro-modules-bot[bot]'
+        )
+      ).status
+    ).toBe('created')
+    expect(api.comments[0]).toEqual(old)
+  })
+
+  test.each(['base', 'head'] as const)(
+    'posts completed results after the PR %s advances',
+    async (revision) => {
+      const api = github()
+      api.pullRequest = {
+        ...pullRequest,
+        [revision]: { ...pullRequest[revision], sha: 'c'.repeat(40) },
+      }
+      expect(await postPerformanceComment(report, api.request)).toEqual({
+        status: 'created',
+        current: false,
+      })
+      expect(api.writes[0]!.body).toContain(
+        'The PR has advanced since these measurements.'
+      )
+      expect(api.writes[0]!.body).toContain(`/commit/${report.headSha}`)
+      // A newer running workflow does not suppress the last completed result.
+      expect(
+        api.requests.some((endpoint) => endpoint.includes('/actions/'))
+      ).toBe(false)
+    }
+  )
+
+  test('never posts to a closed PR', async () => {
+    const api = github()
+    api.pullRequest = { ...pullRequest, state: 'closed' }
+    expect(await postPerformanceComment(report, api.request)).toEqual({
+      status: 'closed',
+      current: false,
+    })
+    expect(api.writes).toHaveLength(0)
+  })
+
+  test('an old run finishing late cannot overwrite a newer completed report, even on a later rerun', async () => {
+    const api = github()
+    await postPerformanceComment(
+      {
+        ...report,
+        workflowRunNumber: 51,
+        workflowRunId: 123457,
+        headSha: 'c'.repeat(40),
+      },
+      api.request
+    )
+    const newest = api.comments[0]!.body
+    expect(
+      (await postPerformanceComment({ ...report, runAttempt: 99 }, api.request))
+        .status
+    ).toBe('superseded')
+    expect(api.comments[0]!.body).toBe(newest)
+    expect(api.writes).toHaveLength(1)
+  })
+
+  test('a newer attempt replaces the same run, while a delayed earlier attempt cannot', async () => {
+    const api = github([previous(50, 1)])
+    expect((await postPerformanceComment(report, api.request)).status).toBe(
+      'updated'
+    )
+    const latest = api.comments[0]!.body
+    expect(
+      (await postPerformanceComment({ ...report, runAttempt: 1 }, api.request))
+        .status
+    ).toBe('superseded')
+    expect(api.comments[0]!.body).toBe(latest)
+    expect(api.writes).toHaveLength(1)
+  })
+
+  test('retrying the same publication updates the same comment', async () => {
+    const api = github()
+    await postPerformanceComment(report, api.request)
+    expect((await postPerformanceComment(report, api.request)).status).toBe(
+      'updated'
+    )
+    expect(api.comments).toHaveLength(1)
+    expect(api.writes[0]!.body).toBe(api.writes[1]!.body)
+  })
+
+  test.each(
+    [
+      [0, 1, 2],
+      [0, 2, 1],
+      [1, 0, 2],
+      [1, 2, 0],
+      [2, 0, 1],
+      [2, 1, 0],
+    ].map((order) => ({ order }))
+  )(
+    'serialized publishers keep the newest report for completion order %j',
+    async ({ order }) => {
+      const api = github()
+      const reports = [
+        {
+          ...report,
+          workflowRunNumber: 49,
+          workflowRunId: 123455,
+          runAttempt: 20,
+        },
+        { ...report, runAttempt: 1 },
+        report,
+      ]
+      for (const index of order)
+        await postPerformanceComment(reports[index]!, api.request)
+      expect(api.comments).toHaveLength(1)
+      expect(api.comments[0]!.body).toContain(
+        '<!-- nitro-performance-source: 123456.2 -->'
+      )
+    }
+  )
+
+  test('finds a newer bot report beyond the first page before posting', async () => {
+    const comments = Array.from({ length: 100 }, (_, id) => ({
+      id,
+      body: 'User comment',
+      user: { login: 'user', type: 'User' },
+    }))
+    const api = github([...comments, previous(51)])
+    expect((await postPerformanceComment(report, api.request)).status).toBe(
+      'superseded'
+    )
+    expect(api.requests).toContain(
+      '/repos/margelo/nitro/issues/123/comments?per_page=100&page=2'
+    )
+    expect(api.writes).toHaveLength(0)
+  })
+
+  test.each([49, 51])(
+    'migrates a legacy comment without losing newer completed run %i',
+    async (runNumber) => {
+      const comment = previous(49)
+      comment.body = `${marker}\nLegacy report\nRun 123455, attempt 1. Download requires GitHub access.`
+      const api = github([comment])
+      api.existingRun.run_number = runNumber
+      expect((await postPerformanceComment(report, api.request)).status).toBe(
+        runNumber < 50 ? 'updated' : 'superseded'
+      )
+      expect(api.requests).toContain(
+        '/repos/margelo/nitro/actions/runs/123455/attempts/1'
+      )
+      expect(api.writes).toHaveLength(runNumber < 50 ? 1 : 0)
+    }
+  )
+
+  test('preserves a newer legacy attempt of the same run', async () => {
+    const comment = previous(50)
+    comment.body = `${marker}\nLegacy report\nRun 123456, attempt 3.`
+    const api = github([comment])
+    api.existingRun.run_number = 50
+    expect((await postPerformanceComment(report, api.request)).status).toBe(
+      'superseded'
+    )
+    expect(api.writes).toHaveLength(0)
+  })
+
+  test('does not let unrecognized legacy metadata freeze future reports', async () => {
+    const comment = previous(50)
+    comment.body = `${marker}\nUnrecognized report`
+    const api = github([comment])
+    expect((await postPerformanceComment(report, api.request)).status).toBe(
+      'updated'
+    )
+    expect(api.writes).toHaveLength(1)
+  })
+
+  test.each([
+    { name: 'Unrelated workflow' },
+    { head_branch: 'another-feature' },
+    { head_repository: { full_name: 'another/nitro' } },
+    { status: 'in_progress', conclusion: null },
+    { conclusion: 'failure' },
+    { run_attempt: 999 },
+  ])(
+    'ignores forged source metadata outside completed reports from this PR: %j',
+    async (source) => {
+      const api = github([previous(999)])
+      api.existingRun = source
+      expect((await postPerformanceComment(report, api.request)).status).toBe(
+        'updated'
+      )
+      expect(api.writes).toHaveLength(1)
+    }
+  )
+
+  test('resolves marker run IDs instead of trusting a forged sequence number', async () => {
+    const api = github([previous(999)])
+    api.existingRun.run_number = 49
+    expect((await postPerformanceComment(report, api.request)).status).toBe(
+      'updated'
+    )
+    expect(api.writes).toHaveLength(1)
+  })
+
+  test('a missing forged source cannot freeze future reports', async () => {
+    const api = github([previous(999)])
+    const request = async (
+      endpoint: string,
+      method = 'GET',
+      body?: { body: string }
+    ) =>
+      endpoint.includes('/actions/runs/')
+        ? null
+        : api.request(endpoint, method, body)
+    expect((await postPerformanceComment(report, request)).status).toBe(
+      'updated'
+    )
+    expect(api.writes).toHaveLength(1)
+  })
+
+  test('fails safely if source provenance cannot be checked because GitHub is unavailable', async () => {
+    const api = github([previous(51)])
+    const request = async (
+      endpoint: string,
+      method = 'GET',
+      body?: { body: string }
+    ) => {
+      if (endpoint.includes('/actions/runs/'))
+        throw new Error('GitHub unavailable')
+      return api.request(endpoint, method, body)
+    }
+    await expect(postPerformanceComment(report, request)).rejects.toThrow(
+      'GitHub unavailable'
+    )
+    expect(api.writes).toHaveLength(0)
   })
 
   test('rejects a human author before making requests', async () => {
-    let requests = 0
+    const api = github()
     await expect(
-      postPerformanceComment(
-        report,
-        async () => {
-          requests++
-          return {}
-        },
-        'mrousavy'
-      )
+      postPerformanceComment(report, api.request, 'mrousavy')
     ).rejects.toThrow('Performance comment author must be a GitHub bot login.')
-    expect(requests).toBe(0)
+    expect(api.requests).toHaveLength(0)
   })
 
-  test('does not post stale results after a PR advances', async () => {
-    let requests = 0
-    const status = await postPerformanceComment(report, async () => {
-      requests++
-      return { ...pullRequest, head: { sha: 'c'.repeat(40) } }
-    })
-    expect(status).toBe('stale')
-    expect(requests).toBe(1)
-  })
+  test.each(['workflowRunId', 'workflowRunNumber', 'runAttempt'] as const)(
+    'rejects invalid %s before making requests',
+    async (key) => {
+      const api = github()
+      await expect(
+        postPerformanceComment({ ...report, [key]: 0 }, api.request)
+      ).rejects.toThrow('Invalid validated PR report metadata')
+      expect(api.requests).toHaveLength(0)
+    }
+  )
 })

--- a/scripts/performance/github-report.ts
+++ b/scripts/performance/github-report.ts
@@ -1,13 +1,20 @@
-import { readFile } from 'node:fs/promises'
+import { appendFile, readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { parseArguments, requiredArgument } from './args'
-import type { ReportMetadata } from './report'
+import type { ValidatedReportMetadata } from './report'
 
 const COMMENT_MARKER = '<!-- nitro-performance-paired-comparison -->'
+const ORDER_MARKER =
+  /^<!-- nitro-performance-source: ([1-9][0-9]*)\.([1-9][0-9]*) -->$/
 
 interface PullRequestReport extends Pick<
-  ReportMetadata,
-  'repository' | 'baseSha' | 'headSha'
+  ValidatedReportMetadata,
+  | 'repository'
+  | 'baseSha'
+  | 'headSha'
+  | 'workflowRunId'
+  | 'workflowRunNumber'
+  | 'runAttempt'
 > {
   pullRequestNumber: number
   markdown: string
@@ -19,39 +26,114 @@ type GitHubRequest = (
   body?: { body: string }
 ) => Promise<unknown>
 
+type CommentResult = {
+  status: 'created' | 'updated' | 'superseded' | 'closed'
+  current: boolean
+}
+
+function positiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0
+}
+
+interface PullRequest {
+  state: string
+  base: { sha: string }
+  head: { sha: string; ref: string; repo: { full_name: string } }
+}
+
+async function existingOrder(
+  body: string,
+  repository: string,
+  pullRequest: PullRequest,
+  request: GitHubRequest
+): Promise<{ runNumber: number; attempt: number } | undefined> {
+  const marker = ORDER_MARKER.exec(body.split('\n')[1] ?? '')
+  // Older reports already identify their run/attempt in the raw-artifact footer.
+  // Neither form is trusted: during rollout HEAD Markdown could forge a marker.
+  const source =
+    marker ?? /\bRun ([1-9][0-9]*), attempt ([1-9][0-9]*)\./.exec(body)
+  if (source == null) return undefined
+  const runId = Number(source[1])
+  const attempt = Number(source[2])
+  if (!positiveInteger(runId) || !positiveInteger(attempt)) return undefined
+  const run = (await request(
+    `/repos/${repository}/actions/runs/${runId}/attempts/${attempt}`
+  )) as {
+    id: number
+    name: string
+    run_number: number
+    run_attempt: number
+    status: string
+    conclusion: string
+    head_branch: string
+    head_repository: { full_name: string }
+  } | null
+  if (
+    run == null ||
+    run.id !== runId ||
+    run.run_attempt !== attempt ||
+    run.name !== 'Nitro Performance' ||
+    run.status !== 'completed' ||
+    run.conclusion !== 'success' ||
+    run.head_branch !== pullRequest.head.ref ||
+    run.head_repository.full_name !== pullRequest.head.repo.full_name ||
+    !positiveInteger(run.run_number)
+  )
+    return undefined
+  return { runNumber: run.run_number, attempt }
+}
+
+// The workflow serializes publishers for the same source repository/branch.
+// Keep the ordering check and comment write inside that concurrency group:
+// GitHub's comment API has no conditional PATCH to make this atomic itself.
 export async function postPerformanceComment(
   report: PullRequestReport,
   request: GitHubRequest,
   botLogin = 'github-actions[bot]'
-): Promise<'created' | 'updated' | 'stale'> {
+): Promise<CommentResult> {
   if (!/^[a-zA-Z0-9-]+\[bot\]$/.test(botLogin)) {
     throw new Error('Performance comment author must be a GitHub bot login.')
   }
   if (
     !/^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/.test(report.repository) ||
-    !Number.isSafeInteger(report.pullRequestNumber) ||
-    report.pullRequestNumber < 1 ||
+    !positiveInteger(report.pullRequestNumber) ||
+    !positiveInteger(report.workflowRunId) ||
+    !positiveInteger(report.workflowRunNumber) ||
+    !positiveInteger(report.runAttempt) ||
     !/^[0-9a-f]{40}$/.test(report.baseSha) ||
     !/^[0-9a-f]{40}$/.test(report.headSha) ||
+    report.markdown.trim().length === 0 ||
     report.markdown.length > 60_000
   ) {
     throw new Error('Invalid validated PR report metadata or size.')
   }
 
   const root = `/repos/${report.repository}`
-  // A PR may have advanced while publication was being prepared.
   const pullRequest = (await request(
     `${root}/pulls/${report.pullRequestNumber}`
-  )) as { state: string; base: { sha: string }; head: { sha: string } }
-  if (
-    pullRequest.state !== 'open' ||
-    pullRequest.base.sha !== report.baseSha ||
-    pullRequest.head.sha !== report.headSha
-  ) {
-    return 'stale'
-  }
+  )) as PullRequest
+  if (pullRequest.state !== 'open') return { status: 'closed', current: false }
+  const current =
+    pullRequest.base.sha === report.baseSha &&
+    pullRequest.head.sha === report.headSha
 
-  const body = { body: `${COMMENT_MARKER}\n${report.markdown}` }
+  const runUrl = `https://github.com/${report.repository}/actions/runs/${report.workflowRunId}/attempts/${report.runAttempt}`
+  const commitUrl = `https://github.com/${report.repository}/commit/`
+  const body = {
+    body: [
+      COMMENT_MARKER,
+      `<!-- nitro-performance-source: ${report.workflowRunId}.${report.runAttempt} -->`,
+      `Measured [\`${report.headSha.slice(0, 8)}\`](${commitUrl}${report.headSha}) against [\`${report.baseSha.slice(0, 8)}\`](${commitUrl}${report.baseSha}). [Run ${report.workflowRunNumber}, attempt ${report.runAttempt}](${runUrl}).`,
+      ...(current
+        ? []
+        : [
+            '',
+            'The PR has advanced since these measurements. Newer completed results will replace this report.',
+          ]),
+      '',
+      report.markdown,
+    ].join('\n'),
+  }
   for (let page = 1; page <= 10; page++) {
     const comments = (await request(
       `${root}/issues/${report.pullRequestNumber}/comments?per_page=100&page=${page}`
@@ -67,8 +149,22 @@ export async function postPerformanceComment(
         comment.body.startsWith(COMMENT_MARKER)
     )
     if (existing != null) {
+      const order = await existingOrder(
+        existing.body,
+        report.repository,
+        pullRequest,
+        request
+      )
+      if (
+        order != null &&
+        (order.runNumber > report.workflowRunNumber ||
+          (order.runNumber === report.workflowRunNumber &&
+            order.attempt > report.runAttempt))
+      ) {
+        return { status: 'superseded', current }
+      }
       await request(`${root}/issues/comments/${existing.id}`, 'PATCH', body)
-      return 'updated'
+      return { status: 'updated', current }
     }
     if (comments.length < 100) {
       await request(
@@ -76,7 +172,7 @@ export async function postPerformanceComment(
         'POST',
         body
       )
-      return 'created'
+      return { status: 'created', current }
     }
   }
   throw new Error('Comment pagination exceeded its safety limit.')
@@ -87,7 +183,7 @@ if (import.meta.main) {
   const directory = requiredArgument(argumentsMap, 'directory')
   const metadata = JSON.parse(
     await readFile(path.join(directory, 'metadata.json'), 'utf8')
-  ) as ReportMetadata
+  ) as ValidatedReportMetadata
   if (metadata.pullRequestNumber != null) {
     const token = process.env.GITHUB_TOKEN
     if (token == null) throw new Error('GITHUB_TOKEN is required.')
@@ -95,20 +191,29 @@ if (import.meta.main) {
       path.join(directory, 'performance-summary.md'),
       'utf8'
     )
-    const status = await postPerformanceComment(
+    const result = await postPerformanceComment(
       { ...metadata, pullRequestNumber: metadata.pullRequestNumber, markdown },
       async (endpoint, method = 'GET', body) => {
+        // The bot token only needs PR access. The workflow token reads Actions
+        // provenance for the existing comment, including previous publisher versions.
+        const requestToken = endpoint.includes('/actions/runs/')
+          ? process.env.GH_TOKEN
+          : token
+        if (requestToken == null)
+          throw new Error('Missing GitHub request token.')
         const response = await fetch(`https://api.github.com${endpoint}`, {
           method,
           signal: AbortSignal.timeout(30_000),
           headers: {
             'Accept': 'application/vnd.github+json',
-            'Authorization': `Bearer ${token}`,
+            'Authorization': `Bearer ${requestToken}`,
             'X-GitHub-Api-Version': '2026-03-10',
             'Content-Type': 'application/json',
           },
           body: body == null ? undefined : JSON.stringify(body),
         })
+        if (endpoint.includes('/actions/runs/') && response.status === 404)
+          return null
         if (!response.ok) {
           throw new Error(`GitHub report request failed: ${response.status}.`)
         }
@@ -118,6 +223,13 @@ if (import.meta.main) {
         ? `${process.env.GITHUB_APP_SLUG}[bot]`
         : 'github-actions[bot]'
     )
-    console.info(`Paired performance PR comment: ${status}.`)
+    if (process.env.GITHUB_OUTPUT != null) {
+      const publishHistory = result.current && result.status !== 'superseded'
+      await appendFile(
+        process.env.GITHUB_OUTPUT,
+        `publish_history=${publishHistory}\n`
+      )
+    }
+    console.info(`Paired performance PR comment: ${result.status}.`)
   }
 }

--- a/scripts/performance/report-validation.test.ts
+++ b/scripts/performance/report-validation.test.ts
@@ -20,6 +20,7 @@ async function fixture() {
     workflow_run: {
       id: metadata.workflowRunId,
       run_attempt: metadata.runAttempt,
+      run_number: 50,
       event: metadata.eventName,
       head_sha: metadata.headSha,
       head_branch: 'feature',
@@ -30,7 +31,11 @@ async function fixture() {
     number: metadata.pullRequestNumber,
     state: 'open',
     base: { sha: metadata.baseSha, repo: { full_name: metadata.repository } },
-    head: { sha: metadata.headSha, repo: { full_name: 'contributor/nitro' } },
+    head: {
+      sha: metadata.headSha,
+      ref: 'feature',
+      repo: { full_name: 'contributor/nitro' },
+    },
   }
   const artifact = path.join(root, 'artifact')
   const output = path.join(root, 'output')
@@ -102,9 +107,10 @@ test('forwards HEAD Markdown unchanged without reading the raw schema or recompu
   expect(
     await Bun.file(path.join(f.output, 'performance-summary.md')).text()
   ).toBe(f.markdown)
-  expect(await Bun.file(path.join(f.output, 'metadata.json')).json()).toEqual(
-    f.metadata
-  )
+  expect(await Bun.file(path.join(f.output, 'metadata.json')).json()).toEqual({
+    ...f.metadata,
+    workflowRunNumber: 50,
+  })
 })
 
 test.each([
@@ -116,6 +122,7 @@ test.each([
   'pr',
   'fork',
   'base-repository',
+  'branch',
   'platform',
   'duplicate-platform',
 ])('rejects a publication with mismatched %s', async (kind) => {
@@ -128,29 +135,49 @@ test.each([
   if (kind === 'pr') f.metadata.pullRequestNumber++
   if (kind === 'fork') f.pr.head.repo.full_name = 'another/nitro'
   if (kind === 'base-repository') f.pr.base.repo.full_name = 'other/repo'
+  if (kind === 'branch') f.pr.head.ref = 'another-feature'
   if (kind === 'platform') f.metadata.platforms = ['../../injected']
   if (kind === 'duplicate-platform') f.metadata.platforms = ['ios', 'ios']
   expect((await f.validate()).exitCode).not.toBe(0)
 })
 
-test.each(['head', 'base', 'closed'])(
-  'skips stale PR results: %s',
+test.each(['head', 'base'])(
+  'allows completed comments after PR %s advances while preserving Bencher policy',
   async (change) => {
     await using f = await fixture()
     if (change === 'head') f.pr.head.sha = 'c'.repeat(40)
     if (change === 'base') f.pr.base.sha = 'c'.repeat(40)
-    if (change === 'closed') f.pr.state = 'closed'
-    const result = await f.validate()
-    expect(result.exitCode).toBe(0)
-    expect(result.text).toContain('Skipping stale')
+    expect((await f.validate()).exitCode).toBe(0)
     expect(await Bun.file(path.join(f.root, 'outputs')).text()).toContain(
       'stale=true'
     )
     expect(
-      await Bun.file(path.join(f.output, 'performance-summary.md')).exists()
-    ).toBe(false)
+      await Bun.file(path.join(f.output, 'performance-summary.md')).text()
+    ).toBe(f.markdown)
   }
 )
+
+test('skips a closed PR without producing a publishable report', async () => {
+  await using f = await fixture()
+  f.pr.state = 'closed'
+  expect((await f.validate()).exitCode).toBe(0)
+  expect(await Bun.file(path.join(f.root, 'outputs')).text()).toContain(
+    'closed=true'
+  )
+  expect(
+    await Bun.file(path.join(f.output, 'performance-summary.md')).exists()
+  ).toBe(false)
+})
+
+test('takes publication order from GitHub, ignoring an artifact-supplied sequence', async () => {
+  await using f = await fixture()
+  Object.assign(f.metadata, { workflowRunNumber: 999999 })
+  expect((await f.validate()).exitCode).toBe(0)
+  expect(
+    (await Bun.file(path.join(f.output, 'metadata.json')).json())
+      .workflowRunNumber
+  ).toBe(50)
+})
 
 test.each(['', 'x'.repeat(60_001)])(
   'rejects empty or oversized comments',

--- a/scripts/performance/report.ts
+++ b/scripts/performance/report.ts
@@ -38,6 +38,11 @@ export interface ReportMetadata extends Pick<
   platforms: ('android' | 'ios')[]
 }
 
+/** Publishing order is supplied by the trusted workflow event, never HEAD code. */
+export interface ValidatedReportMetadata extends ReportMetadata {
+  workflowRunNumber: number
+}
+
 if (import.meta.main) {
   const args = parseArguments(Bun.argv.slice(2))
   const eventName = requiredArgument(args, 'event-name')

--- a/scripts/performance/validate-report.ts
+++ b/scripts/performance/validate-report.ts
@@ -1,4 +1,4 @@
-import type { ReportMetadata } from './report'
+import type { ReportMetadata, ValidatedReportMetadata } from './report'
 import { appendFile, mkdir, readFile, lstat } from 'node:fs/promises'
 import path from 'node:path'
 import { parseArguments, requiredArgument } from './args'
@@ -31,6 +31,12 @@ const metadata: ReportMetadata = JSON.parse(
   await readBoundedFile(path.join(directory, 'metadata.json'), 64 * 1024)
 )
 if (
+  !Number.isSafeInteger(run.run_number) ||
+  run.run_number < 1 ||
+  !Number.isSafeInteger(run.id) ||
+  run.id < 1 ||
+  !Number.isSafeInteger(run.run_attempt) ||
+  run.run_attempt < 1 ||
   metadata.repository !== repository ||
   event.repository.full_name !== repository ||
   metadata.eventName !== run.event ||
@@ -62,23 +68,26 @@ if (run.event === 'pull_request') {
     metadata.pullRequestNumber < 1 ||
     metadata.pullRequestNumber !== pr.number ||
     pr.base.repo.full_name !== repository ||
-    pr.head.repo.full_name !== run.head_repository.full_name
+    pr.head.repo.full_name !== run.head_repository.full_name ||
+    typeof run.head_branch !== 'string' ||
+    run.head_branch.length === 0 ||
+    pr.head.ref !== run.head_branch
   ) {
     throw new Error(
       'Publication metadata does not match the trusted pull request.'
     )
   }
-  if (
-    pr.state !== 'open' ||
-    metadata.baseSha !== pr.base.sha ||
-    metadata.headSha !== pr.head.sha
-  ) {
-    console.info(
-      'Skipping stale performance results: the pull request advanced or closed.'
-    )
+  if (pr.state !== 'open') {
+    console.info('Skipping performance results: the pull request closed.')
+    if (process.env.GITHUB_OUTPUT != null)
+      await appendFile(process.env.GITHUB_OUTPUT, 'closed=true\n')
+    process.exit(0)
+  }
+  if (metadata.baseSha !== pr.base.sha || metadata.headSha !== pr.head.sha) {
+    // Completed PR measurements remain useful in the comment. Keep Bencher's
+    // existing current-revision policy separate from comment publication.
     if (process.env.GITHUB_OUTPUT != null)
       await appendFile(process.env.GITHUB_OUTPUT, 'stale=true\n')
-    process.exit(0)
   }
 } else if (
   !['push', 'schedule', 'workflow_dispatch'].includes(run.event) ||
@@ -97,6 +106,12 @@ if (markdown.length > 60_000 || markdown.trim().length === 0) {
   throw new Error('Performance comment is empty or exceeds GitHub limits.')
 }
 await mkdir(output, { recursive: true })
-await Bun.write(path.join(output, 'metadata.json'), JSON.stringify(metadata))
+await Bun.write(
+  path.join(output, 'metadata.json'),
+  JSON.stringify({
+    ...metadata,
+    workflowRunNumber: run.run_number,
+  } satisfies ValidatedReportMetadata)
+)
 // Markdown is data. Do not interpolate it into shell commands or execute any artifact files.
 await Bun.write(path.join(output, 'performance-summary.md'), markdown)

--- a/scripts/performance/workflow.test.ts
+++ b/scripts/performance/workflow.test.ts
@@ -182,3 +182,30 @@ test.each([false, true])(
     }
   }
 )
+
+test('serializes publication by trusted source branch without dropping queued reports', async () => {
+  const publisher = Bun.YAML.parse(
+    await Bun.file(
+      new URL('../../.github/workflows/performance-report.yml', import.meta.url)
+    ).text()
+  ) as any
+  expect(publisher.concurrency).toEqual({
+    group:
+      'nitro-performance-publisher-${{ github.event.workflow_run.head_repository.id }}-${{ github.event.workflow_run.head_branch }}',
+    queue: 'max',
+  })
+  const steps = publisher.jobs.publish.steps as any[]
+  const comment = steps.find((step) => step.id === 'comment')
+  expect(comment.if).toContain("steps.validate.outputs.closed != 'true'")
+  expect(comment.if).not.toContain('stale')
+  expect(comment.env.GH_TOKEN).toBe('${{ secrets.GITHUB_TOKEN }}')
+  for (const step of steps.filter((candidate) =>
+    /Bencher/.test(candidate.name ?? '')
+  )) {
+    expect(step.if).toContain("steps.validate.outputs.stale != 'true'")
+    expect(step.if).toContain("steps.validate.outputs.closed != 'true'")
+    expect(step.if).toContain(
+      "steps.comment.outputs.publish_history != 'false'"
+    )
+  }
+})


### PR DESCRIPTION
Completed performance results are currently skipped when the PR's head or base advances before publishing. Keep those results visible until a newer completed report replaces them, with a trusted label linking the exact measured commits and workflow attempt. Closed PRs still skip comments; advanced or superseded reports still skip Bencher history.

Order updates by the source workflow's run number, then attempt. Resolve the existing comment's source through GitHub and require a successful completed attempt from the same PR source repository and branch, including when migrating older comments. An old run finishing late—or being rerun after a newer run—cannot replace newer results. Per-source concurrency with GitHub's documented [`queue: max`](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#example-queueing-multiple-pending-runs) serializes the read/update sequence without dropping the previous pending publication.

Builds on merged #1623, which already shows the report in the run summary. This PR changes the trusted publishing policy; it takes effect after reaching `main`. It does not execute artifact code or change the rendered report's contents.

Validation: 133 performance-tool tests pass, including completion-order permutations, reruns, repeated publication, advanced/closed PRs, legacy comments, forged ordering metadata and fork/branch provenance. TypeScript, ESLint and diff checks pass. Actionlint 1.7.12 passes with only its unsupported `concurrency.queue` diagnostic excluded; a workflow test checks the exact queue configuration against GitHub's documented syntax.
