### PR TITLE
perf: measure four balanced process pairs per benchmark

### DIFF
--- a/.github/PERFORMANCE.md
+++ b/.github/PERFORMANCE.md
@@ -2,11 +2,19 @@
 
 `Nitro Performance` builds the dedicated `apps/benchmark` Release/Hermes app.
 Each platform installs base and head side by side on the same machine. It
-alternates base and head in each app's suite order, then finishes any remaining
-cases in the longer suite. With the same case order, each function runs back to back. There is one AB pair, with five warmup batches and twenty measured
-batches per process. Each case gets a fresh app process; installation, startup,
-transport and process restarts are outside timing. There is no automatic third
-pair. Manual reruns are retained as identifiable workflow attempts.
+runs four pairs at each position in the apps' suite order: **AB, BA, BA, AB**
+(A = base, B = head), then moves to the next position. It finishes any remaining
+cases in the longer suite. With the same case order, each function runs back to
+back with each revision first twice. Each launch gets a fresh app process,
+five warmup batches and twenty measured batches: eighty measured batches per
+revision and case. Installation, startup, transport and process restarts are
+outside timing. Apps are built and installed once, then reused across all four
+pairs. Manual reruns are retained as identifiable workflow attempts.
+
+Startup waits for two animation frames, with no fixed one-second sleep. Keep
+the frame handoff and warmup: synchronous JS does not prevent native startup
+work or OS scheduling from competing for the CPU. The Android crash monitor's
+one-second polling interval runs concurrently and does not delay measurements.
 
 Each case uses checked-in operation counts from
 [`iterations.ts`](../apps/benchmark/src/benchmarks/iterations.ts), separately for
@@ -31,13 +39,16 @@ owned native storage. Other allocating cases retain GC and native yields. Raw `i
 
 ## Reading results
 
-The main score is the median (p50) of batch averages in ns/op, not individual-call
-tail latency. The report shows every observed change of at least 5%, including
-Promise cases. This is a presentation threshold, not a calibrated regression
+The main score is the median (p50) of all measured batch averages across the four
+processes in ns/op, not individual-call tail latency. The report shows every
+observed change of at least 5%, including Promise cases. This is a presentation
+threshold, not a calibrated regression
 budget. Expand the report for the remaining metrics; the raw JSON retains all
 samples. Matching pooled medians do not prove
-equal performance. One pair cannot establish repeatability between launches or justify confidence
-intervals. Repeat measurement jobs or same-revision runs to investigate variation.
+equal performance. Per-pair raw results preserve launch-to-launch variation;
+four pairs do not establish a calibrated regression budget or justify treating
+eighty batches as independent process runs. Repeat measurement jobs or
+same-revision runs to investigate variation.
 
 Performance is currently report-only. Build, execution and malformed-result
 failures still fail CI. Turning observed differences into a regression gate needs
@@ -75,9 +86,9 @@ architecture and toolchain metadata. iOS apps are tar archives to preserve
 permissions and symlinks. Gradle's basic cache is the sole Android cache owner;
 Gradle still checks source/task inputs, while exact app reuse is by artifact ID.
 There is no new iOS compiler cache. App reuse avoids build work on manual reruns. With 46 cases in each revision, a run
-uses 92 fresh processes (46 base + 46 head).
-Closer comparisons reduce time separation, but fixed base-first order can still
-introduce bias; same-revision runs are needed to assess that on each testbed.
+uses 368 fresh processes (184 base + 184 head), while retaining one build and
+installation per revision. Balanced order reduces consistent first/second
+effects, but same-revision runs are still needed to assess noise on each testbed.
 
 ## Artifacts and publishing
 

--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -25,8 +25,8 @@ permits cleartext only to `127.0.0.1` and `localhost` for the host receiver.
 
 ## Run locally
 
-For an already booted Android API 36 emulator, compare two fresh launches of the
-same built APK to check measurement variation:
+For an already booted Android API 36 emulator, compare four pairs of fresh
+launches of the same built APK to check measurement variation:
 
 ```sh
 bun scripts/performance/run-sequence.ts \
@@ -51,11 +51,14 @@ The host installs each binary once, then launches a fresh process for each case
 and assembles their results. This releases Nitro's runtime-scoped JSI reference
 bookkeeping between cases; GC alone cannot clear that cache. Each process posts
 one result only after its timing is complete. Per-case raw results are kept beside
-the combined output in `base-1-cases/` and `head-1-cases/` directories.
-Base and head launches alternate in each app's suite order; the report matches
+the combined `base-1.json` through `base-4.json` and matching head outputs, in
+`base-1-cases/` through `base-4-cases/` and matching head directories.
+At each position in the apps' suite order, launches run **AB, BA, BA, AB**
+(A = base, B = head) before advancing to the next position. The report matches
 results by ID even when cases move, appear or disappear. With the same case order,
 each function runs back to back. Identical SHAs reuse one installed binary.
-Startup, transport, and process restarts are not timed.
+Startup, transport, and process restarts are not timed. Startup waits for two
+animation frames, with no fixed one-second sleep.
 For iOS, use `--platform ios`, a simulator UDID for `--device-id`, and the built
 `NitroBenchmark.app` for `--base-app` and `--head-app`, with matching
 simulator/toolchain metadata.
@@ -68,7 +71,8 @@ Each metric has fixed Android/iOS counts in
 [`iterations.ts`](src/benchmarks/iterations.ts), seeded from the existing
 GitHub-runner results with roughly 150 ms of timed work per sample. There is no
 calibration process. Each measurement process performs five warmup batches and
-twenty samples. Each revision uses its own checked-in count and chunk size for
+twenty samples, for eighty measured samples across the four processes per
+revision and case. Each revision uses its own checked-in count and chunk size for
 each case. Slow samples are retained without shortening the work.
 
 Adding a case requires an explicit count. Revisit the counts when changing the

--- a/scripts/performance/generate-report.test.ts
+++ b/scripts/performance/generate-report.test.ts
@@ -274,7 +274,7 @@ describe('HEAD report generation', () => {
       const base = await Bun.file(baseFile).json()
       await rm(baseFile)
       expect((await generate(fixture)).error).toContain(
-        'Expected one ios base run'
+        'Expected 1 ios base runs'
       )
       await writeJson(baseFile, base)
       await writeJson(
@@ -284,7 +284,7 @@ describe('HEAD report generation', () => {
         ).json()
       )
       expect((await generate(fixture)).error).toContain(
-        'Expected one ios head run'
+        'Expected 1 ios head runs'
       )
     } finally {
       await rm(root, { recursive: true, force: true })
@@ -303,8 +303,18 @@ test('rerunning Android retains the exact earlier iOS measurements and app build
     manifest.artifacts.android.measurementAttempt = 2
     await writeJson(
       path.join(fixture.artifact, 'raw/android/measurement.json'),
-      { buildArtifactId: 1, runAttempt: 2 }
+      { buildArtifactId: 1, runAttempt: 2, pairCount: 4 }
     )
+    for (let pair = 2; pair <= 4; pair++) {
+      for (const revision of ['base', 'head'] as const) {
+        const value = run('android', revision)
+        value.configuration.runId = `android-${revision}-${pair}`
+        await writeJson(
+          path.join(fixture.artifact, `raw/android/${revision}-${pair}.json`),
+          value
+        )
+      }
+    }
     await writeJson(manifestFile, manifest)
     expect(await generate(fixture)).toEqual({ exitCode: 0, error: '' })
     const markdown = await Bun.file(
@@ -312,6 +322,73 @@ test('rerunning Android retains the exact earlier iOS measurements and app build
     ).text()
     expect(markdown).toContain('Android: [measurements, attempt 2]')
     expect(markdown).toContain('iOS: [measurements, attempt 1]')
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('validates all four pairs and preserves their contribution to the report', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-four-pairs-'))
+  try {
+    const fixture = await createFixture(root)
+    for (const platform of ['android', 'ios'] as const) {
+      const directory = path.join(fixture.artifact, 'raw', platform)
+      const measurementFile = path.join(directory, 'measurement.json')
+      const measurement = await Bun.file(measurementFile).json()
+      await writeJson(measurementFile, { ...measurement, pairCount: 4 })
+      for (const revision of ['base', 'head'] as const) {
+        for (let pair = 1; pair <= 4; pair++) {
+          const value = run(platform, revision)
+          value.configuration.runId = `${platform}-${revision}-${pair}`
+          // The first pair is an outlier. All four must contribute, instead of
+          // accidentally reporting only base-1/head-1 from the earlier protocol.
+          value.metrics[0]!.samplesNsPerOp.fill(
+            revision === 'base' ? 100 : pair === 1 ? 200 : 110
+          )
+          await writeJson(
+            path.join(directory, `${revision}-${pair}.json`),
+            value
+          )
+        }
+      }
+    }
+    expect(await generate(fixture)).toEqual({ exitCode: 0, error: '' })
+    const bmf = await Bun.file(
+      path.join(fixture.output, 'bencher-ios.json')
+    ).json()
+    expect(bmf['nitro-cpp/primitive/add-numbers'].latency.value).toBe(110)
+    const markdown = await Bun.file(
+      path.join(fixture.output, 'performance-summary.md')
+    ).text()
+    expect(markdown).toContain('🔴 +10% slower')
+    expect(markdown).not.toContain('+100% slower')
+
+    const directory = path.join(fixture.artifact, 'raw/ios')
+    const lastFile = path.join(directory, 'head-4.json')
+    const last = await Bun.file(lastFile).json()
+    await rm(lastFile)
+    expect((await generate(fixture)).error).toContain(
+      'Expected 4 ios head runs'
+    )
+    await writeJson(lastFile, last)
+    // Duplicate data under the right filename must not impersonate pair four.
+    await writeJson(
+      lastFile,
+      await Bun.file(path.join(directory, 'head-1.json')).json()
+    )
+    expect((await generate(fixture)).error).toContain('run metadata is invalid')
+    await writeJson(lastFile, last)
+    await writeJson(path.join(directory, 'head-5.json'), last)
+    expect((await generate(fixture)).error).toContain(
+      'Expected 4 ios head runs'
+    )
+    await rm(path.join(directory, 'head-5.json'))
+    const measurementFile = path.join(directory, 'measurement.json')
+    const measurement = await Bun.file(measurementFile).json()
+    await writeJson(measurementFile, { ...measurement, pairCount: 3 })
+    expect((await generate(fixture)).error).toContain(
+      'measurement pair count is invalid'
+    )
   } finally {
     await rm(root, { recursive: true, force: true })
   }

--- a/scripts/performance/generate-report.ts
+++ b/scripts/performance/generate-report.ts
@@ -20,6 +20,7 @@ const report: PerformanceReport = JSON.parse(
 )
 const workflowRunUrl = `https://github.com/${report.repository}/actions/runs/${report.workflowRunId}`
 const builds = new Map<string, BuildMetadata>()
+const pairCounts = new Map<string, number>()
 for (const platform of ['android', 'ios'] as const) {
   const ids = report.artifacts[platform]
   const build: BuildMetadata = await Bun.file(
@@ -52,47 +53,67 @@ for (const platform of ['android', 'ios'] as const) {
       `${platform} measurement provenance does not match this report.`
     )
   }
+  // A retained measurement from before balanced repeats contains one pair.
+  // Explicit counts prevent an incomplete four-pair artifact passing as one.
+  const pairCount =
+    measurement.pairCount === undefined ? 1 : measurement.pairCount
+  if (pairCount !== 1 && pairCount !== 4) {
+    throw new Error(`${platform} measurement pair count is invalid.`)
+  }
+  pairCounts.set(platform, pairCount)
   builds.set(platform, build)
 }
 
-async function loadRawRun(
+async function loadRawRuns(
   platform: 'android' | 'ios',
   revision: 'base' | 'head',
   expectedSha: string
-): Promise<BenchmarkRunResult> {
+): Promise<BenchmarkRunResult[]> {
   const directory = path.join(artifactDirectory, 'raw', platform)
   const filePattern = new RegExp(`^${revision}-[0-9]+\\.json$`)
   const files = (await readdir(directory)).filter((file) =>
     filePattern.test(file)
   )
-  if (files.length !== 1 || files[0] !== `${revision}-1.json`) {
-    throw new Error(`Expected one ${platform} ${revision} run.`)
-  }
-  const run = validateBenchmarkRun(
-    JSON.parse(await readFile(path.join(directory, files[0]!), 'utf8'))
+  const pairCount = pairCounts.get(platform)!
+  const expectedFiles = Array.from(
+    { length: pairCount },
+    (_, index) => `${revision}-${index + 1}.json`
   )
   if (
-    run.configuration.runId !== `${platform}-${revision}-1` ||
-    run.configuration.reverse !== false ||
-    run.configuration.platform !== platform ||
-    run.configuration.architecture !== builds.get(platform)!.architecture ||
-    run.configuration.toolchain !== builds.get(platform)!.toolchain ||
-    run.configuration.benchmarkIndex !== undefined ||
-    run.metrics.length !== run.benchmarkCount ||
-    run.configuration.commitSha !== expectedSha ||
-    run.configuration.suiteHash !==
-      (revision === 'base' ? report.baseSuiteHash : report.headSuiteHash) ||
-    run.metrics.some((metric) => !METRIC_ID_PATTERN.test(metric.id))
+    files.length !== pairCount ||
+    expectedFiles.some((file) => !files.includes(file))
   ) {
-    throw new Error(`${platform} ${revision} run metadata is invalid.`)
+    throw new Error(`Expected ${pairCount} ${platform} ${revision} runs.`)
   }
-  return run
+  return Promise.all(
+    expectedFiles.map(async (file, index) => {
+      const run = validateBenchmarkRun(
+        JSON.parse(await readFile(path.join(directory, file), 'utf8'))
+      )
+      if (
+        run.configuration.runId !== `${platform}-${revision}-${index + 1}` ||
+        run.configuration.reverse !== false ||
+        run.configuration.platform !== platform ||
+        run.configuration.architecture !== builds.get(platform)!.architecture ||
+        run.configuration.toolchain !== builds.get(platform)!.toolchain ||
+        run.configuration.benchmarkIndex !== undefined ||
+        run.metrics.length !== run.benchmarkCount ||
+        run.configuration.commitSha !== expectedSha ||
+        run.configuration.suiteHash !==
+          (revision === 'base' ? report.baseSuiteHash : report.headSuiteHash) ||
+        run.metrics.some((metric) => !METRIC_ID_PATTERN.test(metric.id))
+      ) {
+        throw new Error(`${platform} ${revision} run metadata is invalid.`)
+      }
+      return run
+    })
+  )
 }
 
 const comparisons = await Promise.all(
   (['android', 'ios'] as const).map(async (platform) => {
-    const headRuns = [await loadRawRun(platform, 'head', report.headSha)]
-    const baseRuns = [await loadRawRun(platform, 'base', report.baseSha)]
+    const headRuns = await loadRawRuns(platform, 'head', report.headSha)
+    const baseRuns = await loadRawRuns(platform, 'base', report.baseSha)
     const comparison = compareRuns(baseRuns, headRuns)
     return { comparison, baseRuns, headRuns }
   })

--- a/scripts/performance/run-sequence.test.ts
+++ b/scripts/performance/run-sequence.test.ts
@@ -247,10 +247,10 @@ test.each([
         ).toBe(1)
         expect(
           await Bun.file(path.join(output, 'measurement.json')).json()
-        ).toEqual({ buildArtifactId: 456, runAttempt: 2 })
+        ).toEqual({ buildArtifactId: 456, runAttempt: 2, pairCount: 4 })
       }
       expect(new Set(processes.map((entry) => entry.pid)).size).toBe(
-        baseIds.length + headIds.length
+        4 * (baseIds.length + headIds.length)
       )
       expect(
         processes.map((entry) => [
@@ -258,39 +258,61 @@ test.each([
           entry.configuration.runId,
         ])
       ).toEqual(
-        mode === 'added-case'
-          ? [
-              [0, `${platform}-base-1`],
-              [0, `${platform}-head-1`],
-              [1, `${platform}-base-1`],
-              [1, `${platform}-head-1`],
-              [2, `${platform}-head-1`],
+        Array.from(
+          { length: Math.max(baseIds.length, headIds.length) },
+          (_, index) =>
+            [
+              'base-1',
+              'head-1',
+              'head-2',
+              'base-2',
+              'head-3',
+              'base-3',
+              'base-4',
+              'head-4',
             ]
-          : mode === 'removed-case'
-            ? [
-                [0, `${platform}-base-1`],
-                [0, `${platform}-head-1`],
-                [1, `${platform}-base-1`],
-              ]
-            : [
-                [0, `${platform}-base-1`],
-                [0, `${platform}-head-1`],
-                [1, `${platform}-base-1`],
-                [1, `${platform}-head-1`],
-              ]
+              .filter(
+                (name) =>
+                  index <
+                  (name.startsWith('base') ? baseIds.length : headIds.length)
+              )
+              .map((name) => [index, `${platform}-${name}`])
+        ).flat()
       )
       expect(
         (await readdir(output)).some((name) => name.startsWith('calibration'))
       ).toBe(false)
-      const base = await Bun.file(path.join(output, 'base-1.json')).json()
-      const head = await Bun.file(path.join(output, 'head-1.json')).json()
-      expect(base.metrics.map((metric: { id: string }) => metric.id)).toEqual(
-        baseIds
-      )
-      expect(head.metrics.map((metric: { id: string }) => metric.id)).toEqual(
-        headIds
-      )
-      const comparisons = compareRuns([base], [head]).comparisons
+      const baseRuns = []
+      const headRuns = []
+      for (let pair = 1; pair <= 4; pair++) {
+        const base = await Bun.file(
+          path.join(output, `base-${pair}.json`)
+        ).json()
+        const head = await Bun.file(
+          path.join(output, `head-${pair}.json`)
+        ).json()
+        expect(base.metrics.map((metric: { id: string }) => metric.id)).toEqual(
+          baseIds
+        )
+        expect(head.metrics.map((metric: { id: string }) => metric.id)).toEqual(
+          headIds
+        )
+        expect(base.configuration.runId).toBe(`${platform}-base-${pair}`)
+        expect(head.configuration.runId).toBe(`${platform}-head-${pair}`)
+        expect(
+          await readdir(path.join(output, `base-${pair}-cases`))
+        ).toHaveLength(baseIds.length)
+        expect(
+          await readdir(path.join(output, `head-${pair}-cases`))
+        ).toHaveLength(headIds.length)
+        baseRuns.push(base)
+        headRuns.push(head)
+      }
+      const comparisons = compareRuns(baseRuns, headRuns).comparisons
+      expect(
+        comparisons.find((metric) => metric.id === baseIds[1])
+          ?.pairChangesPercent
+      ).toEqual([0, 0, 0, 0])
       expect(
         comparisons.find((metric) => metric.id === baseIds[1])?.deltaPercent
       ).toBe(0)

--- a/scripts/performance/run-sequence.ts
+++ b/scripts/performance/run-sequence.ts
@@ -7,6 +7,14 @@ import type { BenchmarkRunResult } from '../../apps/benchmark/src/benchmarks/typ
 import { calculateSuiteHash } from './suite-hash'
 import type { BuildMetadata } from './build-metadata'
 
+// Keep all four pairs adjacent for each case, with each revision first twice.
+const pairOrders = [
+  ['base', 'head'],
+  ['head', 'base'],
+  ['head', 'base'],
+  ['base', 'head'],
+] as const
+
 const argumentsMap = parseArguments(Bun.argv.slice(2))
 const platformArgument = requiredArgument(argumentsMap, 'platform')
 if (platformArgument !== 'android' && platformArgument !== 'ios') {
@@ -66,7 +74,7 @@ if (build != null) {
   )
   await Bun.write(
     path.join(outputDirectory, 'measurement.json'),
-    `${JSON.stringify({ buildArtifactId: Number(process.env.BUILD_ARTIFACT_ID), runAttempt: Number(process.env.GITHUB_RUN_ATTEMPT) }, null, 2)}\n`
+    `${JSON.stringify({ buildArtifactId: Number(process.env.BUILD_ARTIFACT_ID), runAttempt: Number(process.env.GITHUB_RUN_ATTEMPT), pairCount: pairOrders.length }, null, 2)}\n`
   )
 }
 
@@ -85,16 +93,17 @@ if (!sameBinary) {
 
 async function runCase(
   revision: 'base' | 'head',
-  index: number
+  index: number,
+  pair: number
 ): Promise<BenchmarkRunResult> {
   const isBase = revision === 'base'
-  const name = `${revision}-1`
+  const name = `${revision}-${pair}`
   return runDeviceCase(
     deviceId,
     isBase ? baseId : headId,
     {
       platform,
-      runId: `${platform}-${revision}-1`,
+      runId: `${platform}-${name}`,
       reverse: false,
       benchmarkIndex: index,
       commitSha: isBase ? baseSha : headSha,
@@ -108,32 +117,29 @@ async function runCase(
   )
 }
 
-const baseRuns: BenchmarkRunResult[] = []
-const headRuns: BenchmarkRunResult[] = []
+const pairs = pairOrders.map(() => ({
+  base: [] as BenchmarkRunResult[],
+  head: [] as BenchmarkRunResult[],
+}))
 // Each revision reports its own suite size. Alternate fresh processes while
 // both have cases left; the report matches their results by ID, not position.
-let baseCount = 1
-let headCount = 1
-for (let index = 0; index < Math.max(baseCount, headCount); index++) {
-  if (index < baseCount) {
-    const base = await runCase('base', index)
-    baseRuns.push(base)
-    if (index === 0) baseCount = base.benchmarkCount!
-  }
-  if (index < headCount) {
-    const head = await runCase('head', index)
-    headRuns.push(head)
-    if (index === 0) headCount = head.benchmarkCount!
+const counts = { base: 1, head: 1 }
+for (let index = 0; index < Math.max(counts.base, counts.head); index++) {
+  for (const [pairIndex, order] of pairOrders.entries()) {
+    for (const revision of order) {
+      if (index >= counts[revision]) continue
+      const result = await runCase(revision, index, pairIndex + 1)
+      pairs[pairIndex]![revision].push(result)
+      if (index === 0) counts[revision] = result.benchmarkCount!
+    }
   }
 }
-for (const [name, runs] of [
-  ['base-1', baseRuns],
-  ['head-1', headRuns],
-] as const) {
-  if (runs.length === 0) continue
-  const result = combineIsolatedCases(runs)
-  await Bun.write(
-    path.join(outputDirectory, `${name}.json`),
-    `${JSON.stringify(result, null, 2)}\n`
-  )
+for (const [pairIndex, pair] of pairs.entries()) {
+  for (const revision of ['base', 'head'] as const) {
+    const result = combineIsolatedCases(pair[revision])
+    await Bun.write(
+      path.join(outputDirectory, `${revision}-${pairIndex + 1}.json`),
+      `${JSON.stringify(result, null, 2)}\n`
+    )
+  }
 }


### PR DESCRIPTION
Each benchmark currently gets one base/head process pair, so one slow launch can dominate the PR comparison. Measure four adjacent pairs per case in **AB, BA, BA, AB** order, with a fresh process for each launch and each revision first twice.

Build and install each app once, retain the existing five warmups and twenty measured batches per process, and preserve all four numbered base/head runs and per-case JSON. HEAD report generation requires the declared pair count and correct identities, pools all four runs using the existing median calculation, and still accepts retained one-pair measurements from earlier attempts. The table layout and reporting threshold are unchanged.

The one-second app-start sleep was already removed by #1616. Two initial animation frames and five warmups remain; the one-second Android crash-monitor interval runs concurrently. With 46 cases, measurement uses 368 fresh processes per platform. Reducing the sample budget or sharding cases across runners can be evaluated separately.

Validation after rebasing onto the merged #1623 reporting pipeline: 103 performance-tool tests passed, including exact process order and lifecycle on both controllers, same-binary reuse, changed/reordered/unequal suites, all-four-pair reporting, missing/duplicate/extra results, and retaining an earlier iOS measurement while rerunning Android. Package builds, tooling/app typechecks and app lint passed.

The [same-binary CI diagnostic](https://github.com/margelo/nitro/actions/runs/34153555098) passed on both Blacksmith platforms at `376e2ae93f32b0326112b948e2909f91f4b7f729`. Downloaded base/head app artifacts were byte-for-byte identical. The [raw report artifact](https://github.com/margelo/nitro/actions/runs/34153555098/artifacts/10030808462) passed this revision's reporter against GitHub's actual run/artifact metadata. All 736 process results followed the intended order with matching work counts and twenty samples each.

| A/A diagnostic | Android | iOS |
| --- | ---: | ---: |
| Measurement job duration | 25m21s | 23m36s |
| Individual-pair median absolute delta (range across four pairs) | 1.33–1.94% | 1.87–2.72% |
| Pooled median absolute delta | 0.91% | 1.22% |
| Individual-pair cases at least 5% apart | 5–10 / 46 | 6–13 / 46 |
| Pooled cases at least 5% apart | 3 / 46 | 2 / 46 |
| Largest pooled absolute delta | 7.33% | 5.73% |

These are descriptive results from one same-binary job per platform, not a calibrated false-positive rate or a regression gate. Remaining apparent differences are measurement variation.

The diagnostic ran before #1623 merged. The current PR is rebased onto that reporting pipeline and applies the four-pair reader in `generate-report.ts`; publication-envelope validation stays unchanged. Replaying the diagnostic's complete raw artifact through the rebased generator produced byte-identical Markdown and Android/iOS BMF to the original validated report. The controller's execution order is unchanged by the rebase.

The historical diagnostic's separate publishing run failed because main switched to requiring `performance-publication-1` while the older workflow produced only `performance-report-1`. The diagnostic measurements and local report validation succeeded. The rebased PR now produces the publication artifact using HEAD code, so its report can be reviewed before merge. Same-branch manual diagnostics are not main history and should not upload to Bencher.
