### PR TITLE
fix: honor Nitrogen config path

### DIFF
--- a/.github/workflows/run-nitrogen.yml
+++ b/.github/workflows/run-nitrogen.yml
@@ -45,6 +45,10 @@ jobs:
       - name: Build all packages
         run: bun run build
 
+      - name: Test Nitrogen CLI
+        working-directory: packages/nitrogen
+        run: bun test
+
       - name: Run nitrogen in packages/react-native-nitro-test-external
         working-directory: packages/react-native-nitro-test-external
         run: bun i && bun specs

--- a/packages/nitrogen/package.json
+++ b/packages/nitrogen/package.json
@@ -28,7 +28,8 @@
   "scripts": {
     "build": "bun tsc",
     "start": "tsc && node lib/index.js",
-    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit && tsc -p tests/tsconfig.json",
     "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "lint-ci": "eslint \"**/*.{js,ts,tsx}\" -f @jamesacarr/github-actions --max-warnings 0",
     "release": "release-it"

--- a/packages/nitrogen/src/config/NitroConfig.ts
+++ b/packages/nitrogen/src/config/NitroConfig.ts
@@ -21,14 +21,19 @@ export class NitroConfig {
     this.config = config
   }
 
+  static load(configPath: string): NitroConfig {
+    console.log(
+      chalk.reset(`🔧  Loading ${chalk.underline(configPath)} config...`)
+    )
+    const config = readUserConfig(configPath)
+    this.singleton = new NitroConfig(config)
+    return this.singleton
+  }
+
   static get current(): NitroConfig {
     if (this.singleton == null) {
-      console.log(
-        chalk.reset(`🔧  Loading ${chalk.underline('nitro.json')} config...`)
-      )
       const defaultConfigPath = './nitro.json'
-      const config = readUserConfig(defaultConfigPath)
-      this.singleton = new NitroConfig(config)
+      this.singleton = this.load(defaultConfigPath)
     }
     return this.singleton
   }

--- a/packages/nitrogen/src/index.ts
+++ b/packages/nitrogen/src/index.ts
@@ -10,6 +10,7 @@ import { promises as fs } from 'fs'
 import { isValidLogLevel, setLogLevel } from './Logger.js'
 import { initNewNitroModule } from './init.js'
 import { NITROGEN_VERSION } from './config/nitrogenVersion.js'
+import { NitroConfig } from './config/NitroConfig.js'
 
 const commandName = 'nitrogen'
 
@@ -57,6 +58,7 @@ await yargs(hideBin(process.argv))
     async (argv) => {
       const basePath = argv.basePath
       const outputDirectory = argv.out
+      NitroConfig.load(argv.config)
       await runNitrogenCommand(basePath, outputDirectory)
     }
   )

--- a/packages/nitrogen/tests/config-option.test.ts
+++ b/packages/nitrogen/tests/config-option.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+test('loads the configuration passed through --config', async () => {
+  const workingDirectory = await mkdtemp(
+    path.join(tmpdir(), 'nitrogen-config-option-')
+  )
+  const configPath = path.join(workingDirectory, 'custom-config.json')
+  const cliPath = path.resolve(import.meta.dir, '../src/index.ts')
+
+  try {
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        cxxNamespace: ['custom'],
+        ios: { iosModuleName: 'CustomModule' },
+        android: {
+          androidNamespace: ['custom'],
+          androidCxxLibName: 'CustomModule',
+        },
+        autolinking: {},
+      })
+    )
+
+    const child = Bun.spawn(
+      [process.execPath, cliPath, workingDirectory, '--config', configPath],
+      {
+        cwd: workingDirectory,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      }
+    )
+    const [stdout, stderr] = await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+      child.exited,
+    ])
+    const output = stdout + stderr
+
+    expect(output).toContain('custom-config.json')
+    expect(output).toContain("Nitrogen didn't find any spec files")
+    expect(output).not.toContain('The path ./nitro.json does not exist')
+  } finally {
+    await rm(workingDirectory, { recursive: true, force: true })
+  }
+})

--- a/packages/nitrogen/tests/tsconfig.json
+++ b/packages/nitrogen/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["."],
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["bun", "node"]
+  }
+}


### PR DESCRIPTION
## Summary

- pass the parsed --config value into Nitrogen before generation starts
- centralize file-backed singleton initialization in NitroConfig.load() while preserving ./nitro.json as the default
- add a black-box CLI regression and run Nitrogen CLI tests in CI

## Breaking changes

None. Existing invocations still load ./nitro.json by default.

## Verification

- regression test failed before the fix: the CLI logged Loading nitro.json and reported that ./nitro.json did not exist despite a valid --config path
- bun --cwd packages/nitrogen test (1/1)
- bun --cwd packages/nitrogen typecheck
- bun --cwd packages/nitrogen lint-ci
- bun run build
- bun typecheck
- bun specs, with no generated diff
- C++ and Swift format scripts passed through the Xcode toolchain
- full lint-all reached Kotlin lint but the local machine does not have the ktlint executable; no Kotlin/native files are changed and CI will run that lane on the configured runner

## AI assistance

Codex using GPT-5.6 Sol assisted with reproduction, implementation, tests, and review.

Fixes #1554