### PR TITLE
fix: avoid bundling Nitro package metadata

### DIFF
--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -43,6 +43,10 @@ jobs:
       - name: Run TypeScript (tsc)
         run: bun typecheck
 
+      - name: Test Nitro Modules runtime metadata
+        working-directory: packages/react-native-nitro-modules
+        run: bun test --runInBand
+
   lint:
     name: Lint TypeScript (eslint, prettier)
     runs-on: ubuntu-latest

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -70,7 +70,10 @@ export default [
     ],
   },
   ...baseConfig,
-  packageConfig('packages/react-native-nitro-modules', ['./tsconfig.json']),
+  packageConfig('packages/react-native-nitro-modules', [
+    './tsconfig.json',
+    './tests/tsconfig.json',
+  ]),
   packageConfig('packages/nitrogen', true, false),
   packageConfig('packages/react-native-nitro-test'),
   packageConfig('packages/react-native-nitro-test-external'),

--- a/packages/react-native-nitro-modules/package.json
+++ b/packages/react-native-nitro-modules/package.json
@@ -59,10 +59,10 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "write-native-version": "version=$(node -p \"require('./package.json').version\") && sed -i '' \"s/#define NITRO_VERSION \\\".*\\\"/#define NITRO_VERSION \\\"$version\\\"/\" ./cpp/utils/NitroDefines.hpp",
+    "write-native-version": "version=$(node -p \"require('./package.json').version\") && sed -i '' \"s/#define NITRO_VERSION \\\".*\\\"/#define NITRO_VERSION \\\"$version\\\"/\" ./cpp/utils/NitroDefines.hpp && sed -i '' \"s/const jsVersion = '.*'/const jsVersion = '$version'/\" ./src/turbomodule/NativeNitroModules.ts",
     "postversion": "bun run write-native-version",
     "build": "rm -rf lib && bun typecheck && bob build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p tests/tsconfig.json",
     "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "lint-ci": "eslint \"**/*.{js,ts,tsx}\" -f @jamesacarr/github-actions --max-warnings 0",
     "test": "jest",

--- a/packages/react-native-nitro-modules/src/turbomodule/NativeNitroModules.ts
+++ b/packages/react-native-nitro-modules/src/turbomodule/NativeNitroModules.ts
@@ -12,7 +12,7 @@ interface Spec extends TurboModule {
   install(): string | undefined
 }
 
-const jsVersion = require('react-native-nitro-modules/package.json').version
+const jsVersion = '0.37.1'
 
 function getInstalledNitro(): NitroModulesProxy | undefined {
   // @ts-expect-error

--- a/packages/react-native-nitro-modules/tests/runtime-version.test.ts
+++ b/packages/react-native-nitro-modules/tests/runtime-version.test.ts
@@ -1,0 +1,19 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+it('embeds only the package version in the runtime module', () => {
+  const packageJsonPath = path.resolve(__dirname, '../package.json')
+  const nativeModulePath = path.resolve(
+    __dirname,
+    '../src/turbomodule/NativeNitroModules.ts'
+  )
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
+    version: string
+  }
+  const nativeModule = fs.readFileSync(nativeModulePath, 'utf8')
+
+  expect(nativeModule).not.toContain(
+    "require('react-native-nitro-modules/package.json')"
+  )
+  expect(nativeModule).toContain(`const jsVersion = '${packageJson.version}'`)
+})

--- a/packages/react-native-nitro-modules/tests/tsconfig.json
+++ b/packages/react-native-nitro-modules/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["."],
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["jest", "node"]
+  }
+}


### PR DESCRIPTION
## Summary

- replace the runtime package.json require with the release-synchronized JS version literal
- extend the existing postversion hook so the JS literal and native NITRO_VERSION macro update together
- add a regression test and run Nitro Modules package tests in the TypeScript CI workflow

## Breaking changes

None. The existing duplicate-install and native/JS version mismatch checks keep using the same package version.

## Verification

- regression failed before the fix because NativeNitroModules.ts imported react-native-nitro-modules/package.json
- bun nitro test --runInBand: 2 suites passed, 1 new test passed, 1 pre-existing todo
- bun nitro typecheck
- bun nitro lint-ci
- bun nitro build
- bun run build
- bun typecheck
- bun specs, with no generated diff
- bun nitro write-native-version, with both constants remaining synchronized
- verified source, CommonJS, and ESM build artifacts contain the version literal and no package.json import
- C++ and Swift format scripts passed through the Xcode toolchain
- full lint-all reached Kotlin lint but the local machine does not have the ktlint executable; no Kotlin/native files are changed and CI will run that lane on the configured runner

## AI assistance

Codex using GPT-5.6 Sol assisted with reproduction, implementation, tests, and review.

Fixes #1619