### PR TITLE
fix: validate native ArrayBuffer sizes

### DIFF
--- a/apps/example/src/getTests.ts
+++ b/apps/example/src/getTests.ts
@@ -49,6 +49,8 @@ export interface TestRunner {
 const MEMORY_LEAK_TEST_ALLOCATION_COUNT = 55_000
 const EXTERNAL_MEMORY_TEST_SIZE = 1024 * 1024
 const PARALLEL_HYBRID_OBJECT_TEST_TIMEOUT = 120_000
+const INVALID_NATIVE_ARRAY_BUFFER_SIZE_ERROR =
+  'ArrayBuffer size must be finite, non-negative, and within the platform size limit.'
 
 type HermesInternal = {
   getInstrumentedStats?: () => { js_externalBytes: number }
@@ -2634,6 +2636,32 @@ export function getTests(
         .didNotThrow()
         .didReturn('number')
         .equals(13)
+    ),
+    createTest('NitroModules.createNativeArrayBuffer(...) rejects NaN', () =>
+      it(() => NitroModules.createNativeArrayBuffer(Number.NaN)).didThrow(
+        INVALID_NATIVE_ARRAY_BUFFER_SIZE_ERROR
+      )
+    ),
+    createTest(
+      'NitroModules.createNativeArrayBuffer(...) rejects negative sizes',
+      () =>
+        it(() => NitroModules.createNativeArrayBuffer(-1)).didThrow(
+          INVALID_NATIVE_ARRAY_BUFFER_SIZE_ERROR
+        )
+    ),
+    createTest(
+      'NitroModules.createNativeArrayBuffer(...) rejects Infinity',
+      () =>
+        it(() =>
+          NitroModules.createNativeArrayBuffer(Number.POSITIVE_INFINITY)
+        ).didThrow(INVALID_NATIVE_ARRAY_BUFFER_SIZE_ERROR)
+    ),
+    createTest(
+      'NitroModules.createNativeArrayBuffer(...) rejects values beyond the platform size limit',
+      () =>
+        it(() =>
+          NitroModules.createNativeArrayBuffer(Number.MAX_VALUE)
+        ).didThrow(INVALID_NATIVE_ARRAY_BUFFER_SIZE_ERROR)
     ),
     createTest(
       'NitroModules.createNativeArrayBuffer(...) reports external memory pressure',

--- a/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.cpp
+++ b/packages/react-native-nitro-modules/cpp/entrypoint/HybridNitroModulesProxy.cpp
@@ -10,6 +10,10 @@
 #include "JSIConverter.hpp"
 #include "NitroDefines.hpp"
 
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
 namespace margelo::nitro {
 
 void HybridNitroModulesProxy::loadHybridMethods() {
@@ -80,6 +84,10 @@ std::shared_ptr<HybridObject> HybridNitroModulesProxy::updateMemorySize(const st
 }
 
 std::shared_ptr<ArrayBuffer> HybridNitroModulesProxy::createNativeArrayBuffer(double size) {
+  const double maximumSizeExclusive = std::ldexp(1.0, std::numeric_limits<size_t>::digits);
+  if (!std::isfinite(size) || size < 0 || size >= maximumSizeExclusive) [[unlikely]] {
+    throw std::invalid_argument("ArrayBuffer size must be finite, non-negative, and within the platform size limit.");
+  }
   return ArrayBuffer::allocate(static_cast<size_t>(size));
 }
 


### PR DESCRIPTION
## Summary

- reject non-finite, negative, and out-of-range native ArrayBuffer sizes before converting the JavaScript number to size_t
- use the exclusive 2^size_t_bits bound so the 64-bit conversion boundary cannot be admitted through double rounding
- cover NaN, Infinity, negative, and Number.MAX_VALUE inputs in the shared Android runtime harness

## Breaking changes

None. Valid non-negative sizes keep the existing conversion and allocation behavior. Invalid values now throw deterministically instead of reaching an undefined conversion or allocation attempt.

## Verification

- RED on Android API 37 before the fix: both C++ and Swift/Kotlin harness variants returned an ArrayBuffer for NaN instead of throwing
- GREEN Android harness: 8/8 invalid-size assertions passed across both variants
- focused createNativeArrayBuffer harness: 12/12 passed, including valid allocation and external-memory reporting
- Android arm64-v8a debug build passed
- bun run build
- bun typecheck
- bun specs, with no generated diff
- example TypeScript lint passed
- C++ and Swift format scripts passed through the Xcode toolchain
- full lint-all reached Kotlin lint but the local machine does not have the ktlint executable; no Kotlin source is changed and CI will run that lane on the configured runner

## AI assistance

Codex using GPT-5.6 Sol assisted with reproduction, implementation, tests, and review.

Fixes #1545