### PR TITLE
ci: trigger performance tests from PR comments

### DIFF
--- a/.github/PERFORMANCE.md
+++ b/.github/PERFORMANCE.md
@@ -6,9 +6,8 @@ Start a performance comparison by posting a new PR comment containing exactly:
 @nitro-modules-bot please test performance
 ```
 
-`@nitro-modulesbot please test performance` is also accepted. The commenter must
-be a repository owner, member, or collaborator, and the PR must be open. Editing
-an existing comment does not start a run. Pushes, PR updates, schedules, and the
+The commenter must be a repository owner, member, or collaborator, and the PR
+must be open. Editing an existing comment does not start a run. Pushes, PR updates, schedules, and the
 Actions dispatch button do not start performance runs. Manual requests run
 regardless of which files changed, including docs-only PRs.
 

--- a/.github/PERFORMANCE.md
+++ b/.github/PERFORMANCE.md
@@ -1,5 +1,29 @@
 # Release performance CI
 
+Start a performance comparison by posting a new PR comment containing exactly:
+
+```text
+@nitro-modules-bot please test performance
+```
+
+`@nitro-modulesbot please test performance` is also accepted. The commenter must
+be a repository owner, member, or collaborator, and the PR must be open. Editing
+an existing comment does not start a run. Pushes, PR updates, schedules, and the
+Actions dispatch button do not start performance runs. Manual requests run
+regardless of which files changed, including docs-only PRs.
+
+Each request starts an independent workflow run and posts a new report comment,
+even when the commits have not changed. Re-running jobs within that workflow
+updates only that run's report, using its workflow run ID. Requests do not cancel
+one another. The artifact links and attempt details are collapsed under
+**Raw measurements and artifacts**.
+
+The comment trigger and trusted publisher take effect after merging into the
+default branch. A comment event points at the default branch, so preparation
+resolves the PR's current base/head SHAs and head repository through GitHub before
+checking out either revision. Forks are supported. Re-running all jobs resolves
+the current PR revisions again; measurement-only reruns reuse the saved apps.
+
 `Nitro Performance` builds the dedicated `apps/benchmark` Release/Hermes app.
 Each platform installs base and head side by side on the same machine. It
 runs four pairs at each position in the apps' suite order: **AB, BA, BA, AB**
@@ -53,8 +77,8 @@ same-revision runs to investigate variation.
 Performance is currently report-only. Build, execution and malformed-result
 failures still fail CI. Turning observed differences into a regression gate needs
 empirical validation on unchanged commits and intentional slowdowns on each
-unchanged suite/testbed. No Promise case is permanently exempt. Scheduled/manual
-runs with the same base and head SHA measure baseline variation explicitly.
+unchanged suite/testbed. No Promise case is permanently exempt. Local runs with
+the same base and head SHA can measure baseline variation explicitly.
 Reports match results by benchmark ID, regardless of suite hashes, case order,
 versions, iteration counts or runner settings. New cases show their head timing
 as **⭐️ New**; removed cases retain their base timing with **❌ Removed** after.
@@ -105,15 +129,15 @@ containing `performance-summary.md`, `metadata.json`, and `bencher-*.json`.
 The raw artifact is uploaded first so the rendered comment can link its exact ID.
 Renderer and raw-schema changes can therefore be reviewed in PR CI before merging.
 
-One default-branch `Publish Nitro Performance` workflow handles internal PRs,
-forks and main runs. It selects the exact publication artifact for the triggering
+One default-branch `Publish Nitro Performance` workflow handles comment-triggered
+internal PRs and forks. It selects the exact publication artifact for the triggering
 attempt, checks its repository, run, revisions and current PR against GitHub,
-and posts its Markdown unchanged. It reads no raw samples and never installs or
-executes PR code or artifact scripts. Comment content is produced by PR code;
+and posts its Markdown unchanged. The trusted workflow run name identifies the
+triggering PR; the publisher does not choose a PR from artifact-provided data.
+It reads no raw samples and never installs or executes PR code or artifact scripts. Comment content is produced by PR code;
 provenance checks establish its source, not the correctness of its measurements.
-Docs-only and cancelled runs skip publication. Markdown/MDX-only edits also skip
-measurements inside package/app directories. Relevant failures remain failures.
-Stale PR results are skipped. User comments are never edited.
+Cancelled and skipped runs skip publication. Build and measurement failures remain
+failures. Stale PR results are skipped. User comments are never edited.
 
 The publication envelope is independent of raw app schema versions. Keep its
 filenames and identity fields stable when changing benchmarks or report rendering.
@@ -126,8 +150,8 @@ Bencher's JSON adapter validates the already-generated BMF files. The comment is
 posted first so an invalid BMF file cannot prevent the report from appearing.
 Bencher receives median latency values without invented bounds. PR publications
 seed both measured platform baselines at `baseline-<base SHA>` before recording
-the head at `pr-<number>`. Only main-branch runs record main history. Bencher
-receives history only: it does not post a second comment or create alert-driven
+the head at `pr-<number>`. Automatic main-branch history is no longer recorded.
+Bencher receives history only: it does not post a second comment or create alert-driven
 checks.
 
 ## CI runners
@@ -177,8 +201,9 @@ Bot authentication and upload changes take effect after reaching the default bra
 Without the Client ID variable, comments continue as `github-actions[bot]`.
 Removing that variable switches back to the default identity. Configured app
 authentication failures fail the posting job rather than silently switching authors.
-The first run after switching identities creates a new comment; subsequent runs
-update that bot's comment. Earlier comments keep their original author and avatar.
+Each workflow run creates its own comment under the configured identity. Reruns
+update only the matching run's comment from that bot. Switching identities creates
+a new comment; earlier comments keep their original author and avatar.
 
 ## Remaining upstream warnings
 

--- a/.github/workflows/performance-report.yml
+++ b/.github/workflows/performance-report.yml
@@ -5,6 +5,11 @@ on:
     workflows: [Nitro Performance]
     types: [completed]
 
+# Serialize publication attempts for the same run without combining separate requests.
+concurrency:
+  group: performance-report-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
 permissions:
   actions: read
   contents: read
@@ -12,6 +17,7 @@ permissions:
 
 jobs:
   publish:
+    if: github.event.workflow_run.event == 'issue_comment'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout trusted publishing code
@@ -44,27 +50,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          EVENT_NAME=$(jq -r '.workflow_run.event' "$GITHUB_EVENT_PATH")
-          TRUSTED_PR_ARGUMENTS=()
-          if [[ "$EVENT_NAME" == 'pull_request' ]]; then
-            PR_NUMBER=$(jq -r '.pullRequestNumber' untrusted-artifact/metadata.json)
-            if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
-              echo 'Invalid pull request number in performance artifact.' >&2
-              exit 1
-            fi
-            gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > trusted-pull-request.json
-            TRUSTED_PR_ARGUMENTS=(--trusted-pull-request trusted-pull-request.json)
-          fi
+          set -euo pipefail
+          # The run name is set by the default-branch workflow using the triggering PR.
+          PR_NUMBER=$(jq -er '.workflow_run.display_title | capture("^Nitro Performance for PR #(?<number>[1-9][0-9]*)$").number' "$GITHUB_EVENT_PATH")
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > trusted-pull-request.json
           bun scripts/performance/validate-report.ts \
             --artifact-directory untrusted-artifact \
             --output-directory validated-report \
             --expected-repository "$GITHUB_REPOSITORY" \
             --trusted-workflow-event "$GITHUB_EVENT_PATH" \
-            "${TRUSTED_PR_ARGUMENTS[@]}"
+            --trusted-pull-request trusted-pull-request.json
 
       - name: Create Nitro Modules Bot token
         id: performance-bot-token
-        if: steps.download.outcome == 'success' && steps.validate.outputs.stale != 'true' && vars.NITRO_PERFORMANCE_APP_CLIENT_ID != '' && github.event.workflow_run.event == 'pull_request'
+        if: steps.download.outcome == 'success' && steps.validate.outputs.stale != 'true' && vars.NITRO_PERFORMANCE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.NITRO_PERFORMANCE_APP_CLIENT_ID }}

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,91 +1,57 @@
 name: Nitro Performance
+run-name: 'Nitro Performance for PR #${{ github.event.issue.number }}'
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
-  push:
-    branches: [main]
-  schedule:
-    - cron: '17 3 * * 1'
-  workflow_dispatch:
-
-concurrency:
-  group: performance-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
 
 jobs:
   prepare:
+    if: >-
+      github.event.issue.pull_request &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+      (github.event.comment.body == '@nitro-modules-bot please test performance' ||
+       github.event.comment.body == '@nitro-modulesbot please test performance')
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       base_sha: ${{ steps.metadata.outputs.base_sha }}
       head_sha: ${{ steps.metadata.outputs.head_sha }}
+      head_repository: ${{ steps.metadata.outputs.head_repository }}
       pr_number: ${{ steps.metadata.outputs.pr_number }}
-      relevant: ${{ steps.metadata.outputs.relevant }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-
       - id: metadata
-        name: Resolve revisions and relevant paths
+        name: Resolve pull request revisions
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PUSH_BASE_SHA: ${{ github.event.before }}
-          CURRENT_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
           set -euo pipefail
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            BASE_SHA="$PR_BASE_SHA"
-            HEAD_SHA="$PR_HEAD_SHA"
-            NUMBER="$PR_NUMBER"
-          elif [[ "$EVENT_NAME" == "push" && ! "$PUSH_BASE_SHA" =~ ^0+$ ]]; then
-            BASE_SHA="$PUSH_BASE_SHA"
-            HEAD_SHA="$CURRENT_SHA"
-            NUMBER="0"
-          else
-            BASE_SHA="$CURRENT_SHA"
-            HEAD_SHA="$CURRENT_SHA"
-            NUMBER="0"
-          fi
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > pull-request.json
+          jq -e --arg repository "$GITHUB_REPOSITORY" --argjson number "$PR_NUMBER" '
+            .number == $number and .state == "open" and .base.repo.full_name == $repository and
+            (.base.sha | test("^[0-9a-f]{40}$")) and (.head.sha | test("^[0-9a-f]{40}$")) and
+            (.head.repo.full_name | test("^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$"))
+          ' pull-request.json > /dev/null
+          jq -r '"base_sha=\(.base.sha)", "head_sha=\(.head.sha)",
+            "head_repository=\(.head.repo.full_name)", "pr_number=\(.number)"' \
+            pull-request.json >> "$GITHUB_OUTPUT"
 
-          RELEVANT=true
-          if [[ "$BASE_SHA" != "$HEAD_SHA" ]] && git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
-            '.github/workflows/performance.yml' \
-            '.github/workflows/performance-report.yml' \
-            'bun.lock' \
-            'package.json' \
-            'scripts/performance' \
-            'apps/benchmark' \
-            'packages/react-native-nitro-modules' \
-            'packages/react-native-nitro-test' \
-            'packages/react-native-nitro-test-external' \
-            ':(glob,exclude)**/*.md' \
-            ':(glob,exclude)**/*.mdx'; then
-            RELEVANT=false
-          fi
-
-          {
-            echo "base_sha=$BASE_SHA"
-            echo "head_sha=$HEAD_SHA"
-            echo "pr_number=$NUMBER"
-            echo "relevant=$RELEVANT"
-          } >> "$GITHUB_OUTPUT"
-          if [[ "$RELEVANT" == 'false' ]]; then
-            echo 'No performance-sensitive files changed.' >> "$GITHUB_STEP_SUMMARY"
-          fi
-
+      - name: Checkout performance tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: ${{ steps.metadata.outputs.head_repository }}
+          ref: ${{ steps.metadata.outputs.head_sha }}
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        if: steps.metadata.outputs.relevant == 'true'
         with:
           bun-version: 1.3.14
       - name: Test performance tooling
-        if: steps.metadata.outputs.relevant == 'true'
         run: |
           bun install --frozen-lockfile
           bun run test:performance-tools
@@ -95,7 +61,6 @@ jobs:
 
   build-android:
     needs: prepare
-    if: needs.prepare.outputs.relevant == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 40
     outputs:
@@ -106,12 +71,14 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.base_sha }}
           path: base
+          persist-credentials: false
       - name: Checkout head
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          repository: ${{ needs.prepare.outputs.head_repository }}
           ref: ${{ needs.prepare.outputs.head_sha }}
           path: head
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
@@ -162,8 +129,9 @@ jobs:
       - name: Checkout measurement controller
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          repository: ${{ needs.prepare.outputs.head_repository }}
           ref: ${{ env.HEAD_SHA }}
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
@@ -227,7 +195,6 @@ jobs:
 
   build-ios:
     needs: prepare
-    if: needs.prepare.outputs.relevant == 'true'
     runs-on: blacksmith-6vcpu-macos-26
     timeout-minutes: 60
     outputs:
@@ -238,12 +205,14 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.base_sha }}
           path: base
+          persist-credentials: false
       - name: Checkout head
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          repository: ${{ needs.prepare.outputs.head_repository }}
           ref: ${{ needs.prepare.outputs.head_sha }}
           path: head
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
@@ -293,8 +262,9 @@ jobs:
       - name: Checkout measurement controller
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          repository: ${{ needs.prepare.outputs.head_repository }}
           ref: ${{ env.HEAD_SHA }}
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
@@ -348,7 +318,7 @@ jobs:
   nitro-performance:
     name: nitro-performance
     needs: [prepare, measure-android, measure-ios]
-    if: always() && !cancelled() && needs.prepare.outputs.relevant == 'true'
+    if: always() && !cancelled() && needs.prepare.result == 'success'
     runs-on: ubuntu-24.04
     steps:
       - name: Require successful platform runs
@@ -364,8 +334,9 @@ jobs:
       - name: Checkout report tooling
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          repository: ${{ needs.prepare.outputs.head_repository }}
           ref: ${{ needs.prepare.outputs.head_sha }}
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -13,8 +13,7 @@ jobs:
     if: >-
       github.event.issue.pull_request &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
-      (github.event.comment.body == '@nitro-modules-bot please test performance' ||
-       github.event.comment.body == '@nitro-modulesbot please test performance')
+      github.event.comment.body == '@nitro-modules-bot please test performance'
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -108,8 +108,9 @@ process variability, raw artifacts, trusted reporting, and Bencher publishing.
 CI retains exact app artifacts for measurement-only reruns. It builds both
 revisions even when definitions change, and reuses one binary for identical SHAs.
 New and removed cases stay visible in the table without a percentage comparison.
-Same-revision scheduled/manual runs show baseline variation. Performance remains
-report-only.
+Post `@nitro-modules-bot please test performance` on an open PR to start CI. Each
+request posts a new report; rerunning the same workflow updates its report. Local
+same-revision runs show baseline variation. Performance remains report-only.
 
 The example's former benchmark screen and TurboModule control have moved here.
 No public Nitro API changes are needed. App dependency versions initially match

--- a/scripts/performance/generate-report.test.ts
+++ b/scripts/performance/generate-report.test.ts
@@ -99,7 +99,7 @@ async function createFixture(root: string): Promise<{
 
   await writeJson(path.join(artifact, 'performance-report.json'), {
     schemaVersion: 2,
-    eventName: 'pull_request',
+    eventName: 'issue_comment',
     repository: REPOSITORY,
     pullRequestNumber: 123,
     baseSha: BASE_SHA,

--- a/scripts/performance/github-report.test.ts
+++ b/scripts/performance/github-report.test.ts
@@ -4,6 +4,7 @@ import { postPerformanceComment } from './github-report'
 const report = {
   repository: 'margelo/nitro',
   pullRequestNumber: 123,
+  workflowRunId: 456,
   baseSha: 'a'.repeat(40),
   headSha: 'b'.repeat(40),
   markdown: '## Nitro performance\n\n| Benchmark | Base | Head |',
@@ -13,7 +14,7 @@ const pullRequest = {
   base: { sha: report.baseSha },
   head: { sha: report.headSha },
 }
-const marker = '<!-- nitro-performance-paired-comparison -->'
+const marker = '<!-- nitro-performance-paired-comparison:456 -->'
 
 describe('paired performance PR comment', () => {
   test('creates a comment without modifying user comments', async () => {
@@ -74,6 +75,116 @@ describe('paired performance PR comment', () => {
           body: { body: `${marker}\n${report.markdown}` },
         },
       ])
+    }
+  )
+
+  test('new requests on the same commits create reports and reruns update only their own report', async () => {
+    const comments = [
+      {
+        id: 1,
+        body: '<!-- nitro-performance-paired-comparison -->\nlegacy report',
+        user: { login: 'github-actions[bot]', type: 'Bot' },
+      },
+    ]
+    const request = async (
+      endpoint: string,
+      method = 'GET',
+      body?: { body: string }
+    ) => {
+      if (endpoint.includes('/pulls/')) return pullRequest
+      if (method === 'POST') {
+        comments.push({
+          id: comments.length + 1,
+          body: body!.body,
+          user: { login: 'github-actions[bot]', type: 'Bot' },
+        })
+        return {}
+      }
+      if (method === 'PATCH') {
+        comments.find((comment) => endpoint.endsWith(`/${comment.id}`))!.body =
+          body!.body
+        return {}
+      }
+      return comments
+    }
+    expect(await postPerformanceComment(report, request)).toBe('created')
+    const nextRun = {
+      ...report,
+      workflowRunId: 789,
+      markdown: 'Second request',
+    }
+    expect(await postPerformanceComment(nextRun, request)).toBe('created')
+    expect(
+      await postPerformanceComment(
+        { ...report, markdown: 'First run, attempt 2' },
+        request
+      )
+    ).toBe('updated')
+    expect(comments.map((comment) => comment.body)).toEqual([
+      '<!-- nitro-performance-paired-comparison -->\nlegacy report',
+      `${marker}\nFirst run, attempt 2`,
+      '<!-- nitro-performance-paired-comparison:789 -->\nSecond request',
+    ])
+    expect(
+      await postPerformanceComment(
+        { ...nextRun, markdown: 'Second run, attempt 2' },
+        request
+      )
+    ).toBe('updated')
+    expect(comments).toHaveLength(3)
+    expect(comments[1]!.body).toBe(`${marker}\nFirst run, attempt 2`)
+    expect(comments[2]!.body).toBe(
+      '<!-- nitro-performance-paired-comparison:789 -->\nSecond run, attempt 2'
+    )
+  })
+
+  test('finds the same run on a later page before creating a comment', async () => {
+    const writes: unknown[] = []
+    const status = await postPerformanceComment(
+      report,
+      async (endpoint, method = 'GET', body) => {
+        if (method !== 'GET') {
+          writes.push({ endpoint, method, body })
+          return {}
+        }
+        if (endpoint.includes('/pulls/')) return pullRequest
+        if (endpoint.endsWith('page=1')) {
+          return Array.from({ length: 100 }, (_, id) => ({
+            id,
+            body: '<!-- nitro-performance-paired-comparison:123 -->\nOther run',
+            user: { login: 'github-actions[bot]', type: 'Bot' },
+          }))
+        }
+        return [
+          {
+            id: 101,
+            body: marker,
+            user: { login: 'github-actions[bot]', type: 'Bot' },
+          },
+        ]
+      }
+    )
+    expect(status).toBe('updated')
+    expect(writes).toEqual([
+      {
+        endpoint: '/repos/margelo/nitro/issues/comments/101',
+        method: 'PATCH',
+        body: { body: `${marker}\n${report.markdown}` },
+      },
+    ])
+  })
+
+  test.each([0, -1, NaN, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+    'rejects invalid run ID %s before making requests',
+    async (workflowRunId) => {
+      let requests = 0
+      await expect(
+        postPerformanceComment({ ...report, workflowRunId }, async () => {
+          requests++
+          return {}
+        })
+      ).rejects.toThrow('Invalid validated PR report metadata or size.')
+      expect(requests).toBe(0)
     }
   )
 

--- a/scripts/performance/github-report.ts
+++ b/scripts/performance/github-report.ts
@@ -3,11 +3,9 @@ import path from 'node:path'
 import { parseArguments, requiredArgument } from './args'
 import type { ReportMetadata } from './report'
 
-const COMMENT_MARKER = '<!-- nitro-performance-paired-comparison -->'
-
 interface PullRequestReport extends Pick<
   ReportMetadata,
-  'repository' | 'baseSha' | 'headSha'
+  'repository' | 'baseSha' | 'headSha' | 'workflowRunId'
 > {
   pullRequestNumber: number
   markdown: string
@@ -31,6 +29,8 @@ export async function postPerformanceComment(
     !/^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/.test(report.repository) ||
     !Number.isSafeInteger(report.pullRequestNumber) ||
     report.pullRequestNumber < 1 ||
+    !Number.isSafeInteger(report.workflowRunId) ||
+    report.workflowRunId < 1 ||
     !/^[0-9a-f]{40}$/.test(report.baseSha) ||
     !/^[0-9a-f]{40}$/.test(report.headSha) ||
     report.markdown.length > 60_000
@@ -51,7 +51,8 @@ export async function postPerformanceComment(
     return 'stale'
   }
 
-  const body = { body: `${COMMENT_MARKER}\n${report.markdown}` }
+  const marker = `<!-- nitro-performance-paired-comparison:${report.workflowRunId} -->`
+  const body = { body: `${marker}\n${report.markdown}` }
   for (let page = 1; page <= 10; page++) {
     const comments = (await request(
       `${root}/issues/${report.pullRequestNumber}/comments?per_page=100&page=${page}`
@@ -64,7 +65,7 @@ export async function postPerformanceComment(
       (comment) =>
         comment.user.login === botLogin &&
         comment.user.type === 'Bot' &&
-        comment.body.startsWith(COMMENT_MARKER)
+        comment.body.startsWith(marker)
     )
     if (existing != null) {
       await request(`${root}/issues/comments/${existing.id}`, 'PATCH', body)

--- a/scripts/performance/report-markdown.test.ts
+++ b/scripts/performance/report-markdown.test.ts
@@ -49,8 +49,6 @@ test('restores the original table, emphasis, colors, disclosure, and footer', ()
   expect(text).toMatchInlineSnapshot(`
     "## Performance Report
 
-    > ⚠️ **Advisory:** Results do not fail this PR.
-
     ### iOS
 
     <table>
@@ -102,7 +100,12 @@ test('restores the original table, emphasis, colors, disclosure, and footer', ()
 
     Benchmarking Code Diff [\`aaaaaaaa\`...\`bbbbbbbb\`](https://github.com/margelo/nitro/compare/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) ([view raw output](https://github.com/margelo/nitro/actions/runs/123))
 
+    <details>
+      <summary>Raw measurements and artifacts</summary>
+
     Raw measurements: [performance-report-2 (JSON artifact)](https://github.com/margelo/nitro/actions/runs/123/artifacts/987). Run 123, attempt 2. Download requires GitHub access.
+
+    </details>
     "
   `)
 })
@@ -251,6 +254,11 @@ test('keeps exact run, raw JSON, and platform artifact provenance', () => {
       },
     },
   })
+  expect(text).not.toContain('Advisory')
+  const [visible, details] = text.split('<details>')
+  expect(visible).not.toMatch(/Raw measurements:|Android:|iOS:/)
+  expect(details).toContain('<summary>Raw measurements and artifacts</summary>')
+  expect(details!.trimEnd()).toEndWith('</details>')
   expect(text).toContain(`([view raw output](${options.workflowRunUrl}))`)
   expect(text).toContain(
     `Raw measurements: [performance-report-2 (JSON artifact)](${options.workflowRunUrl}/artifacts/987). Run 123, attempt 2. Download requires GitHub access.`
@@ -261,4 +269,14 @@ test('keeps exact run, raw JSON, and platform artifact provenance', () => {
   expect(text).toContain(
     `iOS: [measurements, attempt 2](${options.workflowRunUrl}/artifacts/765), [apps, attempt 1](${options.workflowRunUrl}/artifacts/432).`
   )
+})
+
+test('omits the artifact disclosure when no artifact links are available', () => {
+  const text = renderPerformanceReportMarkdown([], {
+    repository: options.repository,
+    baseSha: options.baseSha,
+    headSha: options.headSha,
+  })
+  expect(text).not.toContain('<details>')
+  expect(text).not.toContain('Advisory')
 })

--- a/scripts/performance/report-markdown.ts
+++ b/scripts/performance/report-markdown.ts
@@ -160,11 +160,7 @@ export function renderPerformanceReportMarkdown(
     artifacts?: PerformanceReport['artifacts']
   }
 ): string {
-  const lines = [
-    '## Performance Report',
-    '',
-    '> ⚠️ **Advisory:** Results do not fail this PR.',
-  ]
+  const lines = ['## Performance Report']
   if (options.baseSha === options.headSha) {
     lines.push(
       '',
@@ -203,6 +199,16 @@ export function renderPerformanceReportMarkdown(
     `Benchmarking Code Diff [\`${options.baseSha.slice(0, 8)}\`...\`${options.headSha.slice(0, 8)}\`](https://github.com/${options.repository}/compare/${options.baseSha}..${options.headSha})${options.workflowRunUrl == null ? '' : ` ([view raw output](${options.workflowRunUrl}))`}`,
     ''
   )
+  const hasArtifacts =
+    options.workflowRunUrl != null &&
+    (options.artifactId != null || options.artifacts != null)
+  if (hasArtifacts) {
+    lines.push(
+      '<details>',
+      '  <summary>Raw measurements and artifacts</summary>',
+      ''
+    )
+  }
   if (options.artifactId != null && options.workflowRunUrl != null) {
     lines.push(
       `Raw measurements: [performance-report-${options.runAttempt} (JSON artifact)](${options.workflowRunUrl}/artifacts/${options.artifactId}). Run ${options.workflowRunUrl.split('/').at(-1)}, attempt ${options.runAttempt}. Download requires GitHub access.`,
@@ -219,5 +225,6 @@ export function renderPerformanceReportMarkdown(
       ''
     )
   }
+  if (hasArtifacts) lines.push('</details>', '')
   return lines.join('\n')
 }

--- a/scripts/performance/report-validation.test.ts
+++ b/scripts/performance/report-validation.test.ts
@@ -3,11 +3,11 @@ import { mkdtemp, rm, symlink } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-async function fixture() {
+async function fixture(eventName = 'pull_request') {
   const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-publication-'))
   const metadata = {
     repository: 'margelo/nitro',
-    eventName: 'pull_request',
+    eventName,
     pullRequestNumber: 123,
     baseSha: 'a'.repeat(40),
     headSha: 'b'.repeat(40),
@@ -21,9 +21,17 @@ async function fixture() {
       id: metadata.workflowRunId,
       run_attempt: metadata.runAttempt,
       event: metadata.eventName,
-      head_sha: metadata.headSha,
-      head_branch: 'feature',
-      head_repository: { full_name: 'contributor/nitro' },
+      // Comment events describe the default branch, not the benchmarked PR.
+      display_title: `Nitro Performance for PR #${metadata.pullRequestNumber}`,
+      head_sha:
+        eventName === 'issue_comment' ? 'd'.repeat(40) : metadata.headSha,
+      head_branch: eventName === 'issue_comment' ? 'main' : 'feature',
+      head_repository: {
+        full_name:
+          eventName === 'issue_comment'
+            ? metadata.repository
+            : 'contributor/nitro',
+      },
     },
   }
   const pr = {
@@ -186,4 +194,42 @@ test('rejects a symlink instead of posting a file outside the publication', asyn
   await Bun.write(outside, 'Must not be posted')
   await symlink(outside, report)
   expect((await f.validate()).exitCode).not.toBe(0)
+})
+
+test.each(['margelo/nitro', 'contributor/nitro'])(
+  'publishes a comment-triggered PR from %s even though the workflow SHA is main',
+  async (headRepository) => {
+    await using f = await fixture('issue_comment')
+    f.pr.head.repo.full_name = headRepository
+    expect((await f.validate()).exitCode).toBe(0)
+    expect(await Bun.file(path.join(f.output, 'metadata.json')).json()).toEqual(
+      f.metadata
+    )
+  }
+)
+
+test.each(['title', 'repository', 'pr', 'sha'])(
+  'rejects a comment-triggered publication with mismatched %s',
+  async (kind) => {
+    await using f = await fixture('issue_comment')
+    if (kind === 'title')
+      f.event.workflow_run.display_title = 'Nitro Performance for PR #999'
+    if (kind === 'repository')
+      f.event.workflow_run.head_repository.full_name = 'contributor/nitro'
+    if (kind === 'pr') f.metadata.pullRequestNumber = f.pr.number = 999
+    if (kind === 'sha') f.metadata.headSha = 'invalid'
+    expect((await f.validate()).exitCode).not.toBe(0)
+  }
+)
+
+test('skips comment-triggered results if the PR head advances', async () => {
+  await using f = await fixture('issue_comment')
+  f.pr.head.sha = 'c'.repeat(40)
+  expect((await f.validate()).exitCode).toBe(0)
+  expect(await Bun.file(path.join(f.root, 'outputs')).text()).toContain(
+    'stale=true'
+  )
+  expect(
+    await Bun.file(path.join(f.output, 'performance-summary.md')).exists()
+  ).toBe(false)
 })

--- a/scripts/performance/report.ts
+++ b/scripts/performance/report.ts
@@ -5,7 +5,12 @@ import { parseArguments, requiredArgument } from './args'
 /** Raw measurements and provenance, retained separately from the rendered publication. */
 export interface PerformanceReport {
   schemaVersion: 2
-  eventName: 'pull_request' | 'push' | 'schedule' | 'workflow_dispatch'
+  eventName:
+    | 'issue_comment'
+    | 'pull_request'
+    | 'push'
+    | 'schedule'
+    | 'workflow_dispatch'
   repository: string
   pullRequestNumber: number | null
   baseSha: string
@@ -42,6 +47,7 @@ if (import.meta.main) {
   const args = parseArguments(Bun.argv.slice(2))
   const eventName = requiredArgument(args, 'event-name')
   if (
+    eventName !== 'issue_comment' &&
     eventName !== 'pull_request' &&
     eventName !== 'push' &&
     eventName !== 'schedule' &&

--- a/scripts/performance/validate-report.ts
+++ b/scripts/performance/validate-report.ts
@@ -36,7 +36,9 @@ if (
   metadata.eventName !== run.event ||
   metadata.workflowRunId !== run.id ||
   metadata.runAttempt !== run.run_attempt ||
-  metadata.headSha !== run.head_sha ||
+  (run.event !== 'issue_comment' && metadata.headSha !== run.head_sha) ||
+  typeof metadata.headSha !== 'string' ||
+  !/^[0-9a-f]{40}$/.test(metadata.headSha) ||
   typeof metadata.baseSha !== 'string' ||
   !/^[0-9a-f]{40}$/.test(metadata.baseSha) ||
   !Array.isArray(metadata.platforms) ||
@@ -52,7 +54,7 @@ if (
   )
 }
 
-if (run.event === 'pull_request') {
+if (run.event === 'issue_comment' || run.event === 'pull_request') {
   const pr = JSON.parse(
     await readFile(requiredArgument(args, 'trusted-pull-request'), 'utf8')
   )
@@ -62,7 +64,10 @@ if (run.event === 'pull_request') {
     metadata.pullRequestNumber < 1 ||
     metadata.pullRequestNumber !== pr.number ||
     pr.base.repo.full_name !== repository ||
-    pr.head.repo.full_name !== run.head_repository.full_name
+    (run.event === 'issue_comment'
+      ? run.head_repository.full_name !== repository ||
+        run.display_title !== `Nitro Performance for PR #${pr.number}`
+      : pr.head.repo.full_name !== run.head_repository.full_name)
   ) {
     throw new Error(
       'Publication metadata does not match the trusted pull request.'

--- a/scripts/performance/workflow.test.ts
+++ b/scripts/performance/workflow.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test'
-import { readFile, mkdtemp, mkdir, rm } from 'node:fs/promises'
+import { readFile, mkdtemp, chmod, rm } from 'node:fs/promises'
 import path from 'node:path'
 import os from 'node:os'
 
@@ -66,7 +66,15 @@ test('one trusted publisher handles internal and fork reports without executing 
   ) as any
   expect(entry.permissions).toEqual({ contents: 'read' })
   expect(entry.jobs['publish-pr']).toBeUndefined()
-  expect(publisher.jobs.publish.if).toBeUndefined()
+  expect(publisher.jobs.publish.if).toBe(
+    "github.event.workflow_run.event == 'issue_comment'"
+  )
+  expect(entry.on).toEqual({ issue_comment: { types: ['created'] } })
+  expect(entry.concurrency).toBeUndefined()
+  expect(publisher.concurrency).toEqual({
+    'group': 'performance-report-${{ github.event.workflow_run.id }}',
+    'cancel-in-progress': false,
+  })
   const source = JSON.stringify(publisher)
   expect(source).not.toMatch(
     /pull_request.head.sha|bun install|NITRO_BENCHER_ENABLED/
@@ -106,50 +114,11 @@ test('one trusted publisher handles internal and fork reports without executing 
   ).toBeLessThan(steps.findIndex((s) => s.name === 'Publish Bencher history'))
 })
 
-test.each([false, true])(
-  'package docs skip measurements unless native code also changed: %s',
-  async (nativeChange) => {
-    const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-relevance-'))
+test.each(['margelo/nitro', 'contributor/nitro'])(
+  'resolves manual PR revisions from %s without filtering changed paths',
+  async (headRepository) => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-request-'))
     try {
-      async function git(...args: string[]) {
-        const child = Bun.spawn(['git', ...args], {
-          cwd: root,
-          stdout: 'pipe',
-          stderr: 'pipe',
-        })
-        const output = await new Response(child.stdout).text()
-        if ((await child.exited) !== 0)
-          throw new Error(await new Response(child.stderr).text())
-        return output.trim()
-      }
-      await git('init', '-q')
-      await git(
-        '-c',
-        'user.name=Fixture',
-        '-c',
-        'user.email=fixture@example.com',
-        'commit',
-        '--allow-empty',
-        '-qm',
-        'base'
-      )
-      const base = await git('rev-parse', 'HEAD')
-      const directory = path.join(root, 'packages/react-native-nitro-modules')
-      await mkdir(directory, { recursive: true })
-      await Bun.write(path.join(directory, 'README.md'), 'documentation')
-      await Bun.write(path.join(directory, 'guide.mdx'), 'documentation')
-      if (nativeChange)
-        await Bun.write(path.join(directory, 'Runtime.cpp'), '// native change')
-      await git('add', '.')
-      await git(
-        '-c',
-        'user.name=Fixture',
-        '-c',
-        'user.email=fixture@example.com',
-        'commit',
-        '-qm',
-        'head'
-      )
       const workflow = Bun.YAML.parse(
         await readFile(
           new URL('../../.github/workflows/performance.yml', import.meta.url),
@@ -159,24 +128,48 @@ test.each([false, true])(
       const script = workflow.jobs.prepare.steps.find(
         (step: any) => step.id === 'metadata'
       ).run
-      const child = Bun.spawn(['bash', '-euo', 'pipefail', '-c', script], {
-        cwd: root,
-        env: {
-          ...process.env,
-          EVENT_NAME: 'pull_request',
-          PR_BASE_SHA: base,
-          PR_HEAD_SHA: await git('rev-parse', 'HEAD'),
-          PR_NUMBER: '1',
-          GITHUB_OUTPUT: path.join(root, 'outputs'),
-          GITHUB_STEP_SUMMARY: path.join(root, 'summary'),
-        },
-        stdout: 'pipe',
-        stderr: 'pipe',
-      })
-      expect(await child.exited).toBe(0)
-      expect(await Bun.file(path.join(root, 'outputs')).text()).toContain(
-        `relevant=${nativeChange}`
+      const pr = {
+        number: 123,
+        state: 'open',
+        base: { sha: 'a'.repeat(40), repo: { full_name: 'margelo/nitro' } },
+        head: { sha: 'b'.repeat(40), repo: { full_name: headRepository } },
+      }
+      // Only the pull lookup is available: no changed-file lookup or git diff.
+      const gh = path.join(root, 'gh')
+      await Bun.write(
+        gh,
+        '#!/bin/bash\n[[ "$*" == "api repos/margelo/nitro/pulls/123" ]] || exit 1\ncat "$PR_FIXTURE"\n'
       )
+      await chmod(gh, 0o755)
+      async function resolve() {
+        await Bun.write(path.join(root, 'pr.json'), JSON.stringify(pr))
+        await rm(path.join(root, 'outputs'), { force: true })
+        const child = Bun.spawn(['bash', '-euo', 'pipefail', '-c', script], {
+          cwd: root,
+          env: {
+            ...process.env,
+            PATH: `${root}:${process.env.PATH}`,
+            PR_FIXTURE: path.join(root, 'pr.json'),
+            PR_NUMBER: '123',
+            GITHUB_REPOSITORY: 'margelo/nitro',
+            GITHUB_OUTPUT: path.join(root, 'outputs'),
+          },
+          stdout: 'pipe',
+          stderr: 'pipe',
+        })
+        return child.exited
+      }
+      expect(await resolve()).toBe(0)
+      expect(await Bun.file(path.join(root, 'outputs')).text()).toBe(
+        `base_sha=${pr.base.sha}\nhead_sha=${pr.head.sha}\nhead_repository=${headRepository}\npr_number=123\n`
+      )
+      pr.state = 'closed'
+      expect(await resolve()).not.toBe(0)
+      expect(await Bun.file(path.join(root, 'outputs')).exists()).toBe(false)
+      pr.state = 'open'
+      pr.head.sha = 'invalid\nhead_sha=injected'
+      expect(await resolve()).not.toBe(0)
+      expect(await Bun.file(path.join(root, 'outputs')).exists()).toBe(false)
     } finally {
       await rm(root, { recursive: true, force: true })
     }


### PR DESCRIPTION
Performance CI currently starts on PR updates, pushes, schedules, and workflow dispatch. Run it only when a repository owner, member, or collaborator posts `@nitro-modules-bot please test performance` on an open PR. Resolve the PR’s base/head commits and repository through GitHub so internal and fork PRs work, and honor requests regardless of changed paths.

Each request creates an independent workflow run and a new performance-table comment, even on unchanged commits. Re-running that workflow updates only its own comment using the workflow run ID. Remove the advisory banner and collapse raw measurements, app artifacts, and attempt details under a disclosure.

The trusted publisher derives the PR from the GitHub workflow run name and validates the report against that PR. Publication attempts for the same run are serialized. Existing stale-result and bot-author checks remain in place.

Validation:
- `bun run test:performance-tools`: 118 passed, including repeated requests, reruns, pagination, fork provenance, and report formatting.
- `bun run typecheck:performance-tools` and ESLint on changed TypeScript files passed.
- Prettier and `actionlint` passed; actionlint used a temporary config listing the existing Blacksmith runner labels.

The comment trigger and publisher changes take effect after merging into the default branch. Full native benchmark runs were not started locally.
