### PR TITLE
ci: add performance request feedback and PR statuses

### DIFF
--- a/.github/PERFORMANCE.md
+++ b/.github/PERFORMANCE.md
@@ -6,15 +6,32 @@ Start a performance comparison by posting a new PR comment containing exactly:
 @nitro-modules-bot please test performance
 ```
 
-The commenter must be a repository owner, member, or collaborator, and the PR
-must be open. Editing an existing comment does not start a run. Pushes, PR updates, schedules, and the
-Actions dispatch button do not start performance runs. Manual requests run
+The PR must be open, and GitHub must report **write**, **maintain**, or **admin**
+access for the commenter in this repository. Read/triage access, org membership
+alone, and access to a fork do not grant permission to start these runs. Other
+users can post the command, but it will not run benchmarks or receive a reaction.
+Editing an existing comment does not start a run. Pushes, PR updates, schedules,
+and the Actions dispatch button do not start performance runs. Manual requests run
 regardless of which files changed, including docs-only PRs.
+
+An accepted request gets a 👍 reaction from the bot. The PR's checks area shows
+`Nitro Performance / <run ID>`, with a yellow pending status while it runs,
+green on success, or red for failures/cancellation. The status links to the run
+logs; publishing failures link to the publishing workflow. Each status belongs
+to the tested head commit, even if the PR advances while measurements run.
+
+Failures also produce a PR comment with direct links to the benchmark attempt
+and publishing logs. Re-running the failed workflow updates the same comment.
+If report publishing fails after measurements succeeded, available results stay
+in that comment. A failed run leaves earlier successful reports visible.
 
 Each request starts an independent workflow run and posts a new report comment,
 even when the commits have not changed. Re-running jobs within that workflow
 updates only that run's report, using its workflow run ID. Requests do not cancel
-one another. The artifact links and attempt details are collapsed under
+one another. After publishing a report, the bot minimizes its older performance
+comments as **Outdated**, including legacy reports. It leaves other authors and
+unrelated comments alone; rerunning an older run never hides a newer report.
+The artifact links and attempt details are collapsed under
 **Raw measurements and artifacts**.
 
 The comment trigger and trusted publisher take effect after merging into the
@@ -128,6 +145,13 @@ containing `performance-summary.md`, `metadata.json`, and `bencher-*.json`.
 The raw artifact is uploaded first so the rendered comment can link its exact ID.
 Renderer and raw-schema changes can therefore be reviewed in PR CI before merging.
 
+The isolated request job saves `performance-request-<attempt>` before any PR code
+runs. It contains the requested head SHA and workflow identity. The publisher
+checks this against the initial commit status written by `github-actions[bot]`
+before trusting it. Measurement-only reruns reuse this request; late events from
+older attempts cannot overwrite a newer status. PR code never receives the bot
+key or a token with status/comment write permissions.
+
 One default-branch `Publish Nitro Performance` workflow handles comment-triggered
 internal PRs and forks. It selects the exact publication artifact for the triggering
 attempt, checks its repository, run, revisions and current PR against GitHub,
@@ -176,13 +200,17 @@ for local build and run commands.
 
 The paired PR comparison can post as a dedicated GitHub App named **Nitro Modules Bot**, using [`docs/static/img/nos.png`](../docs/static/img/nos.png)
 as its avatar. The app needs no hosted service or webhook receiver; Actions
-creates a short-lived installation token just before posting the comment.
+creates short-lived installation tokens for the request acknowledgment and report
+publication in separate jobs that never execute PR code.
 
 To configure it on `margelo/nitro`:
 
 1. Register a GitHub App named `Nitro Modules Bot` with homepage
    `https://nitro.margelo.com`. Disable webhooks and grant only the repository
-   permission **Pull requests: Read & write** (Metadata read access is automatic).
+   permissions **Pull requests: Read & write** and **Issues: Read & write**
+   (Metadata read access is automatic). Issues write access is needed for the 👍
+   reaction on a conversation comment. Existing installations must accept this
+   additional permission before using the acknowledgment workflow.
    Keep installation restricted to the owning account when the app belongs to
    `margelo`.
 2. Upload the NOS image under the app's Display information and install the app
@@ -192,12 +220,13 @@ To configure it on `margelo/nitro`:
 4. Set the repository Actions variable `NITRO_PERFORMANCE_APP_CLIENT_ID` to the
    app's Client ID. Set this last, after the key and installation are ready.
 
-The trusted publisher uses the app's actual slug to recognize their own comments.
-They request only Pull requests write permission for the current repository, and
-the token action revokes the token at the end of the job. Build and measurement jobs never receive the app key. Bencher publishing retains its existing token.
+The trusted publisher uses the app's actual slug to recognize its own comments.
+The acknowledgment job requests Issues write permission, and the publisher
+requests Pull requests write permission, each only for the current repository.
+The token action revokes each token at the end of its job. Build and measurement jobs never receive the app key. Bencher publishing retains its existing token.
 Bot authentication and upload changes take effect after reaching the default branch; report rendering runs from HEAD.
 
-Without the Client ID variable, comments continue as `github-actions[bot]`.
+Without the Client ID variable, comments and reactions use `github-actions[bot]`.
 Removing that variable switches back to the default identity. Configured app
 authentication failures fail the posting job rather than silently switching authors.
 Each workflow run creates its own comment under the configured identity. Reruns

--- a/.github/workflows/performance-report.yml
+++ b/.github/workflows/performance-report.yml
@@ -3,7 +3,7 @@ name: Publish Nitro Performance
 on:
   workflow_run:
     workflows: [Nitro Performance]
-    types: [completed]
+    types: [in_progress, completed]
 
 # Serialize publication attempts for the same run without combining separate requests.
 concurrency:
@@ -14,6 +14,7 @@ permissions:
   actions: read
   contents: read
   pull-requests: write
+  statuses: write
 
 jobs:
   publish:
@@ -33,6 +34,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun scripts/performance/select-report.ts
+
+      - name: Download performance request
+        id: request
+        if: ${{ !cancelled() && steps.select.outputs.request_artifact_id != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ steps.select.outputs.request_artifact_id }}
+          path: performance-request
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Validate requested commit
+        id: request-validation
+        if: ${{ !cancelled() && steps.request.outcome == 'success' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun scripts/performance/workflow-status.ts --directory performance-request --mode validate
 
       - name: Download performance report
         id: download
@@ -63,7 +81,7 @@ jobs:
 
       - name: Create Nitro Modules Bot token
         id: performance-bot-token
-        if: steps.download.outcome == 'success' && steps.validate.outputs.stale != 'true' && vars.NITRO_PERFORMANCE_APP_CLIENT_ID != ''
+        if: ${{ !cancelled() && steps.request-validation.outcome == 'success' && (failure() || steps.select.outputs.artifact_id != '') && vars.NITRO_PERFORMANCE_APP_CLIENT_ID != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.NITRO_PERFORMANCE_APP_CLIENT_ID }}
@@ -94,3 +112,18 @@ jobs:
           BENCHER_API_KEY: ${{ secrets.BENCHER_KEY }}
           BENCHER_PROJECT: nitro
         run: bun scripts/performance/publish.ts --directory validated-report --data-directory untrusted-artifact
+
+      - name: Report failure on the PR
+        if: failure() && steps.request-validation.outcome == 'success'
+        env:
+          GITHUB_TOKEN: ${{ steps.performance-bot-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GITHUB_APP_SLUG: ${{ steps.performance-bot-token.outputs.app-slug }}
+          REPORT_VALIDATED: ${{ steps.validate.outcome == 'success' && steps.validate.outputs.stale != 'true' }}
+        run: bun scripts/performance/notify-failure.ts --directory validated-report
+
+      - name: Update performance status on the PR
+        if: always() && steps.request-validation.outcome == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLICATION_STATUS: ${{ job.status }}
+        run: bun scripts/performance/workflow-status.ts --directory performance-request --mode update

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -9,23 +9,40 @@ permissions:
   contents: read
 
 jobs:
-  prepare:
+  request:
     if: >-
       github.event.issue.pull_request &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
       github.event.comment.body == '@nitro-modules-bot please test performance'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: read
+      issues: write
+      statuses: write
     outputs:
+      allowed: ${{ steps.permission.outputs.allowed }}
       base_sha: ${{ steps.metadata.outputs.base_sha }}
       head_sha: ${{ steps.metadata.outputs.head_sha }}
       head_repository: ${{ steps.metadata.outputs.head_repository }}
       pr_number: ${{ steps.metadata.outputs.pr_number }}
     steps:
+      - id: permission
+        name: Require repository write access
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+          ALLOWED=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$COMMENT_AUTHOR/permission" \
+            --jq '.permission == "write" or .permission == "maintain" or .permission == "admin"')
+          echo "allowed=$ALLOWED" >> "$GITHUB_OUTPUT"
+          if [[ "$ALLOWED" != true ]]; then
+            echo 'Performance requests require write, maintain, or admin repository access.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - id: metadata
         name: Resolve pull request revisions
+        if: steps.permission.outputs.allowed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
@@ -41,11 +58,63 @@ jobs:
             "head_repository=\(.head.repo.full_name)", "pr_number=\(.number)"' \
             pull-request.json >> "$GITHUB_OUTPUT"
 
+      - name: Show pending performance status on the PR
+        if: steps.permission.outputs.allowed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.metadata.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            -f state=pending -f context="Nitro Performance / $GITHUB_RUN_ID" \
+            -f target_url="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            -f description='Performance tests are running'
+          jq --arg repository "$GITHUB_REPOSITORY" --argjson run "$GITHUB_RUN_ID" \
+            --argjson attempt "$GITHUB_RUN_ATTEMPT" \
+            '{repository: $repository, workflowRunId: $run, requestAttempt: $attempt,
+              pullRequestNumber: .number, headSha: .head.sha}' pull-request.json > request.json
+
+      - name: Save performance request
+        if: steps.permission.outputs.allowed == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: performance-request-${{ github.run_attempt }}
+          path: request.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Create Nitro Modules Bot token
+        id: performance-bot-token
+        if: steps.permission.outputs.allowed == 'true' && vars.NITRO_PERFORMANCE_APP_CLIENT_ID != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ vars.NITRO_PERFORMANCE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.NITRO_PERFORMANCE_APP_PRIVATE_KEY }}
+          permission-issues: write
+
+      - name: Acknowledge performance request
+        if: steps.permission.outputs.allowed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.performance-bot-token.outputs.token || secrets.GITHUB_TOKEN }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api --method POST "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID/reactions" -f content='+1'
+
+  prepare:
+    needs: request
+    if: needs.request.outputs.allowed == 'true'
+    runs-on: ubuntu-24.04
+    outputs:
+      base_sha: ${{ needs.request.outputs.base_sha }}
+      head_sha: ${{ needs.request.outputs.head_sha }}
+      head_repository: ${{ needs.request.outputs.head_repository }}
+      pr_number: ${{ needs.request.outputs.pr_number }}
+    steps:
       - name: Checkout performance tooling
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          repository: ${{ steps.metadata.outputs.head_repository }}
-          ref: ${{ steps.metadata.outputs.head_sha }}
+          repository: ${{ needs.request.outputs.head_repository }}
+          ref: ${{ needs.request.outputs.head_sha }}
           persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Thanks for your interest in contributing! Nitro powers thousands of React Native
 > **AI assistants and automated tools:** this file is the source of truth for how to work in this repo. Read it end-to-end before making changes.
 
 **Short version:** You have two good ways to contribute a bug report:
+
 1. **Repro-only PR** — add a minimal failing test (compile or runtime) to this repo so CI goes red, and stop there. See [You don't need to ship a fix](#you-dont-need-to-ship-a-fix--a-clean-repro-is-enough).
 2. **Repro + fix PR** — the same test, plus the fix that makes CI green again. See [The bug-fix flow](#the-bug-fix-flow).
 
@@ -111,6 +112,29 @@ For new features, the same flow applies: add the spec, run `bun specs`, implemen
 - **Nitrogen:** regeneration check — generated output must match what's committed.
 
 If any of these fail, the PR won't be merged. Fix the root cause; do not disable or skip checks.
+
+### Performance tests
+
+Performance CI runs only when requested on an open PR. Someone with **write**,
+**maintain**, or **admin** access to this repository can post:
+
+```text
+@nitro-modules-bot please test performance
+```
+
+The bot adds 👍 when it accepts the request. `Nitro Performance / <run ID>`
+appears in the PR's checks area: yellow while running, green on success, red on
+failure. Click it to see the logs. The bot also posts a comparison table, or a
+failure comment linking to the failed run. Contributors without write access can
+ask a maintainer to run it for their PR; fork PRs are supported.
+
+Each new command creates a separate run and report. Re-run the same workflow to
+update its existing comment. Re-running `measure-android` or `measure-ios` and
+their dependent jobs reuses the saved apps. After a new report is posted, older
+performance comments from the bot are marked **Outdated**. Pushing another commit
+does not start a performance run; post the command again to test that commit.
+
+See [performance CI](.github/PERFORMANCE.md) for the measurement method and artifacts.
 
 ## Pull request checklist
 

--- a/docs/docs/resources/contributing.md
+++ b/docs/docs/resources/contributing.md
@@ -111,6 +111,17 @@ When adding a reproduction, follow the rules in [CONTRIBUTING.md](https://github
 
 Submit a PR that demonstrates this runtime error or crash in the Nitro `apps/example/` app — ideally with a new assertion in [`apps/example/src/getTests.ts`](https://github.com/margelo/nitro/blob/main/apps/example/src/getTests.ts) so the regression is caught by the Harness CI workflows (iOS and Android). A PR that only adds the failing assertion and makes Harness go red is enough on its own; you don't have to land the fix.
 
+## Performance tests
+
+Performance CI is opt-in. A maintainer with write, maintain, or admin repository
+access can post `@nitro-modules-bot please test performance` on an open PR.
+The bot acknowledges it with 👍, adds a status to the PR's checks, and posts the
+results or a failure link. Contributors without write access can ask a maintainer
+to run it, including for PRs from forks.
+
+See [Performance tests in CONTRIBUTING.md](https://github.com/margelo/nitro/blob/main/CONTRIBUTING.md#performance-tests)
+for repeat runs and measurement-only retries.
+
 ## Run Nitro Docs
 
 The Nitro docs ([nitro.margelo.com](https://nitro.margelo.com)) are built with [Docusaurus](https://docusaurus.io).

--- a/scripts/performance/github-report.test.ts
+++ b/scripts/performance/github-report.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, test } from 'bun:test'
-import { postPerformanceComment } from './github-report'
+import { describe, expect, test, spyOn } from 'bun:test'
+import {
+  postPerformanceComment,
+  upsertPerformanceComment,
+  createGitHubRequest,
+} from './github-report'
 
 const report = {
   repository: 'margelo/nitro',
@@ -82,6 +86,7 @@ describe('paired performance PR comment', () => {
     const comments = [
       {
         id: 1,
+        node_id: 'legacy',
         body: '<!-- nitro-performance-paired-comparison -->\nlegacy report',
         user: { login: 'github-actions[bot]', type: 'Bot' },
       },
@@ -89,20 +94,22 @@ describe('paired performance PR comment', () => {
     const request = async (
       endpoint: string,
       method = 'GET',
-      body?: { body: string }
+      body?: Record<string, unknown>
     ) => {
+      if (endpoint === '/graphql') return {}
       if (endpoint.includes('/pulls/')) return pullRequest
       if (method === 'POST') {
         comments.push({
           id: comments.length + 1,
-          body: body!.body,
+          node_id: `comment-${comments.length + 1}`,
+          body: String(body!.body),
           user: { login: 'github-actions[bot]', type: 'Bot' },
         })
         return {}
       }
       if (method === 'PATCH') {
         comments.find((comment) => endpoint.endsWith(`/${comment.id}`))!.body =
-          body!.body
+          String(body!.body)
         return {}
       }
       return comments
@@ -151,7 +158,7 @@ describe('paired performance PR comment', () => {
         if (endpoint.endsWith('page=1')) {
           return Array.from({ length: 100 }, (_, id) => ({
             id,
-            body: '<!-- nitro-performance-paired-comparison:123 -->\nOther run',
+            body: 'Unrelated comment',
             user: { login: 'github-actions[bot]', type: 'Bot' },
           }))
         }
@@ -246,5 +253,165 @@ describe('paired performance PR comment', () => {
     })
     expect(status).toBe('stale')
     expect(requests).toBe(1)
+  })
+})
+
+describe('outdated performance comments', () => {
+  function fixture() {
+    const comments = [
+      {
+        id: 1,
+        node_id: 'legacy',
+        body: '<!-- nitro-performance-paired-comparison -->\nLegacy',
+        user: { login: 'nitro-modules-bot[bot]', type: 'Bot' },
+      },
+      {
+        id: 2,
+        node_id: 'prior-run',
+        body: '<!-- nitro-performance-paired-comparison:100 -->\nPrior run',
+        user: { login: 'nitro-modules-bot[bot]', type: 'Bot' },
+      },
+      {
+        id: 3,
+        node_id: 'human',
+        body: marker,
+        user: { login: 'mrousavy', type: 'User' },
+      },
+      {
+        id: 4,
+        node_id: 'other-bot',
+        body: marker,
+        user: { login: 'another-app[bot]', type: 'Bot' },
+      },
+      {
+        id: 5,
+        node_id: 'unrelated',
+        body: 'An unrelated bot comment',
+        user: { login: 'nitro-modules-bot[bot]', type: 'Bot' },
+      },
+    ]
+    const writes: {
+      endpoint: string
+      method: string
+      body?: Record<string, unknown>
+    }[] = []
+    const request = async (
+      endpoint: string,
+      method = 'GET',
+      body?: Record<string, unknown>
+    ) => {
+      if (endpoint.includes('/pulls/')) return pullRequest
+      if (method === 'GET') return comments
+      writes.push({ endpoint, method, body })
+      return {}
+    }
+    return { comments, writes, request }
+  }
+
+  test('posts first, then hides only earlier reports by the same bot as OUTDATED', async () => {
+    const f = fixture()
+    expect(
+      await postPerformanceComment(report, f.request, 'nitro-modules-bot[bot]')
+    ).toBe('created')
+    expect(f.writes[0]).toEqual({
+      endpoint: '/repos/margelo/nitro/issues/123/comments',
+      method: 'POST',
+      body: { body: `${marker}\n${report.markdown}` },
+    })
+    expect(f.writes.slice(1).map((write) => write.body?.variables)).toEqual([
+      { id: 'legacy' },
+      { id: 'prior-run' },
+    ])
+    for (const write of f.writes.slice(1)) {
+      expect(write.endpoint).toBe('/graphql')
+      expect(write.body?.query).toContain('classifier: OUTDATED')
+    }
+  })
+
+  test('rerunning an older workflow never hides the newer report', async () => {
+    const f = fixture()
+    f.comments.push({
+      id: 6,
+      node_id: 'newer-run',
+      body: marker,
+      user: { login: 'nitro-modules-bot[bot]', type: 'Bot' },
+    })
+    expect(
+      await postPerformanceComment(
+        { ...report, workflowRunId: 100 },
+        f.request,
+        'nitro-modules-bot[bot]'
+      )
+    ).toBe('updated')
+    expect(f.writes[0]?.endpoint).toBe('/repos/margelo/nitro/issues/comments/2')
+    expect(f.writes.slice(1).map((write) => write.body?.variables)).toEqual([
+      { id: 'legacy' },
+    ])
+  })
+
+  test('failed publication does not hide any previous comments', async () => {
+    const f = fixture()
+    await expect(
+      postPerformanceComment(
+        report,
+        async (endpoint, method, body) => {
+          if (method === 'POST' && endpoint !== '/graphql')
+            throw new Error('Posting failed')
+          return f.request(endpoint, method, body)
+        },
+        'nitro-modules-bot[bot]'
+      )
+    ).rejects.toThrow('Posting failed')
+    expect(f.writes).toHaveLength(0)
+  })
+
+  test('failure notifications leave the previous successful reports visible', async () => {
+    const f = fixture()
+    await upsertPerformanceComment(
+      { ...report, markdown: 'Performance tests failed' },
+      f.request,
+      'nitro-modules-bot[bot]'
+    )
+    expect(f.writes).toHaveLength(1)
+    expect(f.writes[0]?.method).toBe('POST')
+  })
+
+  test('a successful retry replaces its failure comment and hides older reports', async () => {
+    const f = fixture()
+    f.comments.push({
+      id: 6,
+      node_id: 'retry',
+      body: `${marker}\nPerformance tests failed`,
+      user: { login: 'nitro-modules-bot[bot]', type: 'Bot' },
+    })
+    expect(
+      await postPerformanceComment(report, f.request, 'nitro-modules-bot[bot]')
+    ).toBe('updated')
+    expect(f.writes[0]).toEqual({
+      endpoint: '/repos/margelo/nitro/issues/comments/6',
+      method: 'PATCH',
+      body: { body: `${marker}\n${report.markdown}` },
+    })
+    expect(f.writes.slice(1).map((write) => write.body?.variables)).toEqual([
+      { id: 'legacy' },
+      { id: 'prior-run' },
+    ])
+  })
+
+  test('surfaces GraphQL errors returned with HTTP 200', async () => {
+    const fetchMock = spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ errors: [{ message: 'Not permitted' }] }), {
+        status: 200,
+      })
+    )
+    try {
+      await expect(
+        createGitHubRequest('test-token')('/graphql', 'POST', {
+          query: 'mutation {}',
+        })
+      ).rejects.toThrow('GitHub GraphQL report request failed.')
+    } finally {
+      fetchMock.mockRestore()
+    }
   })
 })

--- a/scripts/performance/github-report.ts
+++ b/scripts/performance/github-report.ts
@@ -3,25 +3,33 @@ import path from 'node:path'
 import { parseArguments, requiredArgument } from './args'
 import type { ReportMetadata } from './report'
 
-interface PullRequestReport extends Pick<
+export interface PerformanceComment extends Pick<
   ReportMetadata,
-  'repository' | 'baseSha' | 'headSha' | 'workflowRunId'
+  'repository' | 'workflowRunId'
 > {
   pullRequestNumber: number
   markdown: string
 }
 
-type GitHubRequest = (
+interface PullRequestReport extends PerformanceComment {
+  baseSha: string
+  headSha: string
+}
+
+export type GitHubRequest = (
   endpoint: string,
   method?: 'GET' | 'POST' | 'PATCH',
-  body?: { body: string }
+  body?: Record<string, unknown>
 ) => Promise<unknown>
 
-export async function postPerformanceComment(
-  report: PullRequestReport,
-  request: GitHubRequest,
-  botLogin = 'github-actions[bot]'
-): Promise<'created' | 'updated' | 'stale'> {
+interface Comment {
+  id: number
+  node_id: string
+  body: string
+  user: { login: string; type: string }
+}
+
+function validateComment(report: PerformanceComment, botLogin: string): void {
   if (!/^[a-zA-Z0-9-]+\[bot\]$/.test(botLogin)) {
     throw new Error('Performance comment author must be a GitHub bot login.')
   }
@@ -31,17 +39,28 @@ export async function postPerformanceComment(
     report.pullRequestNumber < 1 ||
     !Number.isSafeInteger(report.workflowRunId) ||
     report.workflowRunId < 1 ||
-    !/^[0-9a-f]{40}$/.test(report.baseSha) ||
-    !/^[0-9a-f]{40}$/.test(report.headSha) ||
+    report.markdown.trim().length === 0 ||
     report.markdown.length > 60_000
   ) {
     throw new Error('Invalid validated PR report metadata or size.')
   }
+}
 
-  const root = `/repos/${report.repository}`
+export async function postPerformanceComment(
+  report: PullRequestReport,
+  request: GitHubRequest,
+  botLogin = 'github-actions[bot]'
+): Promise<'created' | 'updated' | 'stale'> {
+  validateComment(report, botLogin)
+  if (
+    !/^[0-9a-f]{40}$/.test(report.baseSha) ||
+    !/^[0-9a-f]{40}$/.test(report.headSha)
+  ) {
+    throw new Error('Invalid validated PR report revisions.')
+  }
   // A PR may have advanced while publication was being prepared.
   const pullRequest = (await request(
-    `${root}/pulls/${report.pullRequestNumber}`
+    `/repos/${report.repository}/pulls/${report.pullRequestNumber}`
   )) as { state: string; base: { sha: string }; head: { sha: string } }
   if (
     pullRequest.state !== 'open' ||
@@ -50,25 +69,59 @@ export async function postPerformanceComment(
   ) {
     return 'stale'
   }
+  return upsertPerformanceComment(report, request, botLogin, true)
+}
 
+// Failure notifications share the run's comment, but leave older reports visible.
+export async function upsertPerformanceComment(
+  report: PerformanceComment,
+  request: GitHubRequest,
+  botLogin = 'github-actions[bot]',
+  minimizePrevious = false
+): Promise<'created' | 'updated'> {
+  validateComment(report, botLogin)
+  const root = `/repos/${report.repository}`
   const marker = `<!-- nitro-performance-paired-comparison:${report.workflowRunId} -->`
   const body = { body: `${marker}\n${report.markdown}` }
+  const previous: Comment[] = []
+  async function markPreviousOutdated() {
+    if (!minimizePrevious) return
+    for (const comment of previous) {
+      await request('/graphql', 'POST', {
+        query: `mutation($id: ID!) {
+          minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+            minimizedComment { isMinimized }
+          }
+        }`,
+        variables: { id: comment.node_id },
+      })
+    }
+  }
   for (let page = 1; page <= 10; page++) {
     const comments = (await request(
       `${root}/issues/${report.pullRequestNumber}/comments?per_page=100&page=${page}`
-    )) as {
-      id: number
-      body: string
-      user: { login: string; type: string }
-    }[]
-    const existing = comments.find(
+    )) as Comment[]
+    const ownReports = comments.filter(
       (comment) =>
         comment.user.login === botLogin &&
         comment.user.type === 'Bot' &&
-        comment.body.startsWith(marker)
+        /^<!-- nitro-performance-paired-comparison(?::[1-9][0-9]*)? -->/.test(
+          comment.body
+        )
+    )
+    const existing = ownReports.find((comment) =>
+      comment.body.startsWith(marker)
+    )
+    // REST lists comments oldest first. Never hide a newer report when rerunning
+    // an older workflow, and never unhide an already-outdated run on a retry.
+    previous.push(
+      ...ownReports.filter(
+        (comment) => existing == null || comment.id < existing.id
+      )
     )
     if (existing != null) {
       await request(`${root}/issues/comments/${existing.id}`, 'PATCH', body)
+      await markPreviousOutdated()
       return 'updated'
     }
     if (comments.length < 100) {
@@ -77,10 +130,34 @@ export async function postPerformanceComment(
         'POST',
         body
       )
+      await markPreviousOutdated()
       return 'created'
     }
   }
   throw new Error('Comment pagination exceeded its safety limit.')
+}
+
+export function createGitHubRequest(token: string): GitHubRequest {
+  return async (endpoint, method = 'GET', body) => {
+    const response = await fetch(`https://api.github.com${endpoint}`, {
+      method,
+      signal: AbortSignal.timeout(30_000),
+      headers: {
+        'Accept': 'application/vnd.github+json',
+        'Authorization': `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2026-03-10',
+        'Content-Type': 'application/json',
+      },
+      body: body == null ? undefined : JSON.stringify(body),
+    })
+    if (!response.ok) {
+      throw new Error(`GitHub report request failed: ${response.status}.`)
+    }
+    const result = (await response.json()) as { errors?: unknown[] }
+    if (result.errors?.length)
+      throw new Error('GitHub GraphQL report request failed.')
+    return result
+  }
 }
 
 if (import.meta.main) {
@@ -98,23 +175,7 @@ if (import.meta.main) {
     )
     const status = await postPerformanceComment(
       { ...metadata, pullRequestNumber: metadata.pullRequestNumber, markdown },
-      async (endpoint, method = 'GET', body) => {
-        const response = await fetch(`https://api.github.com${endpoint}`, {
-          method,
-          signal: AbortSignal.timeout(30_000),
-          headers: {
-            'Accept': 'application/vnd.github+json',
-            'Authorization': `Bearer ${token}`,
-            'X-GitHub-Api-Version': '2026-03-10',
-            'Content-Type': 'application/json',
-          },
-          body: body == null ? undefined : JSON.stringify(body),
-        })
-        if (!response.ok) {
-          throw new Error(`GitHub report request failed: ${response.status}.`)
-        }
-        return response.json()
-      },
+      createGitHubRequest(token),
       process.env.GITHUB_APP_SLUG
         ? `${process.env.GITHUB_APP_SLUG}[bot]`
         : 'github-actions[bot]'

--- a/scripts/performance/notify-failure.test.ts
+++ b/scripts/performance/notify-failure.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from 'bun:test'
+import { failureComment } from './notify-failure'
+
+function fixture() {
+  return {
+    repository: { full_name: 'margelo/nitro' },
+    workflow_run: {
+      id: 456,
+      run_attempt: 2,
+      event: 'issue_comment',
+      display_title: 'Nitro Performance for PR #123',
+      conclusion: 'failure',
+      head_repository: { full_name: 'margelo/nitro' },
+    },
+  }
+}
+
+test('reports build, measurement and tooling failures without needing any artifacts', () => {
+  const comment = failureComment(fixture(), 'margelo/nitro', 789)
+  expect(comment.pullRequestNumber).toBe(123)
+  expect(comment.workflowRunId).toBe(456)
+  expect(comment.markdown).toContain('Performance tests failed')
+  expect(comment.markdown).toContain(
+    'https://github.com/margelo/nitro/actions/runs/456/attempts/2'
+  )
+  expect(comment.markdown).toContain(
+    'https://github.com/margelo/nitro/actions/runs/789'
+  )
+})
+
+test('reports publishing failures and retains an available performance table', () => {
+  const event = fixture()
+  event.workflow_run.conclusion = 'success'
+  const markdown = '## Performance Report\n\n<table>measured results</table>'
+  const comment = failureComment(event, 'margelo/nitro', 789, markdown)
+  expect(comment.markdown).toContain('Performance report publishing failed')
+  expect(comment.markdown).toContain(markdown)
+})
+
+test.each([
+  'title',
+  'repository',
+  'fork',
+  'event',
+  'run',
+  'attempt',
+  'publisher',
+])('rejects untrusted failure notification metadata: %s', (kind) => {
+  const event = fixture()
+  if (kind === 'title') event.workflow_run.display_title = 'Unrelated workflow'
+  if (kind === 'repository') event.repository.full_name = 'other/repo'
+  if (kind === 'fork')
+    event.workflow_run.head_repository.full_name = 'contributor/nitro'
+  if (kind === 'event') event.workflow_run.event = 'push'
+  if (kind === 'run') event.workflow_run.id = 0
+  if (kind === 'attempt') event.workflow_run.run_attempt = 0
+  expect(() =>
+    failureComment(event, 'margelo/nitro', kind === 'publisher' ? 0 : 789)
+  ).toThrow('trusted performance request')
+})

--- a/scripts/performance/notify-failure.ts
+++ b/scripts/performance/notify-failure.ts
@@ -1,0 +1,102 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { parseArguments, requiredArgument } from './args'
+import {
+  createGitHubRequest,
+  upsertPerformanceComment,
+  type PerformanceComment,
+} from './github-report'
+
+interface WorkflowEvent {
+  repository: { full_name: string }
+  workflow_run: {
+    id: number
+    run_attempt: number
+    event: string
+    display_title: string
+    conclusion: string
+    head_repository: { full_name: string }
+  }
+}
+
+export function failureComment(
+  event: WorkflowEvent,
+  repository: string,
+  publisherRunId: number,
+  markdown?: string
+): PerformanceComment {
+  const run = event.workflow_run
+  const number = /^Nitro Performance for PR #([1-9][0-9]*)$/.exec(
+    run.display_title
+  )?.[1]
+  if (
+    event.repository.full_name !== repository ||
+    run.head_repository.full_name !== repository ||
+    run.event !== 'issue_comment' ||
+    number == null ||
+    !Number.isSafeInteger(Number(number)) ||
+    !Number.isSafeInteger(run.id) ||
+    run.id < 1 ||
+    !Number.isSafeInteger(run.run_attempt) ||
+    run.run_attempt < 1 ||
+    !Number.isSafeInteger(publisherRunId) ||
+    publisherRunId < 1
+  ) {
+    throw new Error(
+      'Failure notification does not identify a trusted performance request.'
+    )
+  }
+  const runUrl = `https://github.com/${repository}/actions/runs/${run.id}/attempts/${run.run_attempt}`
+  const publisherUrl = `https://github.com/${repository}/actions/runs/${publisherRunId}`
+  const message =
+    run.conclusion === 'success'
+      ? '❌ **Performance report publishing failed.**'
+      : '❌ **Performance tests failed.**'
+  return {
+    repository,
+    pullRequestNumber: Number(number),
+    workflowRunId: run.id,
+    markdown: [
+      message,
+      '',
+      `[View performance run, attempt ${run.run_attempt}](${runUrl}) · [View publishing logs](${publisherUrl})`,
+      '',
+      run.conclusion === 'success'
+        ? 'Re-run the failed publishing job from the publishing logs. A successful retry updates this comment.'
+        : 'Re-run the failed jobs from the performance run. A successful retry updates this comment.',
+      ...(markdown == null ? [] : ['', markdown]),
+    ].join('\n'),
+  }
+}
+
+if (import.meta.main) {
+  const token = process.env.GITHUB_TOKEN
+  if (token == null) throw new Error('GITHUB_TOKEN is required.')
+  const event = JSON.parse(
+    await readFile(process.env.GITHUB_EVENT_PATH!, 'utf8')
+  ) as WorkflowEvent
+  const args = parseArguments(Bun.argv.slice(2))
+  const markdown =
+    process.env.REPORT_VALIDATED === 'true'
+      ? await readFile(
+          path.join(
+            requiredArgument(args, 'directory'),
+            'performance-summary.md'
+          ),
+          'utf8'
+        )
+      : undefined
+  const comment = failureComment(
+    event,
+    process.env.GITHUB_REPOSITORY!,
+    Number(process.env.GITHUB_RUN_ID),
+    markdown
+  )
+  await upsertPerformanceComment(
+    comment,
+    createGitHubRequest(token),
+    process.env.GITHUB_APP_SLUG
+      ? `${process.env.GITHUB_APP_SLUG}[bot]`
+      : 'github-actions[bot]'
+  )
+}

--- a/scripts/performance/select-report.test.ts
+++ b/scripts/performance/select-report.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test'
-import { selectReportArtifact } from './select-report'
+import { selectReportArtifact, selectRequestArtifact } from './select-report'
 
 test('docs-only and cancelled measurements skip cleanly', () => {
   expect(
@@ -42,4 +42,25 @@ test('selects the immutable artifact for the triggering attempt only', () => {
       []
     )
   ).toThrow()
+})
+
+test('reruns reuse the latest non-expired request from this or an earlier attempt', () => {
+  const artifacts = [1, 2, 3].map((id) => ({
+    id,
+    name: `performance-request-${id}`,
+    expired: false,
+  }))
+  expect(selectRequestArtifact(1, [])).toBeUndefined()
+  expect(selectRequestArtifact(1, artifacts)).toBe(1)
+  expect(selectRequestArtifact(2, artifacts)).toBe(2)
+  expect(selectRequestArtifact(4, artifacts)).toBe(3)
+  expect(
+    selectRequestArtifact(
+      4,
+      artifacts.map((artifact) => ({ ...artifact, expired: true }))
+    )
+  ).toBeUndefined()
+  expect(() => selectRequestArtifact(2, [...artifacts, artifacts[1]!])).toThrow(
+    'ambiguous'
+  )
 })

--- a/scripts/performance/select-report.ts
+++ b/scripts/performance/select-report.ts
@@ -40,6 +40,31 @@ export function selectReportArtifact(
   return id
 }
 
+// Measurement-only reruns retain the original request artifact.
+export function selectRequestArtifact(
+  attempt: number,
+  artifacts: readonly Artifact[]
+): number | undefined {
+  const requests = artifacts
+    .flatMap((artifact) => {
+      const match = /^performance-request-([1-9][0-9]*)$/.exec(artifact.name)
+      if (match == null || artifact.expired || Number(match[1]) > attempt)
+        return []
+      return [{ ...artifact, attempt: Number(match[1]) }]
+    })
+    .sort((a, b) => b.attempt - a.attempt)
+  const latest = requests[0]
+  if (latest == null) return undefined
+  if (
+    !Number.isSafeInteger(latest.id) ||
+    latest.id < 1 ||
+    requests[1]?.attempt === latest.attempt
+  ) {
+    throw new Error('Invalid or ambiguous performance request artifact.')
+  }
+  return latest.id
+}
+
 if (import.meta.main) {
   const event = JSON.parse(
     await readFile(process.env.GITHUB_EVENT_PATH!, 'utf8')
@@ -69,6 +94,18 @@ if (import.meta.main) {
   ])
   if (artifactResponse.total_count > 100 || jobResponse.total_count > 100)
     throw new Error('Performance run exceeds the artifact/job lookup limit.')
+  const requestId = selectRequestArtifact(
+    run.run_attempt,
+    artifactResponse.artifacts
+  )
+  await appendFile(
+    process.env.GITHUB_OUTPUT!,
+    `request_artifact_id=${requestId ?? ''}\n`
+  )
+  if (event.action !== 'completed' || requestId == null) {
+    await appendFile(process.env.GITHUB_OUTPUT!, 'artifact_id=\n')
+    process.exit(0)
+  }
   const id = selectReportArtifact(
     run.conclusion,
     run.run_attempt,

--- a/scripts/performance/workflow-status.test.ts
+++ b/scripts/performance/workflow-status.test.ts
@@ -1,0 +1,134 @@
+import { expect, test } from 'bun:test'
+import {
+  validatePerformanceRequest,
+  updatePerformanceStatus,
+} from './workflow-status'
+import type { GitHubRequest } from './github-report'
+
+function fixture() {
+  const metadata = {
+    repository: 'margelo/nitro',
+    pullRequestNumber: 123,
+    workflowRunId: 456,
+    requestAttempt: 1,
+    headSha: 'a'.repeat(40),
+  }
+  const event = {
+    action: 'completed' as 'in_progress' | 'completed',
+    repository: { full_name: 'margelo/nitro' },
+    workflow_run: {
+      id: 456,
+      run_attempt: 2,
+      event: 'issue_comment',
+      display_title: 'Nitro Performance for PR #123',
+      conclusion: 'success',
+      head_repository: { full_name: 'margelo/nitro' },
+    },
+  }
+  const writes: { endpoint: string; body: unknown }[] = []
+  const status = {
+    context: 'Nitro Performance / 456',
+    target_url: 'https://github.com/margelo/nitro/actions/runs/456',
+    creator: { login: 'github-actions[bot]', type: 'Bot' },
+  }
+  const latest = { run_attempt: 2, status: 'completed' }
+  const request: GitHubRequest = async (endpoint, method = 'GET', body) => {
+    if (method === 'POST') {
+      writes.push({ endpoint, body })
+      return {}
+    }
+    if (endpoint.includes('/statuses?')) return [status]
+    return latest
+  }
+  return { metadata, event, writes, status, latest, request }
+}
+
+test('requires an existing Actions status to trust the commit supplied by an artifact', async () => {
+  const f = fixture()
+  await validatePerformanceRequest(
+    f.metadata,
+    f.event,
+    'margelo/nitro',
+    f.request
+  )
+  f.status.creator.login = 'attacker'
+  await expect(
+    validatePerformanceRequest(f.metadata, f.event, 'margelo/nitro', f.request)
+  ).rejects.toThrow('matching trusted commit status')
+  expect(f.writes).toHaveLength(0)
+})
+
+test.each([
+  'pr',
+  'run',
+  'repository',
+  'attempt',
+  'head',
+  'status-context',
+  'status-url',
+])('rejects forged request metadata or status: %s', async (kind) => {
+  const f = fixture()
+  if (kind === 'pr') f.metadata.pullRequestNumber++
+  if (kind === 'run') f.metadata.workflowRunId++
+  if (kind === 'repository') f.metadata.repository = 'other/repo'
+  if (kind === 'attempt') f.metadata.requestAttempt = 3
+  if (kind === 'head') f.metadata.headSha = 'not a commit'
+  if (kind === 'status-context') f.status.context = 'Nitro Performance / 999'
+  if (kind === 'status-url') f.status.target_url = 'https://example.com'
+  await expect(
+    validatePerformanceRequest(f.metadata, f.event, 'margelo/nitro', f.request)
+  ).rejects.toThrow()
+  expect(f.writes).toHaveLength(0)
+})
+
+test.each([
+  ['in_progress', 'success', 'success', 'pending'],
+  ['completed', 'success', 'success', 'success'],
+  ['completed', 'failure', 'failure', 'failure'],
+  ['completed', 'success', 'failure', 'failure'],
+  ['completed', 'cancelled', 'success', 'error'],
+] as const)(
+  'publishes %s / %s / %s as %s on the tested commit',
+  async (action, conclusion, publicationStatus, expected) => {
+    const f = fixture()
+    f.event.action = action
+    f.event.workflow_run.conclusion = conclusion
+    f.latest.status = action === 'in_progress' ? 'in_progress' : 'completed'
+    await updatePerformanceStatus(
+      f.metadata,
+      f.event,
+      { status: publicationStatus, runId: 789 },
+      f.request
+    )
+    expect(f.writes).toEqual([
+      {
+        endpoint: `/repos/margelo/nitro/statuses/${f.metadata.headSha}`,
+        body: expect.objectContaining({
+          state: expected,
+          context: 'Nitro Performance / 456',
+          target_url: `https://github.com/margelo/nitro/actions/runs/${conclusion === 'success' && publicationStatus === 'failure' ? 789 : 456}`,
+        }),
+      },
+    ])
+  }
+)
+
+test('ignores late webhooks from earlier attempts and already-finished starts', async () => {
+  const f = fixture()
+  f.latest.run_attempt = 3
+  await updatePerformanceStatus(
+    f.metadata,
+    f.event,
+    { status: 'success', runId: 789 },
+    f.request
+  )
+  f.latest.run_attempt = 2
+  f.event.action = 'in_progress'
+  await updatePerformanceStatus(
+    f.metadata,
+    f.event,
+    { status: 'success', runId: 789 },
+    f.request
+  )
+  expect(f.writes).toHaveLength(0)
+})

--- a/scripts/performance/workflow-status.ts
+++ b/scripts/performance/workflow-status.ts
@@ -1,0 +1,153 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { parseArguments, requiredArgument } from './args'
+import { createGitHubRequest, type GitHubRequest } from './github-report'
+
+interface PerformanceRequest {
+  repository: string
+  pullRequestNumber: number
+  workflowRunId: number
+  requestAttempt: number
+  headSha: string
+}
+interface WorkflowEvent {
+  action: 'in_progress' | 'completed'
+  repository: { full_name: string }
+  workflow_run: {
+    id: number
+    run_attempt: number
+    event: string
+    display_title: string
+    conclusion: string | null
+    head_repository: { full_name: string }
+  }
+}
+
+export async function validatePerformanceRequest(
+  metadata: PerformanceRequest,
+  event: WorkflowEvent,
+  repository: string,
+  request: GitHubRequest
+): Promise<void> {
+  const run = event.workflow_run
+  if (
+    !/^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/.test(repository) ||
+    metadata.repository !== repository ||
+    event.repository.full_name !== repository ||
+    run.head_repository.full_name !== repository ||
+    run.event !== 'issue_comment' ||
+    metadata.workflowRunId !== run.id ||
+    !Number.isSafeInteger(run.id) ||
+    run.id < 1 ||
+    !Number.isSafeInteger(metadata.pullRequestNumber) ||
+    metadata.pullRequestNumber < 1 ||
+    run.display_title !==
+      `Nitro Performance for PR #${metadata.pullRequestNumber}` ||
+    !Number.isSafeInteger(metadata.requestAttempt) ||
+    metadata.requestAttempt < 1 ||
+    metadata.requestAttempt > run.run_attempt ||
+    !/^[0-9a-f]{40}$/.test(metadata.headSha)
+  ) {
+    throw new Error('Invalid performance request provenance.')
+  }
+  // Artifacts are untrusted. The initial status, written by the isolated request
+  // job, proves this workflow was authorized to test this exact commit.
+  for (let page = 1; page <= 10; page++) {
+    const statuses = (await request(
+      `/repos/${repository}/commits/${metadata.headSha}/statuses?per_page=100&page=${page}`
+    )) as {
+      context: string
+      target_url: string
+      creator: { login: string; type: string }
+    }[]
+    if (
+      statuses.some(
+        (status) =>
+          status.context === `Nitro Performance / ${run.id}` &&
+          status.target_url ===
+            `https://github.com/${repository}/actions/runs/${run.id}` &&
+          status.creator.login === 'github-actions[bot]' &&
+          status.creator.type === 'Bot'
+      )
+    )
+      return
+    if (statuses.length < 100) break
+  }
+  throw new Error('Performance request has no matching trusted commit status.')
+}
+
+export async function updatePerformanceStatus(
+  metadata: PerformanceRequest,
+  event: WorkflowEvent,
+  publication: { status: string; runId: number },
+  request: GitHubRequest
+): Promise<void> {
+  const run = event.workflow_run
+  const root = `/repos/${metadata.repository}`
+  const latest = (await request(`${root}/actions/runs/${run.id}`)) as {
+    run_attempt: number
+    status: string
+  }
+  // A delayed webhook must not overwrite the status of a newer attempt, or set
+  // a completed run back to pending.
+  if (
+    latest.run_attempt !== run.run_attempt ||
+    (event.action === 'in_progress' && latest.status === 'completed')
+  )
+    return
+  const state =
+    event.action === 'in_progress'
+      ? 'pending'
+      : run.conclusion === 'cancelled'
+        ? 'error'
+        : run.conclusion === 'success' && publication.status === 'success'
+          ? 'success'
+          : 'failure'
+  const description =
+    state === 'pending'
+      ? 'Performance tests are running'
+      : state === 'success'
+        ? 'Performance tests and report publishing succeeded'
+        : state === 'error'
+          ? 'Performance run was cancelled'
+          : 'Performance tests or report publishing failed'
+  await request(`${root}/statuses/${metadata.headSha}`, 'POST', {
+    state,
+    context: `Nitro Performance / ${run.id}`,
+    target_url: `https://github.com/${metadata.repository}/actions/runs/${run.conclusion === 'success' && publication.status === 'failure' ? publication.runId : run.id}`,
+    description,
+  })
+}
+
+if (import.meta.main) {
+  const token = process.env.GITHUB_TOKEN
+  if (token == null) throw new Error('GITHUB_TOKEN is required.')
+  const args = parseArguments(Bun.argv.slice(2))
+  const metadata = JSON.parse(
+    await readFile(
+      path.join(requiredArgument(args, 'directory'), 'request.json'),
+      'utf8'
+    )
+  ) as PerformanceRequest
+  const event = JSON.parse(
+    await readFile(process.env.GITHUB_EVENT_PATH!, 'utf8')
+  ) as WorkflowEvent
+  const request = createGitHubRequest(token)
+  await validatePerformanceRequest(
+    metadata,
+    event,
+    process.env.GITHUB_REPOSITORY!,
+    request
+  )
+  if (requiredArgument(args, 'mode') === 'update') {
+    await updatePerformanceStatus(
+      metadata,
+      event,
+      {
+        status: process.env.PUBLICATION_STATUS!,
+        runId: Number(process.env.GITHUB_RUN_ID),
+      },
+      request
+    )
+  }
+}

--- a/scripts/performance/workflow.test.ts
+++ b/scripts/performance/workflow.test.ts
@@ -125,7 +125,7 @@ test.each(['margelo/nitro', 'contributor/nitro'])(
           'utf8'
         )
       ) as any
-      const script = workflow.jobs.prepare.steps.find(
+      const script = workflow.jobs.request.steps.find(
         (step: any) => step.id === 'metadata'
       ).run
       const pr = {
@@ -170,6 +170,122 @@ test.each(['margelo/nitro', 'contributor/nitro'])(
       pr.head.sha = 'invalid\nhead_sha=injected'
       expect(await resolve()).not.toBe(0)
       expect(await Bun.file(path.join(root, 'outputs')).exists()).toBe(false)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  }
+)
+
+test('bot credentials and write permissions remain isolated from PR code', async () => {
+  const entry = Bun.YAML.parse(
+    await readFile(
+      new URL('../../.github/workflows/performance.yml', import.meta.url),
+      'utf8'
+    )
+  ) as any
+  const request = entry.jobs.request
+  expect(request.permissions.issues).toBe('write')
+  expect(JSON.stringify(request)).not.toMatch(/actions\/checkout|bun install/)
+  expect(entry.jobs.prepare.needs).toBe('request')
+  expect(entry.jobs.prepare.permissions).toBeUndefined()
+  const token = request.steps.find(
+    (step: any) => step.id === 'performance-bot-token'
+  )
+  expect(token.with['permission-issues']).toBe('write')
+  for (const [name, job] of Object.entries(entry.jobs)) {
+    if (name !== 'request') {
+      expect(JSON.stringify(job)).not.toMatch(/secrets\.|performance-bot-token/)
+    }
+  }
+})
+
+test('acknowledges the triggering comment with +1', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-reaction-'))
+  try {
+    const workflow = Bun.YAML.parse(
+      await readFile(
+        new URL('../../.github/workflows/performance.yml', import.meta.url),
+        'utf8'
+      )
+    ) as any
+    const step = workflow.jobs.request.steps.find(
+      (item: any) => item.name === 'Acknowledge performance request'
+    )
+    const gh = path.join(root, 'gh')
+    await Bun.write(
+      gh,
+      '#!/bin/bash\nprintf "%s\\n" "$@" > "$ARGUMENTS_FILE"\n'
+    )
+    await chmod(gh, 0o755)
+    const child = Bun.spawn(['bash', '-euo', 'pipefail', '-c', step.run], {
+      cwd: root,
+      env: {
+        ...process.env,
+        PATH: `${root}:${process.env.PATH}`,
+        GITHUB_REPOSITORY: 'margelo/nitro',
+        COMMENT_ID: '987',
+        ARGUMENTS_FILE: path.join(root, 'arguments'),
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    expect(await child.exited).toBe(0)
+    expect(await Bun.file(path.join(root, 'arguments')).text()).toBe(
+      'api\n--method\nPOST\nrepos/margelo/nitro/issues/comments/987/reactions\n-f\ncontent=+1\n'
+    )
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test.each(['admin', 'maintain', 'write', 'triage', 'read', 'none'])(
+  'checks actual repository permissions before accepting a request: %s',
+  async (permission) => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'nitro-permission-'))
+    try {
+      const entry = Bun.YAML.parse(
+        await readFile(
+          new URL('../../.github/workflows/performance.yml', import.meta.url),
+          'utf8'
+        )
+      ) as any
+      const step = entry.jobs.request.steps.find(
+        (item: any) => item.id === 'permission'
+      )
+      const gh = path.join(root, 'gh')
+      await Bun.write(
+        gh,
+        `#!/bin/bash
+[[ "$1" == api && "$2" == repos/margelo/nitro/collaborators/requester/permission && "$3" == --jq ]] || exit 1
+jq -n --arg permission "$PERMISSION" '{permission: $permission}' | jq -r "$4"
+`
+      )
+      await chmod(gh, 0o755)
+      const child = Bun.spawn(['bash', '-euo', 'pipefail', '-c', step.run], {
+        cwd: root,
+        env: {
+          ...process.env,
+          PATH: `${root}:${process.env.PATH}`,
+          PERMISSION: permission,
+          COMMENT_AUTHOR: 'requester',
+          GITHUB_REPOSITORY: 'margelo/nitro',
+          GITHUB_OUTPUT: path.join(root, 'output'),
+          GITHUB_STEP_SUMMARY: path.join(root, 'summary'),
+        },
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      expect(await child.exited).toBe(0)
+      const allowed = ['admin', 'maintain', 'write'].includes(permission)
+      expect(await Bun.file(path.join(root, 'output')).text()).toBe(
+        `allowed=${allowed}\n`
+      )
+      expect(entry.jobs.prepare.if).toBe(
+        "needs.request.outputs.allowed == 'true'"
+      )
+      expect(JSON.stringify(entry.jobs.request.if)).not.toContain(
+        'author_association'
+      )
     } finally {
       await rm(root, { recursive: true, force: true })
     }


### PR DESCRIPTION
Comment-triggered performance runs currently have no acknowledgment or status on the PR's tested commit, and failures are only visible in Actions. Check the comment author's actual repository permission and accept only write, maintain, or admin access. An isolated request job adds 👍, records the tested head, and creates a pending commit status before executing any PR code.

The PR's checks area shows a separate `Nitro Performance / <run ID>` status for each request. It returns to pending on a rerun and finishes green or red after measurements and publication. Statuses stay on the tested commit if the PR advances, and delayed events cannot overwrite a newer attempt. Failures also update that run's PR comment with links to the benchmark attempt and publishing logs, retaining the table when one is available.

After publishing a successful report, mark older performance comments from the same bot as **Outdated**, including legacy reports. Reruns keep their existing comment and never hide a newer report; failed runs leave earlier successful reports visible. Document the command, access requirements, status colors, and retries in CONTRIBUTING.md and the contributing docs.

The publisher verifies the saved request against the initial Actions-authored commit status before using its head SHA. Bot credentials and write permissions remain isolated from PR code.

Validation:
- 58 focused tests passed across comment publishing, reactions, permission gating, failure reporting, artifact selection, and commit statuses.
- Performance-tool TypeScript, ESLint, Prettier, and actionlint passed. Actionlint used a temporary config listing the existing Blacksmith runner labels.
- The full 156-test suite was attempted twice but was not clean locally: existing process fixtures in `run-sequence.test.ts` and `build-artifacts.test.ts` hit long timer overruns and a follow-on receiver-port conflict. No native benchmark run was started.

Before merging: grant **Issues: Read & write** to Nitro Modules Bot and approve the permission update for its installation. GitHub requires it for conversation-comment reactions; the app currently has only Pull requests write access. The request token asks only for Issues write; the publishing token still asks only for Pull requests write. The settings change is documented but has not been applied.
