### PR TITLE
fix: correct performance statuses and bot permissions

### DIFF
--- a/.github/PERFORMANCE.md
+++ b/.github/PERFORMANCE.md
@@ -224,8 +224,9 @@ To configure it on `margelo/nitro`:
    app's Client ID. Set this last, after the key and installation are ready.
 
 The trusted publisher uses the app's actual slug to recognize its own comments.
-The acknowledgment job requests Issues write permission, and the publisher
-requests Pull requests write permission, each only for the current repository.
+The acknowledgment job requests both Issues and Pull requests write permissions
+so it can react to PR conversation comments. The publisher requests Pull requests
+write permission. Both tokens are restricted to the current repository.
 The token action revokes each token at the end of its job. Build and measurement jobs never receive the app key. Bencher publishing retains its existing token.
 Bot authentication and upload changes take effect after reaching the default branch; report rendering runs from HEAD.
 

--- a/.github/PERFORMANCE.md
+++ b/.github/PERFORMANCE.md
@@ -15,9 +15,10 @@ and the Actions dispatch button do not start performance runs. Manual requests r
 regardless of which files changed, including docs-only PRs.
 
 An accepted request gets a 👍 reaction from the bot. The PR's checks area shows
-`Nitro Performance / <run ID>`, with a yellow pending status while it runs,
+one `Nitro Performance` entry, with a yellow pending status while it runs,
 green on success, or red for failures/cancellation. The status links to the run
-logs; publishing failures link to the publishing workflow. Each status belongs
+logs; publishing failures link to the publishing workflow. New requests replace
+this entry, and older runs finishing later cannot overwrite it. Each status belongs
 to the tested head commit, even if the PR advances while measurements run.
 
 Failures also produce a PR comment with direct links to the benchmark attempt
@@ -149,7 +150,9 @@ The isolated request job saves `performance-request-<attempt>` before any PR cod
 runs. It contains the requested head SHA and workflow identity. The publisher
 checks this against the initial commit status written by `github-actions[bot]`
 before trusting it. Measurement-only reruns reuse this request; late events from
-older attempts cannot overwrite a newer status. PR code never receives the bot
+older attempts cannot overwrite a newer status. Request and publishing jobs share
+a concurrency queue per PR to serialize status writes; builds and measurements
+remain independent. PR code never receives the bot
 key or a token with status/comment write permissions.
 
 One default-branch `Publish Nitro Performance` workflow handles comment-triggered

--- a/.github/workflows/performance-report.yml
+++ b/.github/workflows/performance-report.yml
@@ -5,10 +5,10 @@ on:
     workflows: [Nitro Performance]
     types: [in_progress, completed]
 
-# Serialize publication attempts for the same run without combining separate requests.
+# Share the request job's lock so an older publisher cannot overwrite a new request.
 concurrency:
-  group: performance-report-${{ github.event.workflow_run.id }}
-  cancel-in-progress: false
+  group: performance-status-${{ github.event.workflow_run.display_title }}
+  queue: max
 
 permissions:
   actions: read

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -20,7 +20,7 @@ jobs:
       queue: max
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: write
       statuses: write
     outputs:
@@ -95,6 +95,7 @@ jobs:
           client-id: ${{ vars.NITRO_PERFORMANCE_APP_CLIENT_ID }}
           private-key: ${{ secrets.NITRO_PERFORMANCE_APP_PRIVATE_KEY }}
           permission-issues: write
+          permission-pull-requests: write
 
       - name: Acknowledge performance request
         if: steps.permission.outputs.allowed == 'true'

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -14,6 +14,10 @@ jobs:
       github.event.issue.pull_request &&
       github.event.comment.body == '@nitro-modules-bot please test performance'
     runs-on: ubuntu-24.04
+    # Serialize status writes with the publisher, without cancelling requests.
+    concurrency:
+      group: 'performance-status-Nitro Performance for PR #${{ github.event.issue.number }}'
+      queue: max
     permissions:
       contents: read
       pull-requests: read
@@ -66,7 +70,7 @@ jobs:
         run: |
           set -euo pipefail
           gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
-            -f state=pending -f context="Nitro Performance / $GITHUB_RUN_ID" \
+            -f state=pending -f context='Nitro Performance' \
             -f target_url="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
             -f description='Performance tests are running'
           jq --arg repository "$GITHUB_REPOSITORY" --argjson run "$GITHUB_RUN_ID" \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,9 +122,10 @@ Performance CI runs only when requested on an open PR. Someone with **write**,
 @nitro-modules-bot please test performance
 ```
 
-The bot adds 👍 when it accepts the request. `Nitro Performance / <run ID>`
+The bot adds 👍 when it accepts the request. `Nitro Performance`
 appears in the PR's checks area: yellow while running, green on success, red on
-failure. Click it to see the logs. The bot also posts a comparison table, or a
+failure. New requests replace this entry; older runs finishing later cannot
+overwrite it. Click it to see the logs. The bot also posts a comparison table, or a
 failure comment linking to the failed run. Contributors without write access can
 ask a maintainer to run it for their PR; fork PRs are supported.
 

--- a/docs/docs/resources/contributing.md
+++ b/docs/docs/resources/contributing.md
@@ -115,7 +115,7 @@ Submit a PR that demonstrates this runtime error or crash in the Nitro `apps/exa
 
 Performance CI is opt-in. A maintainer with write, maintain, or admin repository
 access can post `@nitro-modules-bot please test performance` on an open PR.
-The bot acknowledges it with 👍, adds a status to the PR's checks, and posts the
+The bot acknowledges it with 👍, updates the PR's `Nitro Performance` status, and posts the
 results or a failure link. Contributors without write access can ask a maintainer
 to run it, including for PRs from forks.
 

--- a/scripts/performance/workflow-status.test.ts
+++ b/scripts/performance/workflow-status.test.ts
@@ -27,20 +27,22 @@ function fixture() {
   }
   const writes: { endpoint: string; body: unknown }[] = []
   const status = {
-    context: 'Nitro Performance / 456',
+    context: 'Nitro Performance',
+    state: 'pending',
     target_url: 'https://github.com/margelo/nitro/actions/runs/456',
     creator: { login: 'github-actions[bot]', type: 'Bot' },
   }
+  const statuses = [status]
   const latest = { run_attempt: 2, status: 'completed' }
   const request: GitHubRequest = async (endpoint, method = 'GET', body) => {
     if (method === 'POST') {
       writes.push({ endpoint, body })
       return {}
     }
-    if (endpoint.includes('/statuses?')) return [status]
+    if (endpoint.includes('/statuses?')) return statuses
     return latest
   }
-  return { metadata, event, writes, status, latest, request }
+  return { metadata, event, writes, status, statuses, latest, request }
 }
 
 test('requires an existing Actions status to trust the commit supplied by an artifact', async () => {
@@ -66,6 +68,7 @@ test.each([
   'head',
   'status-context',
   'status-url',
+  'status-state',
 ])('rejects forged request metadata or status: %s', async (kind) => {
   const f = fixture()
   if (kind === 'pr') f.metadata.pullRequestNumber++
@@ -75,6 +78,7 @@ test.each([
   if (kind === 'head') f.metadata.headSha = 'not a commit'
   if (kind === 'status-context') f.status.context = 'Nitro Performance / 999'
   if (kind === 'status-url') f.status.target_url = 'https://example.com'
+  if (kind === 'status-state') f.status.state = 'success'
   await expect(
     validatePerformanceRequest(f.metadata, f.event, 'margelo/nitro', f.request)
   ).rejects.toThrow()
@@ -105,7 +109,7 @@ test.each([
         endpoint: `/repos/margelo/nitro/statuses/${f.metadata.headSha}`,
         body: expect.objectContaining({
           state: expected,
-          context: 'Nitro Performance / 456',
+          context: 'Nitro Performance',
           target_url: `https://github.com/margelo/nitro/actions/runs/${conclusion === 'success' && publicationStatus === 'failure' ? 789 : 456}`,
         }),
       },
@@ -131,4 +135,66 @@ test('ignores late webhooks from earlier attempts and already-finished starts', 
     f.request
   )
   expect(f.writes).toHaveLength(0)
+})
+
+test('a newer request owns the shared status even after its publishing fails', async () => {
+  const f = fixture()
+  f.statuses.unshift(
+    {
+      ...f.status,
+      state: 'failure',
+      target_url: 'https://github.com/margelo/nitro/actions/runs/999',
+    },
+    {
+      ...f.status,
+      target_url: 'https://github.com/margelo/nitro/actions/runs/457',
+    }
+  )
+  // The older request is still authentic and can publish its own comment.
+  await validatePerformanceRequest(
+    f.metadata,
+    f.event,
+    'margelo/nitro',
+    f.request
+  )
+  await updatePerformanceStatus(
+    f.metadata,
+    f.event,
+    { status: 'success', runId: 789 },
+    f.request
+  )
+  expect(f.writes).toHaveLength(0)
+  f.metadata.workflowRunId = 457
+  f.event.workflow_run.id = 457
+  await updatePerformanceStatus(
+    f.metadata,
+    f.event,
+    { status: 'success', runId: 999 },
+    f.request
+  )
+  expect(f.writes).toHaveLength(1)
+  expect(f.writes[0]?.body).toMatchObject({
+    context: 'Nitro Performance',
+    state: 'success',
+  })
+})
+
+test('finishes the original numbered status for a run started before the change', async () => {
+  const f = fixture()
+  f.status.context = 'Nitro Performance / 456'
+  await validatePerformanceRequest(
+    f.metadata,
+    f.event,
+    'margelo/nitro',
+    f.request
+  )
+  await updatePerformanceStatus(
+    f.metadata,
+    f.event,
+    { status: 'success', runId: 789 },
+    f.request
+  )
+  expect(f.writes[0]?.body).toMatchObject({
+    context: 'Nitro Performance / 456',
+  })
 })

--- a/scripts/performance/workflow-status.ts
+++ b/scripts/performance/workflow-status.ts
@@ -28,7 +28,7 @@ export async function validatePerformanceRequest(
   event: WorkflowEvent,
   repository: string,
   request: GitHubRequest
-): Promise<void> {
+): Promise<{ context: string; latestRequestUrl?: string }> {
   const run = event.workflow_run
   if (
     !/^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/.test(repository) ||
@@ -52,25 +52,35 @@ export async function validatePerformanceRequest(
   }
   // Artifacts are untrusted. The initial status, written by the isolated request
   // job, proves this workflow was authorized to test this exact commit.
+  let latestRequestUrl: string | undefined
   for (let page = 1; page <= 10; page++) {
     const statuses = (await request(
       `/repos/${repository}/commits/${metadata.headSha}/statuses?per_page=100&page=${page}`
     )) as {
       context: string
+      state: string
       target_url: string
       creator: { login: string; type: string }
     }[]
-    if (
-      statuses.some(
-        (status) =>
-          status.context === `Nitro Performance / ${run.id}` &&
-          status.target_url ===
-            `https://github.com/${repository}/actions/runs/${run.id}` &&
-          status.creator.login === 'github-actions[bot]' &&
-          status.creator.type === 'Bot'
+    // GitHub returns newest first. Only pending statuses identify requests:
+    // a publishing failure can change the final status URL to the publisher.
+    for (const status of statuses) {
+      if (
+        status.creator.login !== 'github-actions[bot]' ||
+        status.creator.type !== 'Bot' ||
+        status.state !== 'pending'
       )
-    )
-      return
+        continue
+      if (status.context === 'Nitro Performance')
+        latestRequestUrl ??= status.target_url
+      if (
+        (status.context === 'Nitro Performance' ||
+          status.context === `Nitro Performance / ${run.id}`) &&
+        status.target_url ===
+          `https://github.com/${repository}/actions/runs/${run.id}`
+      )
+        return { context: status.context, latestRequestUrl }
+    }
     if (statuses.length < 100) break
   }
   throw new Error('Performance request has no matching trusted commit status.')
@@ -82,7 +92,21 @@ export async function updatePerformanceStatus(
   publication: { status: string; runId: number },
   request: GitHubRequest
 ): Promise<void> {
+  const { context, latestRequestUrl } = await validatePerformanceRequest(
+    metadata,
+    event,
+    metadata.repository,
+    request
+  )
   const run = event.workflow_run
+  // Request and publication jobs share a concurrency group, so a new request
+  // cannot replace this owner between the lookup and the status write.
+  if (
+    context === 'Nitro Performance' &&
+    latestRequestUrl !==
+      `https://github.com/${metadata.repository}/actions/runs/${run.id}`
+  )
+    return
   const root = `/repos/${metadata.repository}`
   const latest = (await request(`${root}/actions/runs/${run.id}`)) as {
     run_attempt: number
@@ -113,7 +137,7 @@ export async function updatePerformanceStatus(
           : 'Performance tests or report publishing failed'
   await request(`${root}/statuses/${metadata.headSha}`, 'POST', {
     state,
-    context: `Nitro Performance / ${run.id}`,
+    context,
     target_url: `https://github.com/${metadata.repository}/actions/runs/${run.conclusion === 'success' && publication.status === 'failure' ? publication.runId : run.id}`,
     description,
   })
@@ -133,12 +157,6 @@ if (import.meta.main) {
     await readFile(process.env.GITHUB_EVENT_PATH!, 'utf8')
   ) as WorkflowEvent
   const request = createGitHubRequest(token)
-  await validatePerformanceRequest(
-    metadata,
-    event,
-    process.env.GITHUB_REPOSITORY!,
-    request
-  )
   if (requiredArgument(args, 'mode') === 'update') {
     await updatePerformanceStatus(
       metadata,
@@ -147,6 +165,13 @@ if (import.meta.main) {
         status: process.env.PUBLICATION_STATUS!,
         runId: Number(process.env.GITHUB_RUN_ID),
       },
+      request
+    )
+  } else {
+    await validatePerformanceRequest(
+      metadata,
+      event,
+      process.env.GITHUB_REPOSITORY!,
       request
     )
   }

--- a/scripts/performance/workflow.test.ts
+++ b/scripts/performance/workflow.test.ts
@@ -72,9 +72,19 @@ test('one trusted publisher handles internal and fork reports without executing 
   expect(entry.on).toEqual({ issue_comment: { types: ['created'] } })
   expect(entry.concurrency).toBeUndefined()
   expect(publisher.concurrency).toEqual({
-    'group': 'performance-report-${{ github.event.workflow_run.id }}',
-    'cancel-in-progress': false,
+    group: 'performance-status-${{ github.event.workflow_run.display_title }}',
+    queue: 'max',
   })
+  expect(entry.jobs.request.concurrency).toEqual({
+    group:
+      'performance-status-Nitro Performance for PR #${{ github.event.issue.number }}',
+    queue: 'max',
+  })
+  expect(
+    entry.jobs.request.steps.find(
+      (s: any) => s.name === 'Show pending performance status on the PR'
+    ).run
+  ).toContain("-f context='Nitro Performance'")
   const source = JSON.stringify(publisher)
   expect(source).not.toMatch(
     /pull_request.head.sha|bun install|NITRO_BENCHER_ENABLED/

--- a/scripts/performance/workflow.test.ts
+++ b/scripts/performance/workflow.test.ts
@@ -195,6 +195,7 @@ test('bot credentials and write permissions remain isolated from PR code', async
   ) as any
   const request = entry.jobs.request
   expect(request.permissions.issues).toBe('write')
+  expect(request.permissions['pull-requests']).toBe('write')
   expect(JSON.stringify(request)).not.toMatch(/actions\/checkout|bun install/)
   expect(entry.jobs.prepare.needs).toBe('request')
   expect(entry.jobs.prepare.permissions).toBeUndefined()
@@ -202,6 +203,7 @@ test('bot credentials and write permissions remain isolated from PR code', async
     (step: any) => step.id === 'performance-bot-token'
   )
   expect(token.with['permission-issues']).toBe('write')
+  expect(token.with['permission-pull-requests']).toBe('write')
   for (const [name, job] of Object.entries(entry.jobs)) {
     if (name !== 'request') {
       expect(JSON.stringify(job)).not.toMatch(/secrets\.|performance-bot-token/)


### PR DESCRIPTION
Manual performance requests have two problems: the acknowledgment token omits Pull requests access, causing the 👍 request on a PR comment to fail with HTTP 403, and each request leaves a separate `Nitro Performance / <run ID>` entry in the PR checks overview.

Request both Issues and Pull requests write permissions for the acknowledgment token, including the GitHub Actions fallback. The installed bot already has both permissions. The failure is visible in [run 34335640596](https://github.com/margelo/nitro/actions/runs/34335640596/job/102414257777): token creation succeeds, but posting the reaction fails. This workflow correction takes effect after merging; post a new performance command to verify it live.

Use one `Nitro Performance` status so the latest accepted request replaces the previous result.

The publisher verifies which request owns the shared status before updating it, including when a publishing failure links to a different workflow. Request and publishing jobs share a queue per PR to prevent concurrent writes; builds and measurements remain independent. Runs started before this change finish their existing numbered statuses. Separate report comments and same-run comment updates are preserved.

Validation: 61 focused tests pass, including shared-status ownership, late attempts, legacy runs, permissions, and report comment lifecycle. The 12 workflow tests also pass after adding the acknowledgment permission regression assertions (which fail on the previous configuration). Performance tooling typecheck, ESLint, Prettier, and `git diff --check` pass. Actionlint passes with only its unsupported `concurrency.queue` diagnostic filtered: `queue: max` is [documented GitHub Actions syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-queueing-multiple-pending-runs) but is not yet recognized by actionlint 1.7.12. Native benchmarks were not rerun for these workflow changes.
